### PR TITLE
Add five graph MCP tools wrapping occtkit verbs (#2)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,6 +63,13 @@ The 2 min timeout is per-request in both paths. On serve-mode timeout the child 
 | `get_script` | Return the most recent script executed in this MCP session (kept in memory; not a filesystem read) |
 | `export_model` | List exported BREP/STEP/STL/OBJ file paths |
 | `get_api_reference` | Return OCCTSwift API reference by category (or "all") |
+| `graph_validate` | Validate a BREP's topology graph — wraps `occtkit graph-validate` |
+| `graph_compact` | Drop unreferenced nodes, write rebuilt BREP — wraps `occtkit graph-compact` |
+| `graph_dedup` | Deduplicate shared surface/curve geometry — wraps `occtkit graph-dedup` |
+| `graph_ml` | ML-friendly graph + UV/edge sample export — wraps `occtkit graph-ml` |
+| `feature_recognize` | AAG-based pocket + hole detection — wraps `occtkit feature-recognize` |
+
+The five graph/feature tools are thin one-shot wrappers around pre-compiled occtkit verbs defined in `src/graph-tools.ts`. They go through the same `resolveOcctkit()` discovery as `execute_script` but bypass serve mode — these verbs don't compile Swift at call time, so there's no amortisation benefit. Each takes a BREP file path (use `export_model` to list available ones) and returns the verb's JSON report verbatim.
 
 ## Script Template
 

--- a/src/graph-tools.ts
+++ b/src/graph-tools.ts
@@ -1,0 +1,141 @@
+import { execFile } from "child_process";
+import { existsSync } from "fs";
+import { promisify } from "util";
+import { resolveOcctkit } from "./occtkit.js";
+
+const execFileAsync = promisify(execFile);
+
+type ToolResult = { content: Array<{ type: "text"; text: string }> };
+
+/**
+ * One-shot invocation of a pre-compiled occtkit verb (`graph-validate`,
+ * `graph-compact`, `graph-dedup`, `graph-ml`, `feature-recognize`). These
+ * verbs don't compile Swift at call time, so there's no cold-start to
+ * amortise — plain execFile is fine.
+ *
+ * On success the verb writes one JSON document to stdout. On failure it
+ * writes a line like "Error: …" to stderr and exits non-zero.
+ */
+async function runVerb(
+  verb: string,
+  verbArgs: string[],
+  timeoutMs = 60_000
+): Promise<
+  | { ok: true; stdout: string }
+  | { ok: false; error: string; stderr: string }
+> {
+  const oc = await resolveOcctkit();
+  try {
+    const { stdout } = await execFileAsync(
+      oc.command,
+      [...oc.baseArgs, verb, ...verbArgs],
+      {
+        cwd: oc.cwd,
+        timeout: timeoutMs,
+        maxBuffer: 50 * 1024 * 1024,
+      }
+    );
+    return { ok: true, stdout: stdout.trim() };
+  } catch (err: unknown) {
+    const e = err as { stderr?: string; message?: string };
+    return {
+      ok: false,
+      error: e.message ?? "unknown error",
+      stderr: (e.stderr ?? "").trim(),
+    };
+  }
+}
+
+function requirePath(path: string, kind: string): ToolResult | null {
+  if (!existsSync(path)) {
+    return {
+      content: [
+        {
+          type: "text" as const,
+          text: `${kind} not found: ${path}\nCheck the path. Use export_model to list available files.`,
+        },
+      ],
+    };
+  }
+  return null;
+}
+
+function formatVerbResult(
+  verb: string,
+  result: Awaited<ReturnType<typeof runVerb>>
+): ToolResult {
+  if (result.ok) {
+    return { content: [{ type: "text" as const, text: result.stdout }] };
+  }
+  const tail = result.stderr ? `\n\n${result.stderr}` : "";
+  return {
+    content: [
+      {
+        type: "text" as const,
+        text: `occtkit ${verb} failed.\n\n${result.error}${tail}`,
+      },
+    ],
+  };
+}
+
+// ── graph_validate ──────────────────────────────────────────────────────────
+
+export async function graphValidate(brepPath: string): Promise<ToolResult> {
+  const missing = requirePath(brepPath, "BREP file");
+  if (missing) return missing;
+  return formatVerbResult("graph-validate", await runVerb("graph-validate", [brepPath]));
+}
+
+// ── graph_compact ───────────────────────────────────────────────────────────
+
+export async function graphCompact(
+  brepPath: string,
+  outputPath: string
+): Promise<ToolResult> {
+  const missing = requirePath(brepPath, "BREP file");
+  if (missing) return missing;
+  return formatVerbResult(
+    "graph-compact",
+    await runVerb("graph-compact", [brepPath, outputPath])
+  );
+}
+
+// ── graph_dedup ─────────────────────────────────────────────────────────────
+
+export async function graphDedup(
+  brepPath: string,
+  outputPath: string
+): Promise<ToolResult> {
+  const missing = requirePath(brepPath, "BREP file");
+  if (missing) return missing;
+  return formatVerbResult(
+    "graph-dedup",
+    await runVerb("graph-dedup", [brepPath, outputPath])
+  );
+}
+
+// ── graph_ml ────────────────────────────────────────────────────────────────
+
+export async function graphMl(
+  brepPath: string,
+  uvSamples?: number,
+  edgeSamples?: number
+): Promise<ToolResult> {
+  const missing = requirePath(brepPath, "BREP file");
+  if (missing) return missing;
+  const args = [brepPath];
+  if (uvSamples !== undefined) args.push("--uv-samples", String(uvSamples));
+  if (edgeSamples !== undefined) args.push("--edge-samples", String(edgeSamples));
+  return formatVerbResult("graph-ml", await runVerb("graph-ml", args, 180_000));
+}
+
+// ── feature_recognize ───────────────────────────────────────────────────────
+
+export async function featureRecognize(brepPath: string): Promise<ToolResult> {
+  const missing = requirePath(brepPath, "BREP file");
+  if (missing) return missing;
+  return formatVerbResult(
+    "feature-recognize",
+    await runVerb("feature-recognize", [brepPath])
+  );
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,13 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { z } from "zod";
 import { executeScript, getScene, getScript, exportModel, getApiReference } from "./tools.js";
+import {
+  graphValidate,
+  graphCompact,
+  graphDedup,
+  graphMl,
+  featureRecognize,
+} from "./graph-tools.js";
 
 const server = new McpServer({
   name: "occtmcp",
@@ -101,6 +108,97 @@ server.tool(
   },
   async ({ category }) => {
     return getApiReference(category);
+  }
+);
+
+// ── graph_validate ──────────────────────────────────────────────────────────
+// Run BRepGraph validation on a BREP file and return the report JSON.
+server.tool(
+  "graph_validate",
+  "Validate a BREP shape's topology graph. Returns a JSON report: " +
+    "validity, error/warning counts, and per-category issue details. " +
+    "Use export_model to find BREP paths after execute_script.",
+  {
+    brep_path: z.string().describe("Absolute path to a BREP file."),
+  },
+  async ({ brep_path }) => {
+    return graphValidate(brep_path);
+  }
+);
+
+// ── graph_compact ───────────────────────────────────────────────────────────
+// Compact a BREP's topology graph (drops unreferenced nodes) and write a
+// rebuilt BREP to output_path. Returns JSON stats (nodes before/after).
+server.tool(
+  "graph_compact",
+  "Compact a BREP's topology graph (drops unreferenced nodes) and write the " +
+    "rebuilt shape to output_path. Returns a JSON report with before/after " +
+    "node counts.",
+  {
+    brep_path: z.string().describe("Absolute path to the input BREP file."),
+    output_path: z.string().describe("Absolute path where the compacted BREP is written."),
+  },
+  async ({ brep_path, output_path }) => {
+    return graphCompact(brep_path, output_path);
+  }
+);
+
+// ── graph_dedup ─────────────────────────────────────────────────────────────
+// Deduplicate shared surface/curve geometry in a BREP, write rebuilt BREP.
+server.tool(
+  "graph_dedup",
+  "Deduplicate shared surface/curve geometry in a BREP's topology graph. " +
+    "Writes the rebuilt shape to output_path and returns a JSON report.",
+  {
+    brep_path: z.string().describe("Absolute path to the input BREP file."),
+    output_path: z.string().describe("Absolute path where the deduped BREP is written."),
+  },
+  async ({ brep_path, output_path }) => {
+    return graphDedup(brep_path, output_path);
+  }
+);
+
+// ── graph_ml ────────────────────────────────────────────────────────────────
+// Export the topology graph plus UV/edge samples as ML-friendly JSON.
+server.tool(
+  "graph_ml",
+  "Export a BREP's topology graph as ML-friendly JSON: vertex positions, " +
+    "edge/face adjacency (COO), per-face UV-grid samples (position, normal, " +
+    "gaussian/mean curvature), and per-edge polyline samples. Output can be " +
+    "large for complex shapes — up to ~50 MB.",
+  {
+    brep_path: z.string().describe("Absolute path to a BREP file."),
+    uv_samples: z
+      .number()
+      .int()
+      .positive()
+      .optional()
+      .describe("Per-face UV grid resolution (default 16 × 16)."),
+    edge_samples: z
+      .number()
+      .int()
+      .positive()
+      .optional()
+      .describe("Per-edge polyline sample count (default 32)."),
+  },
+  async ({ brep_path, uv_samples, edge_samples }) => {
+    return graphMl(brep_path, uv_samples, edge_samples);
+  }
+);
+
+// ── feature_recognize ───────────────────────────────────────────────────────
+// AAG heuristic detection of pockets and holes.
+server.tool(
+  "feature_recognize",
+  "Detect pockets and cylindrical holes in a BREP via AAG (attributed " +
+    "adjacency graph) heuristics. Returns a JSON report listing each " +
+    "pocket's floor/wall faces, z-level, depth, and bounds, plus each " +
+    "hole's face index, radius, and depth.",
+  {
+    brep_path: z.string().describe("Absolute path to a BREP file."),
+  },
+  async ({ brep_path }) => {
+    return featureRecognize(brep_path);
   }
 );
 

--- a/src/occtkit-serve.ts
+++ b/src/occtkit-serve.ts
@@ -61,7 +61,7 @@ export class ServeProcess {
     if (this.child && this.child.exitCode === null && !this.child.killed) return;
 
     const oc = await resolveOcctkit();
-    const args = [...oc.baseArgs, "--serve"];
+    const args = [...oc.baseArgs, "run", "--serve"];
     const child = spawn(oc.command, args, {
       cwd: oc.cwd,
       stdio: ["pipe", "pipe", "pipe"],

--- a/src/occtkit.ts
+++ b/src/occtkit.ts
@@ -9,7 +9,7 @@ const execFileAsync = promisify(execFile);
 export interface OcctkitInvocation {
   /** The executable to spawn. */
   command: string;
-  /** Args prepended before the script path. */
+  /** Args prepended before the verb. Empty for PATH, `swift run …` for fallback. */
   baseArgs: string[];
   /** Working directory for the spawn (only set when using the sibling-repo fallback). */
   cwd?: string;
@@ -30,14 +30,14 @@ export async function resolveOcctkit(): Promise<OcctkitInvocation> {
   if (cache) return cache;
 
   if (await onPath()) {
-    cache = { command: "occtkit", baseArgs: ["run"] };
+    cache = { command: "occtkit", baseArgs: [] };
     return cache;
   }
 
   if (existsSync(join(SCRIPTS_PROJECT, "Package.swift"))) {
     cache = {
       command: "swift",
-      baseArgs: ["run", "-c", "release", "occtkit", "run"],
+      baseArgs: ["run", "-c", "release", "occtkit"],
       cwd: SCRIPTS_PROJECT,
     };
     return cache;

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -123,7 +123,7 @@ async function executeOneShot(
   try {
     const { stdout, stderr } = await execFileAsync(
       oc.command,
-      [...oc.baseArgs, scriptPath],
+      [...oc.baseArgs, "run", scriptPath],
       {
         cwd: oc.cwd,
         timeout: TOOL_TIMEOUT_MS, // 2 min for first build; incremental ~1–2s


### PR DESCRIPTION
## Summary

Exposes the BRepGraph + feature-recognition operations landed in OCCTSwiftScripts v0.5.0-rc.1 as five first-class MCP tools, resolving the long-standing request in #2.

| tool | wraps | purpose |
|---|---|---|
| `graph_validate(brep_path)` | `occtkit graph-validate` | validation report JSON |
| `graph_compact(brep_path, output_path)` | `occtkit graph-compact` | drops unreferenced nodes → rebuilt BREP + stats |
| `graph_dedup(brep_path, output_path)` | `occtkit graph-dedup` | deduplicates shared surface/curve geometry → rebuilt BREP + stats |
| `graph_ml(brep_path, uv_samples?, edge_samples?)` | `occtkit graph-ml` | ML-friendly graph + UV/edge samples |
| `feature_recognize(brep_path)` | `occtkit feature-recognize` | AAG pocket + hole detection |

The original `build_graph → handle, query_topology(handle)` shape from the issue doesn't map to MCP's stateless tool-call model; the BREP file is the persistent handle instead. `graph-query` is intentionally not wrapped — it requires a SQLite graph file that occtkit has no standalone verb to generate.

Small refactor included: `resolveOcctkit()` no longer hardcodes the `run` verb. The three callsites (`executeOneShot`, serve-mode spawn, new `runVerb` helper in `src/graph-tools.ts`) supply their own verb.

Depends on #N (occtkit migration). Must merge after that one.

Closes #2.

## Test plan

- [x] `npm run build` clean
- [x] All six paths smoke-tested through the compiled module against a real BREP: warm ~440 ms each; error path (`/nonexistent.brep`) returns a clear message in 0 ms (caught by pre-invocation path check, no shell-out)
- [x] Output envelopes verified against raw `swift run -c release occtkit <verb>` invocations — structurally identical
- [ ] End-to-end MCP smoke after merge: `execute_script` a box → `export_model` → `graph_validate` on the BREP path → `feature_recognize` on same
