### PR TITLE
Migrate execute_script to occtkit + long-lived --serve client (#1)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,22 +18,26 @@ No tests or linter configured.
 
 ## Architecture
 
-The server is a single-process Node.js app (ESM, strict TypeScript) with four source files:
+The server is a single-process Node.js app (ESM, strict TypeScript):
 
 - `src/index.ts` — Creates `McpServer`, registers all five tools with zod schemas, connects stdio transport
-- `src/tools.ts` — Tool implementations: writes Swift code to disk, shells out to `swift run Script`, reads back results
-- `src/paths.ts` — Resolves file paths (scripts project, output dir, manifest)
+- `src/tools.ts` — Tool implementations: writes Swift code to a tempfile, shells out to `occtkit run`, reads back results
+- `src/occtkit.ts` — Resolves how to invoke `occtkit`: prefers PATH, falls back to `swift run -c release occtkit` inside the sibling OCCTSwiftScripts repo, throws a clear setup error if neither is available. Result is memoised
+- `src/paths.ts` — Output dir / manifest path resolution (iCloud-vs-local) and per-call tempfile name generation
 - `src/api-reference.ts` — **Generated** OCCTSwift API reference strings keyed by category. Do not edit by hand — it is rewritten by `scripts/generate-api-reference.mjs` (runs as `npm run prebuild`). The generator parses `~/Projects/OCCTSwift/Sources/OCCTSwift/*.swift` directly, extracts `public func` declarations, and groups them via the editorial `CATEGORIES` array at the top of the script. New OCCTSwift methods that don't match any category are surfaced in the generator's stderr "UNMATCHED" report — extend `CATEGORIES` (add a `markRx` or `nameRx` rule) when something important is missing.
 
 ### Data Flow
 
 `execute_script` is the core tool. It:
-1. Writes the LLM's Swift code to `~/Projects/OCCTSwiftScripts/Sources/Script/main.swift`
-2. Runs `swift run Script` in that project (2min timeout — generous because the cold first build is slow; incremental builds are ~1–2s)
+1. Writes the LLM's Swift code to a per-call tempfile under `os.tmpdir()` and stashes the source for `get_script`
+2. Resolves an `occtkit` invocation via `src/occtkit.ts` and runs `occtkit run <tempfile>` (2min timeout — generous because the cold first build is slow; incremental builds are ~1–2s)
 3. Filters noisy OCCT bridge nullability warnings from build output (`filterBuildOutput`); the same filter runs on the failure path so compiler diagnostics still reach the LLM under the `Script failed.` prefix
 4. Reads `manifest.json` from the output directory and returns it with build output
+5. Removes the tempfile in a `finally` block
 
 Writing `manifest.json` is the side effect that matters: `OCCTSwiftViewport`'s `ScriptWatcher` watches that file, so emitting it is what triggers the live 3D reload.
+
+`occtkit run --serve` (long-lived JSONL request loop) would let us drop the per-call build-cache check overhead, but adoption is deferred — see `gsdali/OCCTSwiftScripts#5` for the upstream framing gap that blocks safe client integration.
 
 ### Output Directory Resolution
 
@@ -41,19 +45,19 @@ Writing `manifest.json` is the side effect that matters: `OCCTSwiftViewport`'s `
 
 ## External Dependencies
 
-These sibling projects must exist at `~/Projects/`:
-
-- **OCCTSwiftScripts** — Swift Package Manager project that compiles and runs the generated `main.swift`
-- **OCCTSwift** — Swift wrapper around OpenCASCADE (dependency of OCCTSwiftScripts)
-- **OCCTSwiftViewport** — Metal viewport that watches the output directory via `ScriptWatcher` and auto-reloads
+- **OCCTSwiftScripts** ≥ v0.5.0-rc.1 — provides the `occtkit` CLI used by every `execute_script` call. Two install options, either works:
+  - `make install` from the OCCTSwiftScripts repo puts `occtkit` on `$PATH` (preferred — fastest invocation, no sibling-repo path dependency).
+  - Clone OCCTSwiftScripts to `~/Projects/OCCTSwiftScripts` so `swift run -c release occtkit` works as the fallback (slower per-call than the binary, but no install step).
+- **OCCTSwift** — Swift wrapper around OpenCASCADE; transitive dep of OCCTSwiftScripts. Required at `~/Projects/OCCTSwift/` only when regenerating `src/api-reference.ts` via `scripts/generate-api-reference.mjs` (runs as `npm run prebuild`).
+- **OCCTSwiftViewport** — Metal viewport that watches the output directory via `ScriptWatcher` and auto-reloads. Optional but expected if you want the live preview.
 
 ## MCP Tools
 
 | Tool | Purpose |
 |------|---------|
-| `execute_script` | Write Swift code to main.swift, compile & run, return output + manifest |
+| `execute_script` | Write Swift code to a tempfile, run via `occtkit run`, return output + manifest |
 | `get_scene` | Read current manifest.json + list output files |
-| `get_script` | Read current main.swift source |
+| `get_script` | Return the most recent script executed in this MCP session (kept in memory; not a filesystem read) |
 | `export_model` | List exported BREP/STEP/STL/OBJ file paths |
 | `get_api_reference` | Return OCCTSwift API reference by category (or "all") |
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,8 +21,9 @@ No tests or linter configured.
 The server is a single-process Node.js app (ESM, strict TypeScript):
 
 - `src/index.ts` — Creates `McpServer`, registers all five tools with zod schemas, connects stdio transport
-- `src/tools.ts` — Tool implementations: writes Swift code to a tempfile, shells out to `occtkit run`, reads back results
+- `src/tools.ts` — Tool implementations: writes Swift code to a tempfile, sends it to a long-lived `occtkit run --serve` child by default, falls back to one-shot `occtkit run <path>` if serve mode is unavailable
 - `src/occtkit.ts` — Resolves how to invoke `occtkit`: prefers PATH, falls back to `swift run -c release occtkit` inside the sibling OCCTSwiftScripts repo, throws a clear setup error if neither is available. Result is memoised
+- `src/occtkit-serve.ts` — Singleton long-lived `occtkit run --serve` child. JSONL request/response over stdin/stdout (one envelope per request, post-`gsdali/OCCTSwiftScripts#5`). Per-request timeout kills the child and respawns on next call. If a returned envelope lacks the `ok` field (pre-fix occtkit), serve mode is permanently disabled for the session and callers fall back to one-shot
 - `src/paths.ts` — Output dir / manifest path resolution (iCloud-vs-local) and per-call tempfile name generation
 - `src/api-reference.ts` — **Generated** OCCTSwift API reference strings keyed by category. Do not edit by hand — it is rewritten by `scripts/generate-api-reference.mjs` (runs as `npm run prebuild`). The generator parses `~/Projects/OCCTSwift/Sources/OCCTSwift/*.swift` directly, extracts `public func` declarations, and groups them via the editorial `CATEGORIES` array at the top of the script. New OCCTSwift methods that don't match any category are surfaced in the generator's stderr "UNMATCHED" report — extend `CATEGORIES` (add a `markRx` or `nameRx` rule) when something important is missing.
 
@@ -30,14 +31,15 @@ The server is a single-process Node.js app (ESM, strict TypeScript):
 
 `execute_script` is the core tool. It:
 1. Writes the LLM's Swift code to a per-call tempfile under `os.tmpdir()` and stashes the source for `get_script`
-2. Resolves an `occtkit` invocation via `src/occtkit.ts` and runs `occtkit run <tempfile>` (2min timeout — generous because the cold first build is slow; incremental builds are ~1–2s)
-3. Filters noisy OCCT bridge nullability warnings from build output (`filterBuildOutput`); the same filter runs on the failure path so compiler diagnostics still reach the LLM under the `Script failed.` prefix
-4. Reads `manifest.json` from the output directory and returns it with build output
-5. Removes the tempfile in a `finally` block
+2. **Serve path (default):** sends `{"args": ["<tempfile>"]}` over stdin to the singleton `occtkit run --serve` child managed by `src/occtkit-serve.ts`, awaits one JSONL envelope `{ ok, exit, stdout, stderr, error? }`. Cold start of the child is 60+s on first call; subsequent calls amortise to ~1–2s incremental.
+3. **One-shot fallback:** if serve mode threw (timeout, child crash, pre-fix occtkit detected), runs `occtkit run <tempfile>` as a fresh subprocess. Triggers automatically; `OCCTMCP_OCCTKIT_NO_SERVE=1` forces this path always.
+4. Filters noisy OCCT bridge nullability warnings from build output (`filterBuildOutput`); the same filter runs on both paths so compiler diagnostics still reach the LLM under the `Script failed.` prefix
+5. Reads `manifest.json` from the output directory and returns it with build output
+6. Removes the tempfile in a `finally` block
 
 Writing `manifest.json` is the side effect that matters: `OCCTSwiftViewport`'s `ScriptWatcher` watches that file, so emitting it is what triggers the live 3D reload.
 
-`occtkit run --serve` (long-lived JSONL request loop) would let us drop the per-call build-cache check overhead, but adoption is deferred — see `gsdali/OCCTSwiftScripts#5` for the upstream framing gap that blocks safe client integration.
+The 2 min timeout is per-request in both paths. On serve-mode timeout the child is `SIGTERM`'d so any pending requests reject and the next `execute_script` respawns it.
 
 ### Output Directory Resolution
 
@@ -45,9 +47,10 @@ Writing `manifest.json` is the side effect that matters: `OCCTSwiftViewport`'s `
 
 ## External Dependencies
 
-- **OCCTSwiftScripts** ≥ v0.5.0-rc.1 — provides the `occtkit` CLI used by every `execute_script` call. Two install options, either works:
+- **OCCTSwiftScripts** ≥ post-`fd2a1cf` (the `--serve` framing fix from `gsdali/OCCTSwiftScripts#5`) — provides the `occtkit` CLI used by every `execute_script` call. Two install options, either works:
   - `make install` from the OCCTSwiftScripts repo puts `occtkit` on `$PATH` (preferred — fastest invocation, no sibling-repo path dependency).
   - Clone OCCTSwiftScripts to `~/Projects/OCCTSwiftScripts` so `swift run -c release occtkit` works as the fallback (slower per-call than the binary, but no install step).
+  - Older OCCTSwiftScripts (without #5's framing) still works in one-shot fallback mode, just without the serve-mode amortisation. The serve client auto-detects the missing `ok` field on the first envelope and disables serve for the session.
 - **OCCTSwift** — Swift wrapper around OpenCASCADE; transitive dep of OCCTSwiftScripts. Required at `~/Projects/OCCTSwift/` only when regenerating `src/api-reference.ts` via `scripts/generate-api-reference.mjs` (runs as `npm run prebuild`).
 - **OCCTSwiftViewport** — Metal viewport that watches the output directory via `ScriptWatcher` and auto-reloads. Optional but expected if you want the live preview.
 

--- a/scripts/generate-api-reference.mjs
+++ b/scripts/generate-api-reference.mjs
@@ -300,6 +300,52 @@ function parseSwiftFile(source, file) {
     });
   }
 
+  // Find `public var NAME: TYPE` (and `public static var`) declarations.
+  // We only capture explicitly-typed declarations so the signature is useful.
+  // Computed properties (`public var x: Type { ... }`) are still captured — we
+  // stop at the `{` or end-of-line and record the inferred type from the colon.
+  const varRx = /^\s+public\s+(?:static\s+)?var\s+(\w+)\s*:\s*([^{=]+?)(?:\s*\{|$)/;
+  for (let i = 0; i < lines.length; i++) {
+    const m = lines[i].match(varRx);
+    if (!m) continue;
+
+    // Skip deprecated shims (same back-scan as funcs).
+    let deprecated = false;
+    for (let k = i - 1; k >= 0 && k >= i - 6; k--) {
+      const prev = lines[k];
+      if (/@available\s*\(\s*\*\s*,\s*deprecated/.test(prev)) {
+        deprecated = true;
+        break;
+      }
+      const trimmed = prev.trim();
+      if (trimmed === "") break;
+      if (
+        !trimmed.startsWith("@") &&
+        !trimmed.startsWith("///") &&
+        !trimmed.startsWith("//")
+      ) {
+        break;
+      }
+    }
+    if (deprecated) continue;
+
+    const name = m[1];
+    const typeStr = m[2].trim();
+    // Skip private-ish patterns: underscore prefix (conventionally internal).
+    if (name.startsWith("_")) continue;
+
+    out.push({
+      type: typeAt(i),
+      mark: markAt(i),
+      name,
+      // Use an arrow form so vars read like getter signatures in the output.
+      signature: `${name} -> ${typeStr}`,
+      kind: "var",
+      file: basename(file),
+      line: i + 1,
+    });
+  }
+
   return out;
 }
 

--- a/src/api-reference.ts
+++ b/src/api-reference.ts
@@ -1514,6 +1514,12 @@ TopologyGraph.solidCompSolidCount(_ solidIndex: Int) -> Int
 ## History
 TopologyGraph.clearHistory()
 
+## History Record Readback (v0.141, #72 Phase 0)
+TopologyGraph.historyRecord(at index: Int) -> HistoryRecord?
+TopologyGraph.findOriginal(of derived: NodeRef) -> NodeRef
+TopologyGraph.findDerived(of original: NodeRef) -> [NodeRef]
+TopologyGraph.recordHistory(operationName: String, original: NodeRef, replacements: [NodeRef])
+
 ## SameDomain
 TopologyGraph.sameDomainFaces(of faceIndex: Int) -> [Int]
 

--- a/src/api-reference.ts
+++ b/src/api-reference.ts
@@ -78,6 +78,7 @@ Shape.& (lhs: Shape, rhs: Shape) -> Shape?
 
 ## Boolean Pre-Validation
 Shape.isValidForBoolean(with other: Shape) -> Bool
+Shape.isValidForBoolean -> Bool
 
 ## Boolean with History
 Shape.fuseWithHistory(_ other: Shape) -> BooleanResult?
@@ -201,11 +202,13 @@ Wire.helixTapered(origin: SIMD3<Double> = .zero, axis: SIMD3<Double> = SIMD3(0, 
 ## Wire Explorer
 Wire.orderedEdgePointCount(at index: Int) -> Int
 Wire.orderedEdgePoints(at index: Int, maxPoints: Int? = nil) -> [SIMD3<Double>]?
+Wire.orderedEdgeCount -> Int
 
 ## Wire Edge Access
 Wire.edges() -> [Edge]
 Wire.allEdgePolylines(deflection: Double = 0.1, maxPointsPerEdge: Int = 1000) -> [[SIMD3<Double>]]
 Wire.edgePolyline(at index: Int, deflection: Double = 0.1, maxPoints: Int = 1000) -> [SIMD3<Double>]?
+Wire.bounds -> (min: SIMD3<Double>, max: SIMD3<Double>)
 
 ## Wire Topology Analysis
 Wire.analyze(tolerance: Double = 1e-6) -> WireAnalysis?
@@ -254,6 +257,7 @@ Curve2D.mirrored(acrossLine point: SIMD2<Double>, direction: SIMD2<Double>) -> C
 Curve2D.mirrored(acrossPoint point: SIMD2<Double>) -> Curve2D?
 Curve2D.length(from u1: Double, to u2: Double) -> Double?
 Curve2D.parameterAtLength(_ arcLength: Double, from fromParameter: Double? = nil) -> Double?
+Curve2D.length -> Double?
 
 ## Local Properties (Curvature, Normal, Inflection)
 Curve2D.curvature(at u: Double) -> Double
@@ -336,21 +340,44 @@ Curve2D.deserializeCurves(_ data: String) -> [Curve2D]?
 
 ## Geom2d_Circle Properties
 Curve2D.setRadius(_ r: Double) -> Bool
+Curve2D.radius -> Double
+Curve2D.eccentricity -> Double
+Curve2D.center -> SIMD2<Double>
+Curve2D.xAxis -> (position: SIMD2<Double>, direction: SIMD2<Double>)
+Curve2D.circleProperties -> CircleProperties
 
 ## Geom2d_Ellipse Properties
 Curve2D.setMajorRadius(_ r: Double) -> Bool
 Curve2D.setMinorRadius(_ r: Double) -> Bool
+Curve2D.majorRadius -> Double
+Curve2D.minorRadius -> Double
+Curve2D.eccentricity -> Double
+Curve2D.focal -> Double
+Curve2D.focus1 -> SIMD2<Double>
+Curve2D.ellipseProperties -> EllipseProperties
 
 ## Geom2d_Parabola Properties
 Curve2D.setFocal(_ f: Double) -> Bool
+Curve2D.focal -> Double
+Curve2D.focus -> SIMD2<Double>
+Curve2D.eccentricity -> Double
+Curve2D.parameter -> Double
+Curve2D.parabolaProperties -> ParabolaProperties
 
 ## Geom2d_Line Properties
 Curve2D.setDirection(_ d: SIMD2<Double>) -> Bool
 Curve2D.setLocation(_ p: SIMD2<Double>) -> Bool
 Curve2D.distance(to point: SIMD2<Double>) -> Double
+Curve2D.direction -> SIMD2<Double>
+Curve2D.location -> SIMD2<Double>
+Curve2D.lin2d -> (location: SIMD2<Double>, direction: SIMD2<Double>)
+Curve2D.lineProperties -> LineProperties
 
 ## Geom2d_OffsetCurve Properties
 Curve2D.setOffset(_ v: Double) -> Bool
+Curve2D.offset -> Double
+Curve2D.basisCurve -> Curve2D?
+Curve2D.offsetProperties -> OffsetProperties
 
 ## v0.115.0: Interpolation expansion, trim, length
 Curve2D.interpolate(points: [SIMD2<Double>], startTangent: SIMD2<Double>, endTangent: SIMD2<Double>) -> Curve2D?
@@ -370,6 +397,16 @@ Curve2D.bsplineLocateU(u: Double, paramTol: Double) -> (i1: Int, i2: Int)
 Curve2D.bsplineKnot(index: Int) -> Double
 Curve2D.bsplineMultiplicity(index: Int) -> Int
 Curve2D.bsplineIsCN(_ n: Int) -> Bool
+Curve2D.bsplineFirstUKnotIndex -> Int
+Curve2D.bsplineLastUKnotIndex -> Int
+Curve2D.bsplineKnotDistribution -> Int
+Curve2D.bsplineMultiplicities -> [Int]
+Curve2D.bsplineStartPoint -> SIMD2<Double>
+Curve2D.bsplineEndPoint -> SIMD2<Double>
+Curve2D.bsplinePoles -> [SIMD2<Double>]
+Curve2D.bsplineIsClosed -> Bool
+Curve2D.bsplineIsPeriodic -> Bool
+Curve2D.bsplineContinuity -> Int
 
 ## Bezier 2D completions
 Curve2D.bezierInsertPoleAfter(_ index: Int, point: SIMD2<Double>) -> Bool
@@ -377,6 +414,9 @@ Curve2D.bezierRemovePole(_ index: Int) -> Bool
 Curve2D.bezierSegment(u1: Double, u2: Double) -> Bool
 Curve2D.bezierIncreaseDegree(_ degree: Int) -> Bool
 Curve2D.bezierReverse() -> Bool
+Curve2D.bezierStartPoint -> SIMD2<Double>
+Curve2D.bezierEndPoint -> SIMD2<Double>
+Curve2D.bezierPoles -> [SIMD2<Double>]
 
 ## Curve2D Transform
 Curve2D.translate(dx: Double, dy: Double) -> Bool
@@ -388,6 +428,30 @@ Curve2D.mirrorAxis(origin: SIMD2<Double>, direction: SIMD2<Double>) -> Bool
 ## Geom2dEval TBezier / AHTBezier Curves
 Curve2D.tBezier(poles: [SIMD2<Double>], alpha: Double) -> Curve2D?
 Curve2D.ahtBezier(poles: [SIMD2<Double>], algDegree: Int, alpha: Double, beta: Double) -> Curve2D?
+
+## Properties
+Curve2D.domain -> ClosedRange<Double>
+Curve2D.isClosed -> Bool
+Curve2D.isPeriodic -> Bool
+Curve2D.period -> Double?
+Curve2D.startPoint -> SIMD2<Double>
+Curve2D.endPoint -> SIMD2<Double>
+
+## BSpline Queries
+Curve2D.poleCount -> Int?
+Curve2D.poles -> [SIMD2<Double>]?
+Curve2D.degree -> Int?
+
+## Bounding Box
+Curve2D.boundingBox -> (min: SIMD2<Double>, max: SIMD2<Double>)?
+
+## Geom2d_Hyperbola Properties
+Curve2D.majorRadius -> Double
+Curve2D.minorRadius -> Double
+Curve2D.eccentricity -> Double
+Curve2D.focal -> Double
+Curve2D.focus1 -> SIMD2<Double>
+Curve2D.hyperbolaProperties -> HyperbolaProperties
 
 ## Geom2dAPI_Interpolate
 Curve2D.interpolate2D(points: [(Double, Double)], periodic: Bool = false, tolerance: Double = 1e-6) -> Curve2D?
@@ -439,6 +503,11 @@ Curve2D.removeKnot(at index: Int, multiplicity: Int, tolerance: Double) -> Bool
 Curve2D.segment(u1: Double, u2: Double) -> Bool
 Curve2D.increaseDegree(to degree: Int) -> Bool
 Curve2D.resolution(tolerance: Double) -> Double
+Curve2D.knotCount -> Int
+Curve2D.poleCount -> Int
+Curve2D.degree -> Int
+Curve2D.isRational -> Bool
+Curve2D.bspline -> BSpline
 
 ## Curve2D Extras
 Curve2D.reverse() -> Bool
@@ -457,9 +526,12 @@ Curve2D.evalBatchD1(params: [Double]) -> [(point: SIMD2<Double>, d1: SIMD2<Doubl
 
 ## RWMesh iterators, Intf_Tool, BRepAlgo_AsDes, BiTgte, Shape extras, Extrema
 Curve2D.parameterAtPoint(_ point: SIMD2<Double>) -> Double
+Curve2D.curveType -> Int
 
 ## TopoDS_Builder, ShapeContents expanded, FreeBoundsProperties, WireBuilder,
 Curve2D.dn(at u: Double, order n: Int) -> SIMD2<Double>
+Curve2D.isBounded -> Bool
+Curve2D.typeName -> String?
 
 ## BREP serialization, gp distance/contains, BezierSurface, Curve2D extras, BSplineSurface extras
 Curve2D.pole(at index: Int) -> SIMD2<Double>
@@ -469,10 +541,17 @@ Curve2D.resolution(tolerance: Double) -> Double
 Curve2D.bsplineSetPeriodic(_ periodic: Bool) -> Bool
 Curve2D.bsplineWeight(at index: Int) -> Double
 Curve2D.bsplineWeights() -> [Double]
+Curve2D.degree -> Int
+Curve2D.poleCount -> Int
+Curve2D.isRational -> Bool
+Curve2D.bezierProperties -> BezierProperties
 
 ## Final cleanup — IsCN, ReversedParameter, ParametricTransformation,
 Curve2D.isCN(_ n: Int) -> Bool
 Curve2D.reversedParameter(_ u: Double) -> Double
+Curve2D.continuityOrder -> Int
+Curve2D.bezierMaxDegree -> Int
+Curve2D.bsplineMaxDegree -> Int
 
 ## BSpline completions, FilletBuilder, ChamferBuilder
 Curve2D.bsplineSetNotPeriodic() -> Bool
@@ -482,6 +561,9 @@ Curve2D.bsplineIncrementMultiplicity(from: Int, to: Int, step: Int = 1) -> Bool
 Curve2D.bsplineSetKnots(_ knots: [Double]) -> Bool
 Curve2D.bsplineReverse() -> Bool
 Curve2D.bsplineMovePointAndTangent(u: Double, point: SIMD2<Double>, tangent: SIMD2<Double>, tolerance: Double, poleRange: ClosedRange<Int>) -> Bool
+
+## Curve2D continuity
+Curve2D.continuity -> Int
 
 ## ShapeConstruct_Curve extensions
 Curve2D.convertSegmentToBSpline(first: Double, last: Double, precision: Double = 1e-6) -> Curve2D?
@@ -535,6 +617,7 @@ Curve3D.mirrored(acrossPoint point: SIMD3<Double>) -> Curve3D?
 Curve3D.mirrored(acrossAxis point: SIMD3<Double>, direction: SIMD3<Double>) -> Curve3D?
 Curve3D.mirrored(acrossPlane point: SIMD3<Double>, normal: SIMD3<Double>) -> Curve3D?
 Curve3D.length(from u1: Double, to u2: Double) -> Double?
+Curve3D.length -> Double?
 
 ## Conversion (GeomConvert)
 Curve3D.toBSpline() -> Curve3D?
@@ -585,6 +668,7 @@ Curve3D.joined(curves: [Curve3D], tolerance: Double = 1e-6) -> Curve3D?
 
 ## ShapeAnalysis_Curve expansion
 Curve3D.projectPoint(_ point: SIMD3<Double>, precision: Double = 1e-6) -> PointProjection
+Curve3D.distance(to point: SIMD3<Double>, precision: Double = 1e-6) -> Double
 Curve3D.validateRange(first: Double, last: Double, precision: Double = 1e-6) -> ValidatedRange
 Curve3D.samplePoints(first: Double, last: Double, maxPoints: Int = 1000) -> [SIMD3<Double>]
 
@@ -600,6 +684,11 @@ Curve3D.hyperbolaThreePoints(s1: SIMD3<Double>, s2: SIMD3<Double>, center: SIMD3
 
 ## LocalAnalysis
 Curve3D.continuityWith(_ other: Curve3D, u1: Double, u2: Double, order: Int = 4) -> ContinuityAnalysis?
+Curve3D.isC0 -> Bool
+Curve3D.isG1 -> Bool
+Curve3D.isC1 -> Bool
+Curve3D.isG2 -> Bool
+Curve3D.isC2 -> Bool
 
 ## v0.80.0: Extrema, ProjLib, gce factories
 Curve3D.extremaCC(range1: ClosedRange<Double>? = nil, other: Curve3D, range2: ClosedRange<Double>? = nil) -> CurveCurveExtrema
@@ -620,21 +709,54 @@ Curve3D.deserializeCurves(_ data: String) -> [Curve3D]?
 
 ## Geom_Circle Properties
 Curve3D.setRadius(_ r: Double) -> Bool
+Curve3D.radius -> Double
+Curve3D.eccentricity -> Double
+Curve3D.center -> SIMD3<Double>
+Curve3D.xAxis -> (position: SIMD3<Double>, direction: SIMD3<Double>)
+Curve3D.yAxis -> (position: SIMD3<Double>, direction: SIMD3<Double>)
+Curve3D.circleProperties -> CircleProperties
 
 ## Geom_Ellipse Properties
 Curve3D.setMajorRadius(_ r: Double) -> Bool
 Curve3D.setMinorRadius(_ r: Double) -> Bool
+Curve3D.majorRadius -> Double
+Curve3D.minorRadius -> Double
+Curve3D.eccentricity -> Double
+Curve3D.focal -> Double
+Curve3D.focus1 -> SIMD3<Double>
+Curve3D.focus2 -> SIMD3<Double>
+Curve3D.parameter -> Double
+Curve3D.directrix1 -> (position: SIMD3<Double>, direction: SIMD3<Double>)
+Curve3D.ellipseProperties -> EllipseProperties
 
 ## Geom_Hyperbola Properties
 Curve3D.setMajorRadius(_ r: Double) -> Bool
 Curve3D.setMinorRadius(_ r: Double) -> Bool
+Curve3D.majorRadius -> Double
+Curve3D.minorRadius -> Double
+Curve3D.eccentricity -> Double
+Curve3D.focal -> Double
+Curve3D.focus1 -> SIMD3<Double>
+Curve3D.asymptote1 -> (position: SIMD3<Double>, direction: SIMD3<Double>)
+Curve3D.hyperbolaProperties -> HyperbolaProperties
 
 ## Geom_Parabola Properties
 Curve3D.setFocal(_ f: Double) -> Bool
+Curve3D.focal -> Double
+Curve3D.focus -> SIMD3<Double>
+Curve3D.eccentricity -> Double
+Curve3D.parameter -> Double
+Curve3D.directrix -> (position: SIMD3<Double>, direction: SIMD3<Double>)
+Curve3D.parabolaProperties -> ParabolaProperties
 
 ## Geom_Line Properties
 Curve3D.setDirection(_ d: SIMD3<Double>) -> Bool
 Curve3D.setLocation(_ p: SIMD3<Double>) -> Bool
+Curve3D.direction -> SIMD3<Double>
+Curve3D.location -> SIMD3<Double>
+Curve3D.position -> (location: SIMD3<Double>, direction: SIMD3<Double>)
+Curve3D.lin -> (location: SIMD3<Double>, direction: SIMD3<Double>)
+Curve3D.lineProperties -> LineProperties
 
 ## v0.115.0: Interpolation expansion, length, closest point
 Curve3D.interpolate(points: [SIMD3<Double>], startTangent: SIMD3<Double>, endTangent: SIMD3<Double>) -> Curve3D?
@@ -649,9 +771,17 @@ Curve3D.arcLengthBetween(_ param1: Double, _ param2: Double) -> Double
 Curve3D.closestParameter(to point: SIMD3<Double>) -> Double
 Curve3D.splitAtContinuity(continuity: Int = 1, tolerance: Double = 1e-6, maxSegments: Int = 32) -> [Curve3D]
 Curve3D.concatenateG1(curves: [Curve3D], tolerance: Double = 1e-6) -> Curve3D?
+Curve3D.totalArcLength -> Double
 
 ## v0.125.0: Bezier Curve deep method completion
 Curve3D.bezierIsCN(_ n: Int) -> Bool
+Curve3D.bezierStartPoint -> SIMD3<Double>
+Curve3D.bezierEndPoint -> SIMD3<Double>
+Curve3D.bezierPoles -> [SIMD3<Double>]
+Curve3D.bezierWeights -> [Double]?
+Curve3D.bezierIsClosed -> Bool
+Curve3D.bezierIsPeriodic -> Bool
+Curve3D.bezierContinuity -> Int
 
 ## Bezier 3D completions
 Curve3D.bezierInsertPoleBefore(_ index: Int, point: SIMD3<Double>) -> Bool
@@ -686,12 +816,31 @@ Curve3D.tBezierRational(poles: [SIMD3<Double>], weights: [Double], alpha: Double
 Curve3D.ahtBezier(poles: [SIMD3<Double>], algDegree: Int, alpha: Double, beta: Double) -> Curve3D?
 Curve3D.ahtBezierRational(poles: [SIMD3<Double>], weights: [Double], algDegree: Int, alpha: Double, beta: Double) -> Curve3D?
 
+## Properties
+Curve3D.domain -> ClosedRange<Double>
+Curve3D.isClosed -> Bool
+Curve3D.isPeriodic -> Bool
+Curve3D.period -> Double?
+Curve3D.startPoint -> SIMD3<Double>
+Curve3D.endPoint -> SIMD3<Double>
+
+## BSpline Queries
+Curve3D.poleCount -> Int?
+Curve3D.poles -> [SIMD3<Double>]?
+Curve3D.degree -> Int
+
+## Bounding Box
+Curve3D.boundingBox -> (min: SIMD3<Double>, max: SIMD3<Double>)?
+
 ## RWStl, ShapeAnalysis_Curve statics, BRepExtrema_SelfIntersection pairs,
 Curve3D.isClosedWithPrecision(_ precision: Double) -> Bool
+Curve3D.isPeriodicSA -> Bool
+Curve3D.offsetBasisCurve -> Curve3D?
 
 ## Geom_TrimmedCurve
 Curve3D.trimmed(u1: Double, u2: Double) -> Curve3D?
 Curve3D.setTrim(u1: Double, u2: Double) -> Bool
+Curve3D.trimmedBasis -> Curve3D?
 
 ## GC_MakeCircle
 Curve3D.gcCircle(center: SIMD3<Double>, normal: SIMD3<Double>, radius: Double) -> Curve3D?
@@ -722,6 +871,13 @@ Curve3D.segment(u1: Double, u2: Double) -> Bool
 Curve3D.increaseDegree(to degree: Int) -> Bool
 Curve3D.resolution(tolerance3d: Double) -> Double
 Curve3D.setPeriodic(_ periodic: Bool) -> Bool
+Curve3D.knotCount -> Int
+Curve3D.poleCount -> Int
+Curve3D.degree -> Int
+Curve3D.isRational -> Bool
+Curve3D.knots -> [Double]
+Curve3D.multiplicities -> [Int]
+Curve3D.bspline -> BSpline
 
 ## Bezier Curve Methods
 Curve3D.pole(at index: Int) -> SIMD3<Double>
@@ -731,6 +887,10 @@ Curve3D.insertPoleAfter(index: Int, point: SIMD3<Double>) -> Bool
 Curve3D.removePole(at index: Int) -> Bool
 Curve3D.segment(u1: Double, u2: Double) -> Bool
 Curve3D.increaseDegree(to degree: Int) -> Bool
+Curve3D.isRational -> Bool
+Curve3D.degree -> Int
+Curve3D.poleCount -> Int
+Curve3D.bezier -> Bezier
 
 ## Curve3D Extras
 Curve3D.reverse() -> Bool
@@ -752,6 +912,7 @@ Curve3D.evalBatchD1(params: [Double]) -> [(point: SIMD3<Double>, d1: SIMD3<Doubl
 Curve3D.parameterAtPoint(_ point: SIMD3<Double>) -> Double
 Curve3D.locateNearestPoint(_ point: SIMD3<Double>, initParam: Double, tolerance: Double = 1e-6) -> (parameter: Double, distance: Double)?
 Curve3D.projectPointAll(_ point: SIMD3<Double>, maxResults: Int = 10) -> [(parameter: Double, distance: Double)]
+Curve3D.curveType -> Int
 
 ## MakeEdge completions, ProjOnCurve/Surf, DistShapeShape, ShapeFix_Wire/Face,
 Curve3D.bsplineSetKnot(index: Int, value: Double) -> Bool
@@ -766,9 +927,12 @@ Curve3D.bsplineLocalD2(u: Double, fromKnot: Int, toKnot: Int) -> (point: SIMD3<D
 Curve3D.bsplineLocalD3(u: Double, fromKnot: Int, toKnot: Int) -> (point: SIMD3<Double>, d1: SIMD3<Double>, d2: SIMD3<Double>, d3: SIMD3<Double>)
 Curve3D.bsplineLocalDN(u: Double, fromKnot: Int, toKnot: Int, n: Int) -> SIMD3<Double>
 Curve3D.bsplineLocateU(_ u: Double, tolerance: Double = 1e-10) -> Int
+Curve3D.bsplineMaxDegree -> Int
 
 ## TopoDS_Builder, ShapeContents expanded, FreeBoundsProperties, WireBuilder,
 Curve3D.dn(at u: Double, order n: Int) -> SIMD3<Double>
+Curve3D.isBounded -> Bool
+Curve3D.typeName -> String?
 
 ## Curve3D LProp3d Extensions
 Curve3D.localCurvature(at u: Double) -> Double
@@ -781,6 +945,8 @@ Curve3D.isCN(_ n: Int) -> Bool
 Curve3D.reversedParameter(_ u: Double) -> Double
 Curve3D.parametricTransformation(rotation: [Double], translation: SIMD3<Double>) -> Double
 Curve3D.bezierResolution(tolerance3d: Double) -> Double
+Curve3D.continuityOrder -> Int
+Curve3D.bezierMaxDegree -> Int
 
 ## BSpline completions, FilletBuilder, ChamferBuilder
 Curve3D.bsplineSetNotPeriodic() -> Bool
@@ -790,6 +956,13 @@ Curve3D.bsplineIncrementMultiplicity(from: Int, to: Int, step: Int = 1) -> Bool
 Curve3D.bsplineSetKnots(_ knots: [Double]) -> Bool
 Curve3D.bsplineReverse() -> Bool
 Curve3D.bsplineMovePointAndTangent(u: Double, point: SIMD3<Double>, tangent: SIMD3<Double>, tolerance: Double, poleRange: ClosedRange<Int>) -> Bool
+
+## Curve3D continuity
+Curve3D.continuity -> Int
+
+## Builder extensions, Section ops, Curve/Surface queries
+Curve3D.firstParameter -> Double
+Curve3D.lastParameter -> Double
 
 ## GeomConvert_ApproxCurve/Surface
 Curve3D.approxWithDetails(tolerance: Double, continuity: ApproxContinuity = .c2, maxSegments: Int = 100, maxDegree: Int = 8) -> ApproxCurveResult
@@ -839,6 +1012,8 @@ Surface.fromTorus(origin: SIMD3<Double>, axis: SIMD3<Double>, majorRadius: Doubl
 
 ## Geom_OffsetSurface Extensions
 Surface.setOffsetValue(_ value: Double)
+Surface.offsetValue -> Double
+Surface.offsetBasis -> Surface?
 
 ## ShapeAnalysis_Surface
 Surface.projectPointUV(_ point: SIMD3<Double>, precision: Double = 1e-6) -> (u: Double, v: Double, gap: Double)
@@ -882,9 +1057,20 @@ Surface.insertVKnot(v: Double, multiplicity: Int = 1, tolerance: Double = 1e-6) 
 Surface.segment(u1: Double, u2: Double, v1: Double, v2: Double) -> Bool
 Surface.increaseDegree(uDeg: Int, vDeg: Int) -> Bool
 Surface.exchangeUV() -> Bool
+Surface.nbUKnots -> Int
+Surface.nbVKnots -> Int
+Surface.nbUPoles -> Int
+Surface.nbVPoles -> Int
+Surface.uDegree -> Int
+Surface.vDegree -> Int
+Surface.isURational -> Bool
+Surface.isVRational -> Bool
+Surface.bsplineSurface -> BSpline
 
 ## Surface Extras
 Surface.copy() -> Surface?
+Surface.parameterBounds -> (uMin: Double, uMax: Double, vMin: Double, vMax: Double)
+Surface.surfaceContinuityOrder -> Int
 
 ## GridEval Surface Extensions
 Surface.gridEvalD0(uParams: [Double], vParams: [Double]) -> [SIMD3<Double>]
@@ -898,6 +1084,7 @@ Surface.evalD2(u: Double, v: Double) -> (point: SIMD3<Double>, d1u: SIMD3<Double
 ## RWMesh iterators, Intf_Tool, BRepAlgo_AsDes, BiTgte, Shape extras, Extrema
 Surface.locateNearestPoint(_ point: SIMD3<Double>, initU: Double, initV: Double, tolerance: Double = 1e-6) -> (u: Double, v: Double, distance: Double)?
 Surface.projectPointAll(_ point: SIMD3<Double>, maxResults: Int = 10) -> [(u: Double, v: Double, distance: Double)]
+Surface.surfaceType -> Int
 
 ## MakeEdge completions, ProjOnCurve/Surf, DistShapeShape, ShapeFix_Wire/Face,
 Surface.bsplineSetUKnot(index: Int, value: Double) -> Bool
@@ -909,6 +1096,7 @@ Surface.bsplineRemoveUKnot(index: Int, multiplicity: Int, tolerance: Double) -> 
 
 ## TopoDS_Builder, ShapeContents expanded, FreeBoundsProperties, WireBuilder,
 Surface.dn(u: Double, v: Double, nu: Int, nv: Int) -> SIMD3<Double>
+Surface.typeName -> String?
 
 ## Surface LProp3d Extensions
 Surface.localCurvatures(u: Double, v: Double) -> LocalCurvatures?
@@ -924,6 +1112,13 @@ Surface.bsplineResolution(tolerance3d: Double) -> (uResolution: Double, vResolut
 Surface.bsplineSetUPeriodic(_ periodic: Bool) -> Bool
 Surface.bsplineSetVPeriodic(_ periodic: Bool) -> Bool
 Surface.bsplineWeight(uIndex: Int, vIndex: Int) -> Double
+Surface.nbUPoles -> Int
+Surface.nbVPoles -> Int
+Surface.uDegree -> Int
+Surface.vDegree -> Int
+Surface.isURational -> Bool
+Surface.isVRational -> Bool
+Surface.bezierProperties -> BezierProperties
 
 ## Final cleanup — IsCN, ReversedParameter, ParametricTransformation,
 Surface.isCNu(_ n: Int) -> Bool
@@ -934,6 +1129,8 @@ Surface.uReversedParameter(_ u: Double) -> Double
 Surface.vReversedParameter(_ v: Double) -> Double
 Surface.bsplineRemoveVKnot(index: Int, mult: Int, tolerance: Double) -> Bool
 Surface.bezierResolution(tolerance3d: Double) -> (u: Double, v: Double)
+Surface.bezierMaxDegree -> Int
+Surface.bsplineMaxDegree -> Int
 
 ## BSpline completions, FilletBuilder, ChamferBuilder
 Surface.bsplineSetUNotPeriodic() -> Bool
@@ -952,9 +1149,18 @@ Surface.bsplineSetWeightRow(uIndex: Int, weights: [Double]) -> Bool
 Surface.bsplineIncrementUMultiplicity(fromIndex: Int, toIndex: Int, step: Int) -> Bool
 Surface.bsplineIncrementVMultiplicity(fromIndex: Int, toIndex: Int, step: Int) -> Bool
 Surface.bsplineCheckAndSegment(u1: Double, u2: Double, v1: Double, v2: Double, uTolerance: Double = 1e-10, vTolerance: Double = 1e-10) -> Bool
+Surface.bsplineFirstUKnotIndex -> Int
+Surface.bsplineLastUKnotIndex -> Int
+Surface.bsplineFirstVKnotIndex -> Int
+Surface.bsplineLastVKnotIndex -> Int
+
+## Surface continuity
+Surface.continuity -> Int
+Surface.nBounds -> (uSpans: Int, vSpans: Int)
 
 ## Surface Extensions (ShapeCustom_Surface periodic + gap)
 Surface.convertToPeriodic() -> Surface?
+Surface.conversionGap -> Double
 
 ## GeomConvert_ApproxCurve/Surface
 Surface.approxWithDetails(tolerance: Double, uContinuity: ApproxContinuity = .c1, vContinuity: ApproxContinuity = .c1, maxDegree: Int = 8, maxSegments: Int = 100) -> ApproxSurfaceResult
@@ -974,12 +1180,17 @@ Surface.splitByArea(parts: Int, intoSquares: Bool = false) -> SplitResult?
 ## Curve/Surface Recognition
 Surface.toAnalyticalWithGap(tolerance: Double) -> SurfaceToAnalyticalResult?
 Surface.toAnalyticalWithGap(tolerance: Double, uMin: Double, uMax: Double, vMin: Double, vMax: Double) -> SurfaceToAnalyticalResult?
+Surface.isCanonical -> Bool
 
 ## GeomFill_Stretch
 Surface.stretchFill(p1: [SIMD3<Double>], p2: [SIMD3<Double>], p3: [SIMD3<Double>], p4: [SIMD3<Double>]) -> StretchFillResult?
 
 ## GeomFill_AppSurf
 Surface.appSurf(curves: [Curve3D], degMin: Int = 3, degMax: Int = 8, tol3d: Double = 1e-3, tol2d: Double = 1e-3) -> AppSurfResult?
+
+## (uncategorized)
+Surface.torusAxis -> (origin: SIMD3<Double>, direction: SIMD3<Double>)?
+Surface.revolutionAxis -> (origin: SIMD3<Double>, direction: SIMD3<Double>)?
 
 ## Evaluation
 Surface.point(atU u: Double, v: Double) -> SIMD3<Double>
@@ -1096,6 +1307,11 @@ Surface.splitByContinuity(criterion: Int = 2, tolerance: Double = 1e-6) -> Conti
 
 ## LocalAnalysis
 Surface.continuityWith(_ other: Surface, u1: Double, v1: Double, u2: Double, v2: Double, order: Int = 4) -> ContinuityAnalysis?
+Surface.isC0 -> Bool
+Surface.isG1 -> Bool
+Surface.isC1 -> Bool
+Surface.isG2 -> Bool
+Surface.isC2 -> Bool
 
 ## GeomFill_NSections
 Surface.nSections(curves: [Curve3D], params: [Double]) -> Surface?
@@ -1128,19 +1344,36 @@ Surface.deserializeSurfaces(_ data: String) -> [Surface]?
 ## Geom_Plane Properties
 Surface.uIso(_ u: Double) -> Curve3D?
 Surface.vIso(_ v: Double) -> Curve3D?
+Surface.coefficients -> (a: Double, b: Double, c: Double, d: Double)
+Surface.pln -> (origin: SIMD3<Double>, normal: SIMD3<Double>)
+Surface.planeProperties -> PlaneProperties
 
 ## Geom_SphericalSurface Properties
 Surface.setRadius(_ r: Double) -> Bool
 Surface.uIso(_ u: Double) -> Curve3D?
 Surface.vIso(_ v: Double) -> Curve3D?
+Surface.radius -> Double
+Surface.area -> Double
+Surface.volume -> Double
+Surface.center -> SIMD3<Double>
+Surface.sphere -> (center: SIMD3<Double>, radius: Double)
+Surface.sphereProperties -> SphereProperties
 
 ## Geom_ToroidalSurface Properties
 Surface.setMajorRadius(_ r: Double) -> Bool
 Surface.setMinorRadius(_ r: Double) -> Bool
+Surface.majorRadius -> Double
+Surface.minorRadius -> Double
+Surface.area -> Double
+Surface.volume -> Double
+Surface.torusProperties -> TorusProperties
 
 ## Geom_CylindricalSurface Properties
 Surface.setRadius(_ r: Double) -> Bool
 Surface.uIso(_ u: Double) -> Curve3D?
+Surface.radius -> Double
+Surface.axis -> (position: SIMD3<Double>, direction: SIMD3<Double>)
+Surface.cylinderProperties -> CylinderProperties
 
 ## v0.115.0: Surface from point grid, normal, curvatures
 Surface.fromPointGrid(points: [SIMD3<Double>], uCount: Int, vCount: Int, degMin: Int = 3, degMax: Int = 8, continuity: Int = 2, tolerance: Double = 1e-3) -> Surface?
@@ -1162,17 +1395,37 @@ Surface.bsplineUKnot(index: Int) -> Double
 Surface.bsplineVKnot(index: Int) -> Double
 Surface.bsplineUMultiplicity(index: Int) -> Int
 Surface.bsplineVMultiplicity(index: Int) -> Int
+Surface.bsplineUKnotDistribution -> Int
+Surface.bsplineVKnotDistribution -> Int
+Surface.bsplinePoles -> [SIMD3<Double>]
+Surface.bsplineBounds -> (u1: Double, u2: Double, v1: Double, v2: Double)
+Surface.bsplineIsUClosed -> Bool
+Surface.bsplineIsVClosed -> Bool
 
 ## v0.125.0: Bezier Surface deep method completion
 Surface.bezierUIso(u: Double) -> Curve3D?
 Surface.bezierVIso(v: Double) -> Curve3D?
 Surface.bezierIsCNu(_ n: Int) -> Bool
 Surface.bezierIsCNv(_ n: Int) -> Bool
+Surface.bezierIsUClosed -> Bool
+Surface.bezierIsVClosed -> Bool
+Surface.bezierIsUPeriodic -> Bool
+Surface.bezierIsVPeriodic -> Bool
+Surface.bezierContinuity -> Int
+Surface.bezierPoles -> [SIMD3<Double>]
+Surface.bezierWeights -> [Double]?
+Surface.bezierBounds -> (u1: Double, u2: Double, v1: Double, v2: Double)
+Surface.bezierNbUPoles -> Int
+Surface.bezierNbVPoles -> Int
+Surface.bezierUDegree -> Int
+Surface.bezierVDegree -> Int
 
 ## BSpline Surface completions
 Surface.bsplineUReverse() -> Bool
 Surface.bsplineVReverse() -> Bool
 Surface.bsplinePeriodicNormalization(u: inout Double, v: inout Double) -> Bool
+Surface.bsplineUMultiplicities -> [Int]
+Surface.bsplineVMultiplicities -> [Int]
 
 ## Bezier Surface completions
 Surface.bezierInsertPoleColAfter(_ colIndex: Int, poles: [SIMD3<Double>]) -> Bool
@@ -1215,6 +1468,49 @@ Surface.gordon(profiles: [Curve3D], guides: [Curve3D], tolerance: Double = 1e-3)
 Surface.tBezier(poles: [SIMD3<Double>], uCount: Int, vCount: Int, alphaU: Double, alphaV: Double) -> Surface?
 Surface.ahtBezier(poles: [SIMD3<Double>], uCount: Int, vCount: Int, algDegreeU: Int, algDegreeV: Int, alphaU: Double, alphaV: Double, betaU: Double, betaV: Double) -> Surface?
 
+## Properties
+Surface.surfaceKind -> SurfaceType
+Surface.continuityClass -> Continuity
+Surface.isPlane -> Bool
+Surface.isCylinder -> Bool
+Surface.isCone -> Bool
+Surface.isSphere -> Bool
+Surface.isTorus -> Bool
+Surface.isBezier -> Bool
+Surface.isBSpline -> Bool
+Surface.isSurfaceOfRevolution -> Bool
+Surface.isSurfaceOfExtrusion -> Bool
+Surface.isOffsetSurface -> Bool
+Surface.domain -> (uMin: Double, uMax: Double, vMin: Double, vMax: Double)
+Surface.isUClosed -> Bool
+Surface.isVClosed -> Bool
+Surface.isUPeriodic -> Bool
+Surface.isVPeriodic -> Bool
+Surface.uPeriod -> Double?
+Surface.vPeriod -> Double?
+
+## Bounding Box
+Surface.boundingBox -> (min: SIMD3<Double>, max: SIMD3<Double>)?
+
+## BSpline/Bezier Queries
+Surface.uPoleCount -> Int
+Surface.vPoleCount -> Int
+Surface.poles -> [[SIMD3<Double>]]
+Surface.uDegree -> Int
+Surface.vDegree -> Int
+
+## Geom_ConicalSurface Properties
+Surface.semiAngle -> Double
+Surface.refRadius -> Double
+Surface.apex -> SIMD3<Double>
+Surface.axis -> (position: SIMD3<Double>, direction: SIMD3<Double>)
+Surface.coneProperties -> ConeProperties
+
+## Geom_SweptSurface Properties
+Surface.direction -> SIMD3<Double>
+Surface.basisCurve -> Curve3D?
+Surface.sweptProperties -> SweptProperties
+
 Infinite surfaces must be trimmed before converting to BSpline.`,
 
   analysis: `# Analysis & Measurement
@@ -1227,6 +1523,10 @@ Edge.normal(at parameter: Double) -> SIMD3<Double>?
 Edge.centerOfCurvature(at parameter: Double) -> SIMD3<Double>?
 Edge.torsion(at parameter: Double) -> Double?
 Edge.project(point: SIMD3<Double>) -> CurveProjection?
+Edge.distance(to point: SIMD3<Double>) -> Double?
+Edge.parameterBounds -> (first: Double, last: Double)?
+Edge.curveType -> CurveType
+Edge.curve3D -> Curve3D?
 
 ## Sampling
 Edge.points(count: Int? = nil) -> [SIMD3<Double>]
@@ -1235,6 +1535,8 @@ Edge.points(count: Int? = nil) -> [SIMD3<Double>]
 Edge.isSeam(on face: Face) -> Bool
 Edge.adjacentFaces(in shape: Shape) -> (Face, Face?)?
 Edge.dihedralAngle(between face1: Face, and face2: Face, at parameter: Double = 0.5) -> Double?
+Edge.hasCurve3D -> Bool
+Edge.isClosed3D -> Bool
 
 ## Curve Approximation
 Edge.approximatedCurve(tolerance: Double = 1e-3, maxSegments: Int = 100, maxDegree: Int = 8) -> Curve3D?
@@ -1249,10 +1551,20 @@ Edge.pcurveValue(at parameter: Double, on face: Face) -> SIMD2<Double>?
 Edge.approxCurveOnSurface(face: Face, tolerance: Double = 1e-4, maxSegments: Int = 10, maxDegree: Int = 8) -> Shape?
 
 ## Properties
+Edge.length -> Double
+Edge.bounds -> (min: SIMD3<Double>, max: SIMD3<Double>)
+Edge.isLine -> Bool
+Edge.isCircle -> Bool
+Edge.endpoints -> (start: SIMD3<Double>, end: SIMD3<Double>)
 Face.isHorizontal(tolerance: Double = 0.01) -> Bool
 Face.isUpwardFacing(tolerance: Double = 0.01) -> Bool
 Face.isDownwardFacing(tolerance: Double = 0.01) -> Bool
 Face.isVertical(tolerance: Double = 0.01) -> Bool
+Face.normal -> SIMD3<Double>?
+Face.outerWire -> Wire?
+Face.bounds -> (min: SIMD3<Double>, max: SIMD3<Double>)
+Face.isPlanar -> Bool
+Face.zLevel -> Double?
 
 ## Surface Properties
 Face.area(tolerance: Double = 1e-6) -> Double
@@ -1264,23 +1576,49 @@ Face.principalCurvatures(atU u: Double, v: Double) -> PrincipalCurvatures?
 Face.project(point: SIMD3<Double>) -> SurfaceProjection?
 Face.allProjections(of point: SIMD3<Double>) -> [SurfaceProjection]
 Face.intersection(with other: Face, tolerance: Double = 1e-6) -> Shape?
+Face.uvBounds -> (uMin: Double, uMax: Double, vMin: Double, vMax: Double)?
+Face.surfaceType -> SurfaceType
 
 ## BRepGProp_Face Evaluation
 Face.evaluateGProp(u: Double, v: Double) -> GPropEvaluation?
+Face.naturalBounds -> (uMin: Double, uMax: Double, vMin: Double, vMax: Double)?
+
+## Angles
+Edge.angle(to other: Edge, atParameter t: Double = 0.5) -> Double?
+Edge.isParallel(to other: Edge, toleranceRadians: Double = 1e-4) -> Bool?
+Edge.isPerpendicular(to other: Edge, toleranceRadians: Double = 1e-4) -> Bool?
+Face.angle(to other: Face) -> Double?
+Face.isParallel(to other: Face, toleranceRadians: Double = 1e-4) -> Bool?
+Face.isPerpendicular(to other: Face, toleranceRadians: Double = 1e-4) -> Bool?
+Face.isCoplanar(with other: Face, tolerance: Double = 1e-6) -> Bool?
+
+## Circle properties (v0.143 M4)
+Edge.circleProperties -> CircleProperties?
+Face.revolutionProperties -> RevolutionProperties?
 
 ## Validation
 Shape.healed() -> Shape?
+Shape.isValid -> Bool
 
 ## Sub-Shape Extraction
 Shape.subShapeCount(ofType type: ShapeType) -> Int
 Shape.subShape(type: ShapeType, index: Int) -> Shape?
 Shape.subShapes(ofType type: ShapeType) -> [Shape]
+Shape.solidCount -> Int
+Shape.solids -> [Shape]
+Shape.shellCount -> Int
+Shape.shells -> [Shape]
+Shape.wireCount -> Int
+Shape.wires -> [Shape]
 
 ## Shape Measurement Extensions
 Shape.properties(density: Double = 1.0) -> ShapeProperties?
 Shape.distance(to other: Shape, deflection: Double = 1e-6) -> DistanceResult?
 Shape.minDistance(to other: Shape) -> Double?
 Shape.intersects(_ other: Shape, tolerance: Double = 1e-6) -> Bool
+Shape.volume -> Double?
+Shape.surfaceArea -> Double?
+Shape.centerOfMass -> SIMD3<Double>?
 
 ## Shape Analysis
 Shape.analyze(tolerance: Double = 1e-6) -> ShapeAnalysisResult?
@@ -1308,6 +1646,7 @@ Face.meshProps(type: MeshPropsType) -> MeshPropsResult
 
 ## MeshShapeTool (Static Mesh Utilities)
 Face.uvPoints(edge: Edge) -> (u1: Double, v1: Double, u2: Double, v2: Double)?
+Face.maxMeshTolerance -> Double
 
 ## ValidateEdge (BRepLib_ValidateEdge)
 Edge.validate(on face: Face, tolerance: Double = 1e-3) -> ValidateEdgeResult
@@ -1320,9 +1659,29 @@ Edge.tangentialDeflectionPoints(angularDeflection: Double = 0.1, curvatureDeflec
 
 ## BRepGProp_Sinert (Surface Inertia per Face)
 Face.surfaceInertia(epsilon: Double) -> FaceSurfaceInertia
+Face.surfaceInertia -> FaceSurfaceInertia
 
 ## BRepGProp_Vinert (Volume Inertia per Face)
 Face.volumeInertia(planeNormal: SIMD3<Double>, planeDistance: Double = 0) -> FaceVolumeInertia
+Face.volumeInertia -> FaceVolumeInertia
+
+## Shape Type
+Shape.shapeType -> ShapeType
+Shape.isValidSolid -> Bool
+
+## Bounds
+Shape.bounds -> (min: SIMD3<Double>, max: SIMD3<Double>)
+Shape.size -> SIMD3<Double>
+Shape.center -> SIMD3<Double>
+
+## Face Validity Checking
+Face.faceCheckResult -> Shape.CheckResult
+
+## BRepGProp_Cinert (Curve Inertia per Edge)
+Edge.curveInertia -> CurveInertia
+
+## (uncategorized)
+Face.primaryAxis -> ShapeAxis?
 
 Shape properties (volume, surfaceArea, centerOfMass, bounds, isValid) are accessed as Swift computed properties.`,
 
@@ -1338,6 +1697,7 @@ Exporter.writeGLTF(shape: Shape, to url: URL, binary: Bool = true, deflection: D
 ## STL Export
 Exporter.writeSTL(shape: Shape, to url: URL, deflection: Double = 0.1, ascii: Bool = false) throws
 Exporter.stlData(shape: Shape, deflection: Double = 0.1) throws -> Data
+Exporter.errorDescription -> String?
 
 ## STEP Export
 Exporter.writeSTEP(shape: Shape, to url: URL, name: String? = nil) throws
@@ -1381,6 +1741,14 @@ Shape.stepData(name: String? = nil) throws -> Data
 
 ## STEP Optimization
 Exporter.optimizeSTEP(input: URL, output: URL) throws
+
+## PDF 1.4 export (#85, v0.150)
+Exporter.writePDF(drawing: Drawing, to url: URL, pageSize: SIMD2<Double> = SIMD2(841, 595), deflection: Double = 0.1) throws
+Exporter.writePDF(sheet: Sheet, body: (PDFWriter) -> Void, to url: URL, deflection: Double = 0.1) throws
+
+## SVG export (#86, v0.150)
+Exporter.writeSVG(drawing: Drawing, to url: URL, deflection: Double = 0.1) throws
+Exporter.writeSVG(sheet: Sheet, body: (SVGWriter) -> Void, to url: URL, deflection: Double = 0.1) throws
 
 ## Import
 Shape.load(from url: URL) throws -> Shape
@@ -1458,6 +1826,7 @@ TopologyGraph.isRemoved(nodeKind: NodeKind, nodeIndex: Int) -> Bool
 
 ## Validate
 TopologyGraph.validate() -> ValidationResult
+TopologyGraph.isValid -> Bool
 
 ## Compact
 TopologyGraph.compact() -> CompactResult
@@ -1513,12 +1882,16 @@ TopologyGraph.solidCompSolidCount(_ solidIndex: Int) -> Int
 
 ## History
 TopologyGraph.clearHistory()
+TopologyGraph.historyRecordCount -> Int
+TopologyGraph.isHistoryEnabled -> Bool
 
 ## History Record Readback (v0.141, #72 Phase 0)
 TopologyGraph.historyRecord(at index: Int) -> HistoryRecord?
 TopologyGraph.findOriginal(of derived: NodeRef) -> NodeRef
 TopologyGraph.findDerived(of original: NodeRef) -> [NodeRef]
 TopologyGraph.recordHistory(operationName: String, original: NodeRef, replacements: [NodeRef])
+TopologyGraph.isValid -> Bool
+TopologyGraph.historyRecords -> [HistoryRecord]
 
 ## SameDomain
 TopologyGraph.sameDomainFaces(of faceIndex: Int) -> [Int]
@@ -1531,6 +1904,10 @@ TopologyGraph.productShapeRoot(_ productIndex: Int) -> (kind: NodeKind, index: I
 TopologyGraph.occurrenceProduct(_ occIndex: Int) -> Int
 TopologyGraph.occurrenceParentProduct(_ occIndex: Int) -> Int
 TopologyGraph.occurrenceParentOccurrence(_ occIndex: Int) -> Int?
+TopologyGraph.productCount -> Int
+TopologyGraph.occurrenceCount -> Int
+TopologyGraph.rootProductCount -> Int
+TopologyGraph.rootProductIndices -> [Int]
 
 ## Reference Entry Queries
 TopologyGraph.refChildNodeKind(_ refKind: RefKind, refIndex: Int) -> NodeKind?
@@ -1570,6 +1947,54 @@ TopologyGraph.isShellClosed(_ shellIndex: Int) -> Bool
 ## Solid Additional Queries
 TopologyGraph.solidCompoundCount(_ solidIndex: Int) -> Int
 
+## Topology Counts
+TopologyGraph.nodeCount -> Int
+TopologyGraph.faceCount -> Int
+TopologyGraph.activeFaceCount -> Int
+TopologyGraph.edgeCount -> Int
+TopologyGraph.activeEdgeCount -> Int
+TopologyGraph.vertexCount -> Int
+TopologyGraph.activeVertexCount -> Int
+TopologyGraph.wireCount -> Int
+TopologyGraph.shellCount -> Int
+TopologyGraph.solidCount -> Int
+TopologyGraph.coedgeCount -> Int
+TopologyGraph.compoundCount -> Int
+
+## Geometry Counts
+TopologyGraph.surfaceCount -> Int
+TopologyGraph.curve3DCount -> Int
+TopologyGraph.curve2DCount -> Int
+
+## Root Nodes
+TopologyGraph.rootNodes -> [RootNode]
+
+## Statistics
+TopologyGraph.description -> String
+TopologyGraph.stats -> Stats
+
+## Poly Counts
+TopologyGraph.triangulationCount -> Int
+TopologyGraph.polygon3DCount -> Int
+
+## Active Geometry Counts
+TopologyGraph.activeSurfaceCount -> Int
+TopologyGraph.activeCurve3DCount -> Int
+TopologyGraph.activeCurve2DCount -> Int
+
+## Reference Counts
+TopologyGraph.shellRefCount -> Int
+TopologyGraph.faceRefCount -> Int
+TopologyGraph.wireRefCount -> Int
+TopologyGraph.coedgeRefCount -> Int
+TopologyGraph.vertexRefCount -> Int
+TopologyGraph.solidRefCount -> Int
+TopologyGraph.childRefCount -> Int
+TopologyGraph.occurrenceRefCount -> Int
+
+## CompSolid Count
+TopologyGraph.compSolidCount -> Int
+
 Build a graph-based B-Rep topology from any Shape for fast adjacency queries, analysis, ML export, and geometry sampling. Construct with TopologyGraph(shape:parallel:).`,
 
   topology_graph_builder: `# TopologyGraph Builder (Mutations)
@@ -1600,6 +2025,7 @@ TopologyGraph.appendFullShape(_ shape: Shape, parallel: Bool = false)
 TopologyGraph.beginDeferredInvalidation()
 TopologyGraph.endDeferredInvalidation()
 TopologyGraph.commitMutation()
+TopologyGraph.isDeferredMode -> Bool
 
 ## Builder: Edge Splitting
 TopologyGraph.splitEdge(edgeIndex: Int, vertexIndex: Int, param: Double) -> (subA: Int, subB: Int)?

--- a/src/index.ts
+++ b/src/index.ts
@@ -50,10 +50,11 @@ server.tool(
 );
 
 // ── get_script ──────────────────────────────────────────────────────────────
-// Read the current main.swift source.
+// Return the most recent script run in this MCP session.
 server.tool(
   "get_script",
-  "Read the current Swift CAD script source (main.swift) from OCCTSwiftScripts.",
+  "Return the source of the most recent Swift CAD script executed in this MCP session. " +
+    "Returns a 'no script executed' message if execute_script has not been called yet.",
   {},
   async () => {
     return getScript();
@@ -92,6 +93,8 @@ server.tool(
         "surfaces",
         "analysis",
         "import_export",
+        "topology_graph",
+        "topology_graph_builder",
         "all",
       ])
       .describe("API category to look up"),

--- a/src/occtkit-serve.ts
+++ b/src/occtkit-serve.ts
@@ -1,0 +1,161 @@
+import { spawn, ChildProcess } from "child_process";
+import { resolveOcctkit } from "./occtkit.js";
+
+export interface ServeEnvelope {
+  ok: boolean;
+  exit: number;
+  stdout: string;
+  stderr: string;
+  error?: string;
+}
+
+interface PendingRequest {
+  resolve: (env: ServeEnvelope) => void;
+  reject: (err: Error) => void;
+  timeoutId: NodeJS.Timeout;
+}
+
+/**
+ * Long-lived `occtkit run --serve` child. Sends one JSONL request per call,
+ * receives one envelope per response (post-OCCTSwiftScripts#5 framing).
+ *
+ * Strictly serial — the upstream serve loop processes lines one at a time,
+ * so we queue requests and dispatch envelopes in FIFO order.
+ *
+ * On timeout: kills the child, rejects all pending requests, and lets the
+ * next call respawn. On crash: same.
+ *
+ * On a pre-fix occtkit (envelope shape doesn't match): marks serve as
+ * unsupported for the rest of the session so callers stop trying.
+ */
+export class ServeProcess {
+  private child?: ChildProcess;
+  private buffer = "";
+  private queue: PendingRequest[] = [];
+  private supported = true;
+
+  isSupported(): boolean {
+    return this.supported;
+  }
+
+  async send(scriptPath: string, timeoutMs = 120_000): Promise<ServeEnvelope> {
+    if (!this.supported) {
+      throw new Error("occtkit --serve marked unsupported earlier this session");
+    }
+    await this.ensureChild();
+    return new Promise<ServeEnvelope>((resolve, reject) => {
+      const timeoutId = setTimeout(() => {
+        const idx = this.queue.findIndex((r) => r.resolve === resolve);
+        if (idx >= 0) this.queue.splice(idx, 1);
+        this.killChild();
+        reject(new Error(`occtkit --serve request timed out after ${timeoutMs}ms`));
+      }, timeoutMs);
+
+      this.queue.push({ resolve, reject, timeoutId });
+      const req = JSON.stringify({ args: [scriptPath] }) + "\n";
+      this.child!.stdin!.write(req);
+    });
+  }
+
+  private async ensureChild(): Promise<void> {
+    if (this.child && this.child.exitCode === null && !this.child.killed) return;
+
+    const oc = await resolveOcctkit();
+    const args = [...oc.baseArgs, "--serve"];
+    const child = spawn(oc.command, args, {
+      cwd: oc.cwd,
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    this.child = child;
+    this.buffer = "";
+
+    child.stdout!.on("data", (chunk: Buffer) => this.onStdout(chunk));
+    child.stderr!.on("data", (chunk: Buffer) => {
+      process.stderr.write(`[occtkit serve] ${chunk}`);
+    });
+    child.on("exit", (code, signal) => this.onExit(code, signal));
+    child.on("error", (err) => {
+      process.stderr.write(`[occtkit serve] spawn error: ${err.message}\n`);
+    });
+  }
+
+  private onStdout(chunk: Buffer): void {
+    this.buffer += chunk.toString("utf-8");
+    let nl: number;
+    while ((nl = this.buffer.indexOf("\n")) !== -1) {
+      const line = this.buffer.slice(0, nl);
+      this.buffer = this.buffer.slice(nl + 1);
+      if (line.trim() === "") continue;
+      this.dispatch(line);
+    }
+  }
+
+  private dispatch(line: string): void {
+    const pending = this.queue.shift();
+    if (!pending) {
+      process.stderr.write(`[occtkit serve] unsolicited line dropped: ${line.slice(0, 200)}\n`);
+      return;
+    }
+    clearTimeout(pending.timeoutId);
+
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(line);
+    } catch {
+      pending.reject(new Error(`occtkit serve emitted unparseable line: ${line.slice(0, 200)}`));
+      return;
+    }
+    if (
+      typeof parsed !== "object" ||
+      parsed === null ||
+      typeof (parsed as { ok?: unknown }).ok !== "boolean"
+    ) {
+      // Pre-fix occtkit (or some other client) — disable for the session.
+      this.supported = false;
+      this.killChild();
+      pending.reject(
+        new Error(
+          "occtkit --serve envelope is missing the `ok` field. " +
+            "OCCTSwiftScripts predates the framing fix (#5) — falling back to one-shot mode."
+        )
+      );
+      return;
+    }
+    pending.resolve(parsed as ServeEnvelope);
+  }
+
+  private onExit(code: number | null, signal: NodeJS.Signals | null): void {
+    const failed = this.queue.splice(0);
+    for (const r of failed) {
+      clearTimeout(r.timeoutId);
+      r.reject(new Error(`occtkit --serve exited (code=${code} signal=${signal})`));
+    }
+    this.child = undefined;
+    this.buffer = "";
+  }
+
+  private killChild(): void {
+    if (this.child && !this.child.killed) {
+      this.child.kill("SIGTERM");
+    }
+  }
+
+  shutdown(): void {
+    if (this.child?.stdin) this.child.stdin.end();
+    this.killChild();
+  }
+}
+
+let singleton: ServeProcess | undefined;
+
+export function getServeProcess(): ServeProcess {
+  if (!singleton) {
+    singleton = new ServeProcess();
+    process.on("exit", () => singleton?.shutdown());
+  }
+  return singleton;
+}
+
+export function serveDisabled(): boolean {
+  return process.env.OCCTMCP_OCCTKIT_NO_SERVE === "1";
+}

--- a/src/occtkit.ts
+++ b/src/occtkit.ts
@@ -1,0 +1,52 @@
+import { execFile } from "child_process";
+import { existsSync } from "fs";
+import { join } from "path";
+import { promisify } from "util";
+import { SCRIPTS_PROJECT } from "./paths.js";
+
+const execFileAsync = promisify(execFile);
+
+export interface OcctkitInvocation {
+  /** The executable to spawn. */
+  command: string;
+  /** Args prepended before the script path. */
+  baseArgs: string[];
+  /** Working directory for the spawn (only set when using the sibling-repo fallback). */
+  cwd?: string;
+}
+
+let cache: OcctkitInvocation | undefined;
+
+async function onPath(): Promise<boolean> {
+  try {
+    await execFileAsync("which", ["occtkit"]);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export async function resolveOcctkit(): Promise<OcctkitInvocation> {
+  if (cache) return cache;
+
+  if (await onPath()) {
+    cache = { command: "occtkit", baseArgs: ["run"] };
+    return cache;
+  }
+
+  if (existsSync(join(SCRIPTS_PROJECT, "Package.swift"))) {
+    cache = {
+      command: "swift",
+      baseArgs: ["run", "-c", "release", "occtkit", "run"],
+      cwd: SCRIPTS_PROJECT,
+    };
+    return cache;
+  }
+
+  throw new Error(
+    "occtkit not found. Install one of:\n" +
+      "  • `make install` from ~/Projects/OCCTSwiftScripts (puts occtkit on $PATH)\n" +
+      "  • clone OCCTSwiftScripts to ~/Projects/OCCTSwiftScripts so `swift run occtkit` is available\n" +
+      "Requires OCCTSwiftScripts >= v0.5.0-rc.1."
+  );
+}

--- a/src/paths.ts
+++ b/src/paths.ts
@@ -1,12 +1,15 @@
-import { homedir } from "os";
+import { homedir, tmpdir } from "os";
 import { join } from "path";
 import { existsSync } from "fs";
+import { randomUUID } from "crypto";
 
-/** Root of the OCCTSwiftScripts project. */
+/** Root of the OCCTSwiftScripts project — used as a fallback when occtkit is not on $PATH. */
 export const SCRIPTS_PROJECT = join(homedir(), "Projects", "OCCTSwiftScripts");
 
-/** The script source file that gets rewritten on each execute_script call. */
-export const MAIN_SWIFT = join(SCRIPTS_PROJECT, "Sources", "Script", "main.swift");
+/** Path for a fresh per-call script tempfile. */
+export function tempScriptPath(): string {
+  return join(tmpdir(), `occtmcp-script-${randomUUID()}.swift`);
+}
 
 /** Output directory — prefers iCloud Drive, falls back to local. */
 export function outputDir(): string {

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -6,8 +6,15 @@ import { promisify } from "util";
 import { outputDir, manifestPath, tempScriptPath } from "./paths.js";
 import { API_REFERENCE } from "./api-reference.js";
 import { resolveOcctkit } from "./occtkit.js";
+import {
+  getServeProcess,
+  serveDisabled,
+  type ServeEnvelope,
+} from "./occtkit-serve.js";
 
 const execFileAsync = promisify(execFile);
+
+const TOOL_TIMEOUT_MS = 120_000;
 
 /** Source of the most recent script run in this MCP session, for `get_script`. */
 let lastScriptCode: string | undefined;
@@ -44,66 +51,122 @@ function filterBuildOutput(raw: string): string {
 
 // ── execute_script ──────────────────────────────────────────────────────────
 
+type ToolResult = { content: Array<{ type: "text"; text: string }> };
+
 export async function executeScript(
   code: string,
   description?: string
-): Promise<{ content: Array<{ type: "text"; text: string }> }> {
+): Promise<ToolResult> {
   const scriptPath = tempScriptPath();
   await writeFile(scriptPath, code, "utf-8");
   lastScriptCode = code;
 
   try {
-    const oc = await resolveOcctkit();
-    try {
-      const { stdout, stderr } = await execFileAsync(
-        oc.command,
-        [...oc.baseArgs, scriptPath],
-        {
-          cwd: oc.cwd,
-          timeout: 120_000, // 2 min for first build; incremental ~1–2s
-          maxBuffer: 10 * 1024 * 1024,
+    if (!serveDisabled()) {
+      const serve = getServeProcess();
+      if (serve.isSupported()) {
+        try {
+          const env = await serve.send(scriptPath, TOOL_TIMEOUT_MS);
+          return await formatServeResult(env, description);
+        } catch (err) {
+          const msg = err instanceof Error ? err.message : String(err);
+          process.stderr.write(
+            `[occtmcp] serve mode failed (${msg}); falling back to one-shot occtkit run\n`
+          );
         }
-      );
-
-      const filteredStdout = filterBuildOutput(stdout || "");
-      const filteredStderr = filterBuildOutput(stderr || "");
-      const output = [filteredStdout, filteredStderr].filter(Boolean).join("\n").trim();
-
-      let manifest = "";
-      const mp = manifestPath();
-      if (existsSync(mp)) {
-        const raw = await readFile(mp, "utf-8");
-        manifest = `\n\nManifest:\n${raw}`;
       }
-
-      return {
-        content: [
-          {
-            type: "text" as const,
-            text: `Script executed successfully.${description ? ` (${description})` : ""}\n\nOutput:\n${output || "(no output)"}${manifest}`,
-          },
-        ],
-      };
-    } catch (err: unknown) {
-      const error = err as { stdout?: string; stderr?: string; message?: string };
-      const parts = [
-        filterBuildOutput(error.stdout || ""),
-        filterBuildOutput(error.stderr || ""),
-      ].filter(Boolean);
-
-      const output = parts.join("\n").trim() || error.message || "Unknown error";
-
-      return {
-        content: [
-          {
-            type: "text" as const,
-            text: `Script failed.\n\n${output}`,
-          },
-        ],
-      };
     }
+    return await executeOneShot(scriptPath, description);
   } finally {
     await unlink(scriptPath).catch(() => {});
+  }
+}
+
+async function formatServeResult(
+  env: ServeEnvelope,
+  description?: string
+): Promise<ToolResult> {
+  const combined = [env.stdout, env.stderr].filter(Boolean).join("\n");
+  const filtered = filterBuildOutput(combined);
+  if (env.ok) {
+    let manifest = "";
+    const mp = manifestPath();
+    if (existsSync(mp)) {
+      const raw = await readFile(mp, "utf-8");
+      manifest = `\n\nManifest:\n${raw}`;
+    }
+    return {
+      content: [
+        {
+          type: "text" as const,
+          text: `Script executed successfully.${description ? ` (${description})` : ""}\n\nOutput:\n${filtered || "(no output)"}${manifest}`,
+        },
+      ],
+    };
+  }
+  const errorTail = env.error ? (filtered ? `\n\n${env.error}` : env.error) : "";
+  return {
+    content: [
+      {
+        type: "text" as const,
+        text: `Script failed.\n\n${filtered}${errorTail}`.trim() || "Unknown error",
+      },
+    ],
+  };
+}
+
+async function executeOneShot(
+  scriptPath: string,
+  description?: string
+): Promise<ToolResult> {
+  const oc = await resolveOcctkit();
+  try {
+    const { stdout, stderr } = await execFileAsync(
+      oc.command,
+      [...oc.baseArgs, scriptPath],
+      {
+        cwd: oc.cwd,
+        timeout: TOOL_TIMEOUT_MS, // 2 min for first build; incremental ~1–2s
+        maxBuffer: 10 * 1024 * 1024,
+      }
+    );
+
+    const filteredStdout = filterBuildOutput(stdout || "");
+    const filteredStderr = filterBuildOutput(stderr || "");
+    const output = [filteredStdout, filteredStderr].filter(Boolean).join("\n").trim();
+
+    let manifest = "";
+    const mp = manifestPath();
+    if (existsSync(mp)) {
+      const raw = await readFile(mp, "utf-8");
+      manifest = `\n\nManifest:\n${raw}`;
+    }
+
+    return {
+      content: [
+        {
+          type: "text" as const,
+          text: `Script executed successfully.${description ? ` (${description})` : ""}\n\nOutput:\n${output || "(no output)"}${manifest}`,
+        },
+      ],
+    };
+  } catch (err: unknown) {
+    const error = err as { stdout?: string; stderr?: string; message?: string };
+    const parts = [
+      filterBuildOutput(error.stdout || ""),
+      filterBuildOutput(error.stderr || ""),
+    ].filter(Boolean);
+
+    const output = parts.join("\n").trim() || error.message || "Unknown error";
+
+    return {
+      content: [
+        {
+          type: "text" as const,
+          text: `Script failed.\n\n${output}`,
+        },
+      ],
+    };
   }
 }
 

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -1,12 +1,16 @@
 import { execFile } from "child_process";
-import { readFile, readdir, writeFile } from "fs/promises";
+import { readFile, readdir, writeFile, unlink } from "fs/promises";
 import { existsSync } from "fs";
 import { join } from "path";
 import { promisify } from "util";
-import { SCRIPTS_PROJECT, MAIN_SWIFT, outputDir, manifestPath } from "./paths.js";
+import { outputDir, manifestPath, tempScriptPath } from "./paths.js";
 import { API_REFERENCE } from "./api-reference.js";
+import { resolveOcctkit } from "./occtkit.js";
 
 const execFileAsync = promisify(execFile);
+
+/** Source of the most recent script run in this MCP session, for `get_script`. */
+let lastScriptCode: string | undefined;
 
 /**
  * Filter out noisy compiler warnings (OCCT bridge nullability warnings, etc.)
@@ -44,60 +48,62 @@ export async function executeScript(
   code: string,
   description?: string
 ): Promise<{ content: Array<{ type: "text"; text: string }> }> {
-  // 1. Write the script
-  await writeFile(MAIN_SWIFT, code, "utf-8");
+  const scriptPath = tempScriptPath();
+  await writeFile(scriptPath, code, "utf-8");
+  lastScriptCode = code;
 
-  // 2. Build & run
   try {
-    const { stdout, stderr } = await execFileAsync(
-      "swift",
-      ["run", "Script"],
-      {
-        cwd: SCRIPTS_PROJECT,
-        timeout: 120_000, // 2 min for first build, incremental is ~1-2s
-        maxBuffer: 10 * 1024 * 1024,
+    const oc = await resolveOcctkit();
+    try {
+      const { stdout, stderr } = await execFileAsync(
+        oc.command,
+        [...oc.baseArgs, scriptPath],
+        {
+          cwd: oc.cwd,
+          timeout: 120_000, // 2 min for first build; incremental ~1–2s
+          maxBuffer: 10 * 1024 * 1024,
+        }
+      );
+
+      const filteredStdout = filterBuildOutput(stdout || "");
+      const filteredStderr = filterBuildOutput(stderr || "");
+      const output = [filteredStdout, filteredStderr].filter(Boolean).join("\n").trim();
+
+      let manifest = "";
+      const mp = manifestPath();
+      if (existsSync(mp)) {
+        const raw = await readFile(mp, "utf-8");
+        manifest = `\n\nManifest:\n${raw}`;
       }
-    );
 
-    const filteredStdout = filterBuildOutput(stdout || "");
-    const filteredStderr = filterBuildOutput(stderr || "");
-    const output = [filteredStdout, filteredStderr].filter(Boolean).join("\n").trim();
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: `Script executed successfully.${description ? ` (${description})` : ""}\n\nOutput:\n${output || "(no output)"}${manifest}`,
+          },
+        ],
+      };
+    } catch (err: unknown) {
+      const error = err as { stdout?: string; stderr?: string; message?: string };
+      const parts = [
+        filterBuildOutput(error.stdout || ""),
+        filterBuildOutput(error.stderr || ""),
+      ].filter(Boolean);
 
-    // 3. Read manifest if it exists
-    let manifest = "";
-    const mp = manifestPath();
-    if (existsSync(mp)) {
-      const raw = await readFile(mp, "utf-8");
-      manifest = `\n\nManifest:\n${raw}`;
+      const output = parts.join("\n").trim() || error.message || "Unknown error";
+
+      return {
+        content: [
+          {
+            type: "text" as const,
+            text: `Script failed.\n\n${output}`,
+          },
+        ],
+      };
     }
-
-    return {
-      content: [
-        {
-          type: "text" as const,
-          text: `Script executed successfully.${description ? ` (${description})` : ""}\n\nOutput:\n${output || "(no output)"}${manifest}`,
-        },
-      ],
-    };
-  } catch (err: unknown) {
-    const error = err as { stdout?: string; stderr?: string; message?: string };
-    // For errors, keep more output to help diagnose, but still filter noise
-    const parts = [
-      filterBuildOutput(error.stdout || ""),
-      filterBuildOutput(error.stderr || ""),
-    ].filter(Boolean);
-
-    // If filtering removed everything useful, fall back to the raw message
-    const output = parts.join("\n").trim() || error.message || "Unknown error";
-
-    return {
-      content: [
-        {
-          type: "text" as const,
-          text: `Script failed.\n\n${output}`,
-        },
-      ],
-    };
+  } finally {
+    await unlink(scriptPath).catch(() => {});
   }
 }
 
@@ -135,15 +141,18 @@ export async function getScene(): Promise<{
 export async function getScript(): Promise<{
   content: Array<{ type: "text"; text: string }>;
 }> {
-  if (!existsSync(MAIN_SWIFT)) {
+  if (lastScriptCode === undefined) {
     return {
-      content: [{ type: "text" as const, text: "No script found at " + MAIN_SWIFT }],
+      content: [
+        {
+          type: "text" as const,
+          text: "No script has been executed in this session. Call execute_script first.",
+        },
+      ],
     };
   }
-
-  const source = await readFile(MAIN_SWIFT, "utf-8");
   return {
-    content: [{ type: "text" as const, text: source }],
+    content: [{ type: "text" as const, text: lastScriptCode }],
   };
 }
 
@@ -167,7 +176,8 @@ export async function exportModel(): Promise<{
       f.endsWith(".step") ||
       f.endsWith(".brep") ||
       f.endsWith(".stl") ||
-      f.endsWith(".obj")
+      f.endsWith(".obj") ||
+      f.endsWith(".json")
   );
 
   if (modelFiles.length === 0) {


### PR DESCRIPTION
## Summary

Replaces the brittle `swift run Script`-in-sibling-repo pattern with the new `occtkit` CLI from OCCTSwiftScripts v0.5.0-rc.1+, and amortises cold-start across the MCP session via a long-lived `occtkit run --serve` child.

- **`33adf07` path-based migration** — write user Swift to a per-call tempfile under `os.tmpdir()`, invoke `occtkit run <tempfile>` via the new `src/occtkit.ts` resolver (PATH first, sibling-repo `swift run` fallback). `get_script` now returns the source kept in memory this session.
- **`7ec8b35` long-lived `--serve` client** — singleton `ServeProcess` in `src/occtkit-serve.ts` that speaks JSONL to `occtkit run --serve`, parses one envelope per request. Per-request 2-min timeout; SIGTERMs and respawns on timeout or crash. Falls back to one-shot when pre-fix occtkit is detected, or with `OCCTMCP_OCCTKIT_NO_SERVE=1`. Smoke-tested: cold 4.8 s, warm 1.2 s (~4× speedup).
- **`b1cac1a` generator extended for `public var`** — closes #1. `Face.surfaceType`, `Edge.curveType`, `Shape.bounds`, `Shape.volume` etc. now appear in `get_api_reference` analysis output with their actual enum / tuple types instead of the old fictional `-> String`.

Requires OCCTSwiftScripts ≥ post-`fd2a1cf` (the framing fix from gsdali/OCCTSwiftScripts#5).

Closes #1.

## Test plan

- [x] `npm run build` clean
- [x] Serve-mode smoke test (4 mixed requests against a real `occtkit run --serve`): envelopes parse cleanly, cold→warm transition measured
- [x] `src/api-reference.ts` regenerated against current OCCTSwift sources — `Face.surfaceType -> SurfaceType`, `Edge.curveType -> CurveType`, `bounds` non-optional all present
- [ ] End-to-end MCP smoke after merge: `execute_script` → `get_scene` → `get_script` → `export_model` against live OCCTSwiftViewport
- [ ] Verify the one-shot fallback actually fires by running against an intentionally-pre-fix pinned OCCTSwiftScripts (optional — fallback path is exercised today only when the singleton marks itself unsupported)
