### PR TITLE
Add 25 MCP tools (closes #6 minus simplify_mesh)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## What This Is
 
-MCP server that gives LLMs the ability to create and iterate on CAD models using OpenCASCADE via OCCTSwift. The server exposes five tools over stdio transport using the `@modelcontextprotocol/sdk`.
+MCP server that gives LLMs the ability to create and iterate on CAD models using OpenCASCADE via OCCTSwift. The server exposes a growing set of tools over stdio transport using the `@modelcontextprotocol/sdk` — a few core tools (`execute_script`, scene reads, API reference) plus thin wrappers around occtkit verbs (graph ops, feature recognition, drawing export, reconstruct) and pure-TS scene-mutation tools (remove/rename/clear/appearance/compare/export).
 
 ## Build & Run
 
@@ -14,17 +14,25 @@ npm start        # node dist/index.js (stdio transport)
 npm run dev      # tsc --watch
 ```
 
-No tests or linter configured.
+```bash
+npm test                  # node:test unit tests for scene-mutation logic (no occtkit)
+npm run test:integration  # node:test end-to-end chain through occtkit (slow; ~30–120s)
+```
+
+Tests under `tests/unit/` exercise the pure-TS scene-mutation code against a tempdir (set `OCCTMCP_OUTPUT_DIR` to redirect manifest reads/writes). `tests/integration/` runs every Phase 2 + Phase 3 verb-wrapping tool through a real occtkit subprocess against a tempdir seeded from a starter BREP. No linter configured.
 
 ## Architecture
 
 The server is a single-process Node.js app (ESM, strict TypeScript):
 
-- `src/index.ts` — Creates `McpServer`, registers all five tools with zod schemas, connects stdio transport
-- `src/tools.ts` — Tool implementations: writes Swift code to a tempfile, sends it to a long-lived `occtkit run --serve` child by default, falls back to one-shot `occtkit run <path>` if serve mode is unavailable
+- `src/index.ts` — Creates `McpServer`, registers every tool with zod schemas, connects stdio transport
+- `src/tools.ts` — Core tool implementations (`execute_script`, `get_scene`, `get_script`, `export_model`, `get_api_reference`): writes Swift code to a tempfile, sends it to a long-lived `occtkit run --serve` child by default, falls back to one-shot `occtkit run <path>` if serve mode is unavailable. `executeScript` calls `snapshotScene()` before running so `compare_versions` has history
+- `src/scene-tools.ts` — Pure-TS scene-mutation tools (`remove_body`, `clear_scene`, `rename_body`, `set_appearance`, `compare_versions`, `export_scene`). Read/modify/write `manifest.json` directly; OCCTSwiftViewport's ScriptWatcher reloads on the write. `export_scene` is the exception: it generates a one-shot Swift script that loads the bodies' BREPs and calls `Exporter.writeXxx`, run via `occtkit run`. Maintains an in-memory ring buffer of the last 10 manifest snapshots for `compare_versions`
+- `src/api-tools.ts` — Thin wrappers around existing occtkit verbs (`validate_geometry` → `graph-validate`, `recognize_features` → `feature-recognize`, `apply_feature` → `reconstruct`, `generate_drawing` → `drawing-export`). Each resolves a `bodyId` against the scene manifest, passes the BREP path to the verb, returns the verb's JSON output
+- `src/verb-tools.ts` — Wrappers around the post-#6 batch of occtkit verbs: `compute_metrics`, `query_topology`, `measure_distance`, `check_thickness`, `analyze_clearance`, `generate_mesh` (pure reads); `transform_body`, `boolean_op`, `mirror_or_pattern`, `heal_shape` (scene mutators — snapshot before mutating, support in-place vs new-body output); `read_brep`, `import_file` (run the verb in a staging tmpdir then merge into the live manifest, since `load-brep` / `import` would otherwise clobber the live manifest with their own); `render_preview` (PNG out). Most verbs accept JSON-on-stdin or `<request.json>` form — wrappers always go via `runVerbJSON` (writes a tempfile, passes the path)
 - `src/occtkit.ts` — Resolves how to invoke `occtkit`: prefers PATH, falls back to `swift run -c release occtkit` inside the sibling OCCTSwiftScripts repo, throws a clear setup error if neither is available. Result is memoised
 - `src/occtkit-serve.ts` — Singleton long-lived `occtkit run --serve` child. JSONL request/response over stdin/stdout (one envelope per request, post-`gsdali/OCCTSwiftScripts#5`). Per-request timeout kills the child and respawns on next call. If a returned envelope lacks the `ok` field (pre-fix occtkit), serve mode is permanently disabled for the session and callers fall back to one-shot
-- `src/paths.ts` — Output dir / manifest path resolution (iCloud-vs-local) and per-call tempfile name generation
+- `src/paths.ts` — Output dir / manifest path resolution. Resolution order: `OCCTMCP_OUTPUT_DIR` env var (used by the test suite) > iCloud Drive > local fallback (`~/.occtswift-scripts/output`). Per-call tempfile name generation lives here too
 - `src/api-reference.ts` — **Generated** OCCTSwift API reference strings keyed by category. Do not edit by hand — it is rewritten by `scripts/generate-api-reference.mjs` (runs as `npm run prebuild`). The generator parses `~/Projects/OCCTSwift/Sources/OCCTSwift/*.swift` directly, extracts `public func` declarations, and groups them via the editorial `CATEGORIES` array at the top of the script. New OCCTSwift methods that don't match any category are surfaced in the generator's stderr "UNMATCHED" report — extend `CATEGORIES` (add a `markRx` or `nameRx` rule) when something important is missing.
 
 ### Data Flow
@@ -68,8 +76,37 @@ The 2 min timeout is per-request in both paths. On serve-mode timeout the child 
 | `graph_dedup` | Deduplicate shared surface/curve geometry — wraps `occtkit graph-dedup` |
 | `graph_ml` | ML-friendly graph + UV/edge sample export — wraps `occtkit graph-ml` |
 | `feature_recognize` | AAG-based pocket + hole detection — wraps `occtkit feature-recognize` |
+| `remove_body` | Delete a body from the manifest + its BREP file (pure TS) |
+| `clear_scene` | Wipe all bodies from the manifest + delete their BREPs (pure TS) |
+| `rename_body` | Change a body's id in the manifest (pure TS) |
+| `set_appearance` | Update color / opacity / roughness / metallic / name on a body (pure TS) |
+| `compare_versions` | Diff current scene vs a snapshot N runs back; uses an in-memory ring buffer |
+| `export_scene` | Export current scene to step / iges / brep / stl / obj / gltf / glb (templated `occtkit run` script) |
+| `validate_geometry` | Per-body topology validation — resolves bodyId → BREP, wraps `graph-validate` |
+| `recognize_features` | Pockets + holes for a scene body — resolves bodyId, wraps `feature-recognize` |
+| `apply_feature` | Apply a single feature spec to a scene body — wraps `occtkit reconstruct` |
+| `generate_drawing` | Multi-view ISO 128-30 DXF for a scene body — wraps `occtkit drawing-export` |
+| `compute_metrics` | Volume / area / centroid / bbox / principal axes — wraps `occtkit metrics` |
+| `query_topology` | Find faces/edges/vertices matching criteria — wraps `occtkit query-topology` |
+| `measure_distance` | Min distance + contacts between two bodies — wraps `occtkit measure-distance` |
+| `check_thickness` | Wall-thickness analysis — wraps `occtkit check-thickness` |
+| `analyze_clearance` | Pairwise interference / clearance — wraps `occtkit analyze-clearance` |
+| `generate_mesh` | Triangle mesh + quality metrics — wraps `occtkit mesh` |
+| `transform_body` | Translate / rotate / uniform-scale a body (in place or new) — wraps `occtkit transform` |
+| `boolean_op` | Union / subtract / intersect / split between two bodies — wraps `occtkit boolean` |
+| `mirror_or_pattern` | Mirror / linear / circular pattern — wraps `occtkit pattern` |
+| `heal_shape` | Heal imported / non-watertight geometry — wraps `occtkit heal` |
+| `read_brep` | Add a `.brep` from disk to the scene — wraps `occtkit load-brep` (staged + merged) |
+| `import_file` | STEP / IGES / STL / OBJ import — wraps `occtkit import` (staged + merged) |
+| `render_preview` | One-shot PNG render of the scene — wraps `occtkit render-preview` |
+| `inspect_assembly` | Walk an XCAF assembly tree — wraps `occtkit inspect-assembly` |
+| `set_assembly_metadata` | Modify XCAF document or per-component metadata — wraps `occtkit set-metadata` |
 
-The five graph/feature tools are thin one-shot wrappers around pre-compiled occtkit verbs defined in `src/graph-tools.ts`. They go through the same `resolveOcctkit()` discovery as `execute_script` but bypass serve mode — these verbs don't compile Swift at call time, so there's no amortisation benefit. Each takes a BREP file path (use `export_model` to list available ones) and returns the verb's JSON report verbatim.
+The five graph/feature tools (`graph_*`, `feature_recognize`) are thin one-shot wrappers around pre-compiled occtkit verbs defined in `src/graph-tools.ts`. They go through the same `resolveOcctkit()` discovery as `execute_script` but bypass serve mode — these verbs don't compile Swift at call time, so there's no amortisation benefit. Each takes a BREP file path (use `export_model` to list available ones) and returns the verb's JSON report verbatim.
+
+The scene-mutation tools (`remove_body`, `clear_scene`, `rename_body`, `set_appearance`, `compare_versions`) are pure manifest manipulation — they don't shell out to occtkit at all. `export_scene` is the exception: it generates a small templated Swift program that loads the relevant BREPs and calls `Exporter.writeXxx`, run via `occtkit run` (one-shot, not serve). The `validate_geometry` / `recognize_features` / `apply_feature` / `generate_drawing` tools resolve a `bodyId` against the manifest and delegate to the corresponding occtkit verb.
+
+Only one tool from [#6](https://github.com/gsdali/OCCTMCP/issues/6) remains unbuilt: `simplify_mesh`, blocked on the `occtkit simplify-mesh` verb in OCCTSwiftScripts#22. The decimation algorithm is ready in [OCCTSwiftMesh v0.1.0](https://github.com/gsdali/OCCTSwiftMesh/releases/tag/v0.1.0) (QEM via vendored meshoptimizer); the verb just needs wiring. Once the verb lands, the MCP wrapper is a thin pass-through — same pattern as `generate_mesh`.
 
 ## Script Template
 

--- a/README.md
+++ b/README.md
@@ -15,13 +15,87 @@ The LLM has full access to OCCTSwift's 900+ CAD operations: primitives, booleans
 
 ## Tools
 
+35 tools, organized below. Most LLM flows can answer "what's the volume?", "make it red", "boolean-subtract these", "render a preview", "export to STEP", and "draw this" without ever round-tripping through `execute_script` — that's reserved for novel geometry the typed tools don't cover.
+
+### Authoring
+
 | Tool | Purpose |
 |------|---------|
-| `execute_script` | Write & execute Swift CAD code |
-| `get_scene` | Read current scene manifest (bodies, colors, materials) |
-| `get_script` | Read current Swift script source |
-| `export_model` | List exported BREP/STEP file paths |
+| `execute_script` | Write & execute arbitrary Swift CAD code (full OCCTSwift API) |
+| `get_script` | Read the most recent script's source |
 | `get_api_reference` | Browse OCCTSwift API by category |
+
+### Scene reads
+
+| Tool | Purpose |
+|------|---------|
+| `get_scene` | Read current scene manifest (bodies, colors, materials) |
+| `export_model` | List exported BREP / STEP / STL / OBJ file paths |
+| `compare_versions` | Diff current scene vs N runs ago (added / removed / appearance / file changed) |
+
+### Scene mutation
+
+| Tool | Purpose |
+|------|---------|
+| `remove_body` | Delete a body from the scene (manifest + BREP file) |
+| `clear_scene` | Wipe all bodies, optionally keep diff history |
+| `rename_body` | Change a body's id |
+| `set_appearance` | Update color / opacity / roughness / metallic / display name |
+
+### Introspection
+
+| Tool | Purpose |
+|------|---------|
+| `validate_geometry` | Per-body topology validation (isValid, error counts) |
+| `compute_metrics` | Volume, area, centroid, bounding box, principal axes |
+| `query_topology` | Find faces / edges / vertices matching criteria, return stable IDs |
+| `measure_distance` | Min distance + contacts between two bodies |
+| `recognize_features` | Pockets and holes via AAG heuristics |
+| `inspect_assembly` | Walk an XCAF assembly tree (STEP / IGES / XBF) |
+
+### Construction
+
+| Tool | Purpose |
+|------|---------|
+| `apply_feature` | Drill / fillet / chamfer / extrude / revolve / thread / boolean (FeatureSpec) |
+| `transform_body` | Translate / rotate / uniform-scale (in place or new body) |
+| `boolean_op` | Union / subtract / intersect / split between two bodies |
+| `mirror_or_pattern` | Mirror / linear / circular pattern → N new bodies |
+
+### Engineering analysis
+
+| Tool | Purpose |
+|------|---------|
+| `check_thickness` | Wall-thickness analysis with thin-region flags |
+| `analyze_clearance` | Pairwise interference / minimum clearance |
+| `heal_shape` | Heal imported / non-watertight geometry; before/after stats |
+
+### I/O
+
+| Tool | Purpose |
+|------|---------|
+| `read_brep` | Load a `.brep` from disk into the scene |
+| `import_file` | Multi-format import (STEP / IGES / STL / OBJ); optional XCAF assembly |
+| `export_scene` | Export to STEP / IGES / BREP / STL / OBJ / glTF / GLB |
+| `set_assembly_metadata` | Modify XCAF document or per-component metadata |
+
+### Mesh & visualisation
+
+| Tool | Purpose |
+|------|---------|
+| `generate_mesh` | Tessellate to triangles + quality metrics |
+| `render_preview` | One-shot PNG render |
+| `generate_drawing` | Multi-view ISO 128-30 DXF technical drawing |
+
+### Topology graph (low-level)
+
+| Tool | Purpose |
+|------|---------|
+| `graph_validate` | Validate a BREP's topology graph (raw path) |
+| `graph_compact` | Drop unreferenced graph nodes; write rebuilt BREP |
+| `graph_dedup` | Deduplicate shared surface / curve geometry |
+| `graph_ml` | Export topology + UV/edge samples as ML-friendly JSON |
+| `feature_recognize` | Pockets + holes (raw BREP path; `recognize_features` is the scene-aware wrapper) |
 
 ## Prerequisites
 

--- a/package.json
+++ b/package.json
@@ -11,7 +11,9 @@
     "prebuild": "node scripts/generate-api-reference.mjs",
     "build": "tsc",
     "start": "node dist/index.js",
-    "dev": "tsc --watch"
+    "dev": "tsc --watch",
+    "test": "node --test tests/unit/*.test.mjs",
+    "test:integration": "node --test --test-timeout=300000 tests/integration/*.test.mjs"
   },
   "keywords": [
     "mcp",

--- a/src/api-reference.ts
+++ b/src/api-reference.ts
@@ -160,6 +160,7 @@ Wire.polygon3D(_ points: [SIMD3<Double>], closed: Bool = true) -> Wire?
 ## 3D Paths (for Pipe Sweep)
 Wire.line(from start: SIMD3<Double>, to end: SIMD3<Double>) -> Wire?
 Wire.arc(center: SIMD3<Double>, radius: Double, startAngle: Double, endAngle: Double, normal: SIMD3<Double> = SIMD3(0, 0, 1)) -> Wire?
+Wire.arc(start: SIMD3<Double>, midpoint: SIMD3<Double>, end: SIMD3<Double>) -> Wire?
 Wire.path(_ points: [SIMD3<Double>], closed: Bool = false) -> Wire?
 Wire.bspline(_ controlPoints: [SIMD3<Double>]) -> Wire?
 
@@ -298,7 +299,7 @@ Curve2D.join(_ curves: [Curve2D], tolerance: Double = 1e-6) -> Curve2D?
 Curve2D.evaluateGrid(_ parameters: [Double]) -> [SIMD2<Double>]
 Curve2D.evaluateGridD1(_ parameters: [Double]) -> [(point: SIMD2<Double>, tangent: SIMD2<Double>)]
 
-## v0.51.0: GCE2d_MakeLine variants
+## v0.51.0: GC_MakeLine2d variants
 Curve2D.lineThroughPoints(_ p1: SIMD2<Double>, _ p2: SIMD2<Double>) -> Curve2D?
 Curve2D.lineParallel(point: SIMD2<Double>, direction: SIMD2<Double>, distance: Double) -> Curve2D?
 
@@ -467,23 +468,23 @@ Curve2D.fromEllipseArc(centerX: Double, centerY: Double, majorRadius: Double, mi
 Curve2D.fromHyperbolaArc(centerX: Double, centerY: Double, majorRadius: Double, minorRadius: Double, u1: Double, u2: Double) -> Curve2D?
 Curve2D.fromParabolaArc(centerX: Double, centerY: Double, focal: Double, u1: Double, u2: Double) -> Curve2D?
 
-## GCE2d_MakeCircle
+## GC_MakeCircle2d
 Curve2D.gceCircle(center: SIMD2<Double>, radius: Double) -> Curve2D?
 Curve2D.gceCircle(p1: SIMD2<Double>, p2: SIMD2<Double>, p3: SIMD2<Double>) -> Curve2D?
 Curve2D.gceCircle(center: SIMD2<Double>, pointOn: SIMD2<Double>) -> Curve2D?
 Curve2D.gceCircleParallel(center: SIMD2<Double>, direction: SIMD2<Double>, radius: Double, distance: Double) -> Curve2D?
 Curve2D.gceCircle(axisCenter: SIMD2<Double>, axisDirection: SIMD2<Double>, radius: Double) -> Curve2D?
 
-## GCE2d_MakeEllipse
+## GC_MakeEllipse2d
 Curve2D.gceEllipse(center: SIMD2<Double>, xDirection: SIMD2<Double>, majorRadius: Double, minorRadius: Double) -> Curve2D?
 Curve2D.gceEllipse(s1: SIMD2<Double>, s2: SIMD2<Double>, center: SIMD2<Double>) -> Curve2D?
 Curve2D.gceEllipse(center: SIMD2<Double>, xDirection: SIMD2<Double>, yDirection: SIMD2<Double>, majorRadius: Double, minorRadius: Double) -> Curve2D?
 
-## GCE2d_MakeHyperbola
+## GC_MakeHyperbola2d
 Curve2D.gceHyperbola(center: SIMD2<Double>, xDirection: SIMD2<Double>, majorRadius: Double, minorRadius: Double) -> Curve2D?
 Curve2D.gceHyperbola(s1: SIMD2<Double>, s2: SIMD2<Double>, center: SIMD2<Double>) -> Curve2D?
 
-## GCE2d_MakeParabola
+## GC_MakeParabola2d
 Curve2D.gceParabola(center: SIMD2<Double>, direction: SIMD2<Double>, focalDistance: Double) -> Curve2D?
 Curve2D.gceParabola(directrixPoint: SIMD2<Double>, directrixDirection: SIMD2<Double>, focus: SIMD2<Double>) -> Curve2D?
 

--- a/src/api-tools.ts
+++ b/src/api-tools.ts
@@ -1,0 +1,265 @@
+import { execFile } from "child_process";
+import { readFile, writeFile, unlink, stat } from "fs/promises";
+import { existsSync } from "fs";
+import { join, basename, extname } from "path";
+import { tmpdir } from "os";
+import { promisify } from "util";
+import { randomUUID } from "crypto";
+import { outputDir, manifestPath } from "./paths.js";
+import { resolveOcctkit } from "./occtkit.js";
+import { snapshotScene } from "./scene-tools.js";
+
+const execFileAsync = promisify(execFile);
+
+type ToolResult = { content: Array<{ type: "text"; text: string }> };
+
+type Body = {
+  id?: string;
+  file: string;
+  format?: string;
+  name?: string;
+  color?: number[];
+  roughness?: number;
+  metallic?: number;
+};
+
+type Manifest = {
+  version: number;
+  timestamp: string;
+  description?: string;
+  bodies: Body[];
+  graphs?: unknown[];
+  metadata?: unknown;
+};
+
+function text(t: string): ToolResult {
+  return { content: [{ type: "text" as const, text: t }] };
+}
+
+async function readManifest(): Promise<Manifest | null> {
+  if (!existsSync(manifestPath())) return null;
+  return JSON.parse(await readFile(manifestPath(), "utf-8")) as Manifest;
+}
+
+async function writeManifest(m: Manifest): Promise<void> {
+  m.timestamp = new Date().toISOString();
+  await writeFile(manifestPath(), JSON.stringify(m, null, 2), "utf-8");
+}
+
+function findBody(m: Manifest, bodyId: string): Body | null {
+  return m.bodies.find((b) => b.id === bodyId) ?? null;
+}
+
+async function runVerb(
+  verb: string,
+  verbArgs: string[],
+  timeoutMs = 60_000
+): Promise<{ ok: true; stdout: string } | { ok: false; error: string; stderr: string }> {
+  const oc = await resolveOcctkit();
+  try {
+    const { stdout } = await execFileAsync(
+      oc.command,
+      [...oc.baseArgs, verb, ...verbArgs],
+      { cwd: oc.cwd, timeout: timeoutMs, maxBuffer: 50 * 1024 * 1024 }
+    );
+    return { ok: true, stdout: stdout.trim() };
+  } catch (err: unknown) {
+    const e = err as { stderr?: string; message?: string };
+    return { ok: false, error: e.message ?? "unknown error", stderr: (e.stderr ?? "").trim() };
+  }
+}
+
+// ── validate_geometry ──────────────────────────────────────────────────────
+
+export async function validateGeometry(bodyId?: string): Promise<ToolResult> {
+  const m = await readManifest();
+  if (!m) return text("No scene loaded. Run execute_script first.");
+
+  const targets = bodyId
+    ? m.bodies.filter((b) => b.id === bodyId)
+    : m.bodies.filter((b) => b.format === undefined || b.format === "brep");
+
+  if (bodyId && targets.length === 0) return text(`Body not found: ${bodyId}`);
+  if (targets.length === 0) return text("No BREP bodies in scene.");
+
+  const dir = outputDir();
+  const reports: Array<Record<string, unknown>> = [];
+  for (const b of targets) {
+    const path = join(dir, b.file);
+    if (!existsSync(path)) {
+      reports.push({ id: b.id, file: b.file, error: "BREP file missing" });
+      continue;
+    }
+    const r = await runVerb("graph-validate", [path]);
+    if (!r.ok) {
+      reports.push({ id: b.id, file: b.file, error: r.error, stderr: r.stderr });
+      continue;
+    }
+    try {
+      const parsed = JSON.parse(r.stdout) as Record<string, unknown>;
+      reports.push({ id: b.id, file: b.file, ...parsed });
+    } catch {
+      reports.push({ id: b.id, file: b.file, raw: r.stdout });
+    }
+  }
+
+  return text(JSON.stringify({ bodies: reports }, null, 2));
+}
+
+// ── recognize_features ─────────────────────────────────────────────────────
+
+type FeatureKind = "pocket" | "hole";
+
+export async function recognizeFeatures(
+  bodyId: string,
+  kinds?: FeatureKind[]
+): Promise<ToolResult> {
+  const m = await readManifest();
+  if (!m) return text("No scene loaded. Run execute_script first.");
+
+  const body = findBody(m, bodyId);
+  if (!body) return text(`Body not found: ${bodyId}`);
+
+  const path = join(outputDir(), body.file);
+  if (!existsSync(path)) return text(`BREP file missing: ${path}`);
+
+  const r = await runVerb("feature-recognize", [path]);
+  if (!r.ok) return text(`feature-recognize failed.\n\n${r.error}\n${r.stderr}`);
+
+  let parsed: { pockets?: unknown[]; holes?: unknown[] };
+  try {
+    parsed = JSON.parse(r.stdout);
+  } catch {
+    return text(`Could not parse feature-recognize output:\n\n${r.stdout}`);
+  }
+
+  const wantPockets = !kinds || kinds.includes("pocket");
+  const wantHoles = !kinds || kinds.includes("hole");
+
+  const out: Record<string, unknown> = { bodyId };
+  if (wantPockets) out.pockets = parsed.pockets ?? [];
+  if (wantHoles) out.holes = parsed.holes ?? [];
+
+  return text(JSON.stringify(out, null, 2));
+}
+
+// ── apply_feature ──────────────────────────────────────────────────────────
+
+export async function applyFeature(
+  bodyId: string,
+  feature: Record<string, unknown>,
+  outputBodyId?: string
+): Promise<ToolResult> {
+  const m = await readManifest();
+  if (!m) return text("No scene loaded. Run execute_script first.");
+
+  const body = findBody(m, bodyId);
+  if (!body) return text(`Body not found: ${bodyId}`);
+
+  const dir = outputDir();
+  const inputPath = join(dir, body.file);
+  if (!existsSync(inputPath)) return text(`BREP file missing: ${inputPath}`);
+
+  await snapshotScene();
+
+  const inPlace = !outputBodyId || outputBodyId === bodyId;
+  const targetStem = inPlace
+    ? basename(body.file, extname(body.file))
+    : `applied-${outputBodyId}-${randomUUID().slice(0, 8)}`;
+  const targetFile = `${targetStem}.brep`;
+  const targetPath = join(dir, targetFile);
+
+  const request = {
+    outputDir: dir,
+    outputName: targetStem,
+    inputBrep: inputPath,
+    features: [feature],
+  };
+
+  const requestPath = join(tmpdir(), `occtmcp-reconstruct-${randomUUID()}.json`);
+  await writeFile(requestPath, JSON.stringify(request), "utf-8");
+
+  try {
+    const r = await runVerb("reconstruct", [requestPath], 120_000);
+    if (!r.ok) return text(`reconstruct failed.\n\n${r.error}\n${r.stderr}`);
+
+    let report: { shape?: string; fulfilled?: string[]; skipped?: unknown[]; annotations?: unknown[] };
+    try {
+      report = JSON.parse(r.stdout);
+    } catch {
+      return text(`Could not parse reconstruct output:\n\n${r.stdout}`);
+    }
+
+    if (!report.shape) {
+      return text(
+        `Reconstruct returned null shape. Skipped:\n${JSON.stringify(report.skipped, null, 2)}`
+      );
+    }
+
+    if (!existsSync(targetPath)) {
+      return text(
+        `Reconstruct reported success but output file is missing: ${targetPath}`
+      );
+    }
+
+    if (inPlace) {
+      // file already overwritten in place; manifest is unchanged
+    } else {
+      m.bodies.push({
+        id: outputBodyId,
+        file: targetFile,
+        format: "brep",
+        color: body.color,
+        name: body.name,
+      });
+    }
+    await writeManifest(m);
+
+    return text(
+      `Applied feature ${JSON.stringify(feature)} to "${bodyId}".\n\n` +
+        `Output: ${inPlace ? `(in place) ${body.file}` : `new body "${outputBodyId}" → ${targetFile}`}\n\n` +
+        JSON.stringify(report, null, 2)
+    );
+  } finally {
+    await unlink(requestPath).catch(() => {});
+  }
+}
+
+// ── generate_drawing ───────────────────────────────────────────────────────
+
+export async function generateDrawing(
+  bodyId: string,
+  outputPath: string,
+  spec: Record<string, unknown>
+): Promise<ToolResult> {
+  const m = await readManifest();
+  if (!m) return text("No scene loaded. Run execute_script first.");
+
+  const body = findBody(m, bodyId);
+  if (!body) return text(`Body not found: ${bodyId}`);
+
+  const inputPath = join(outputDir(), body.file);
+  if (!existsSync(inputPath)) return text(`BREP file missing: ${inputPath}`);
+
+  const fullSpec = { ...spec, shape: inputPath, output: outputPath };
+  const specPath = join(tmpdir(), `occtmcp-drawing-${randomUUID()}.json`);
+  await writeFile(specPath, JSON.stringify(fullSpec), "utf-8");
+
+  try {
+    const r = await runVerb("drawing-export", [specPath], 120_000);
+    if (!r.ok) return text(`drawing-export failed.\n\n${r.error}\n${r.stderr}`);
+
+    let size = 0;
+    try {
+      size = (await stat(outputPath)).size;
+    } catch {
+      // ignore
+    }
+
+    return text(
+      `Drawing exported → ${outputPath} (${size} bytes).\n\n${r.stdout}`
+    );
+  } finally {
+    await unlink(specPath).catch(() => {});
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,37 @@ import {
   graphMl,
   featureRecognize,
 } from "./graph-tools.js";
+import {
+  removeBody,
+  clearScene,
+  renameBody,
+  setAppearance,
+  compareVersions,
+  exportScene,
+} from "./scene-tools.js";
+import {
+  validateGeometry,
+  recognizeFeatures,
+  applyFeature,
+  generateDrawing,
+} from "./api-tools.js";
+import {
+  computeMetrics,
+  queryTopology,
+  measureDistance,
+  checkThickness,
+  analyzeClearance,
+  generateMesh,
+  transformBody,
+  booleanOp,
+  mirrorOrPattern,
+  healShape,
+  readBrep,
+  importFile,
+  renderPreview,
+  inspectAssembly,
+  setAssemblyMetadata,
+} from "./verb-tools.js";
 
 const server = new McpServer({
   name: "occtmcp",
@@ -200,6 +231,500 @@ server.tool(
   async ({ brep_path }) => {
     return featureRecognize(brep_path);
   }
+);
+
+// ── remove_body ─────────────────────────────────────────────────────────────
+server.tool(
+  "remove_body",
+  "Delete a body from the current scene by id. Removes the body's BREP file " +
+    "from the output directory and re-emits the manifest (triggers viewport reload).",
+  {
+    bodyId: z.string().describe("The id of the body to remove."),
+  },
+  async ({ bodyId }) => removeBody(bodyId)
+);
+
+// ── clear_scene ─────────────────────────────────────────────────────────────
+server.tool(
+  "clear_scene",
+  "Remove every body from the current scene. Optionally preserves the " +
+    "compare_versions history ring buffer.",
+  {
+    keepHistory: z
+      .boolean()
+      .optional()
+      .describe("If true, keep the compare_versions history ring. Default false."),
+  },
+  async ({ keepHistory }) => clearScene(keepHistory ?? false)
+);
+
+// ── rename_body ─────────────────────────────────────────────────────────────
+server.tool(
+  "rename_body",
+  "Change a body's id in the scene manifest. Fails if the new id is already in use.",
+  {
+    bodyId: z.string().describe("Current body id."),
+    newBodyId: z.string().describe("New body id."),
+  },
+  async ({ bodyId, newBodyId }) => renameBody(bodyId, newBodyId)
+);
+
+// ── set_appearance ──────────────────────────────────────────────────────────
+server.tool(
+  "set_appearance",
+  "Update color / opacity / roughness / metallic / display name for a scene " +
+    "body without re-running a script. The viewport reloads automatically.",
+  {
+    bodyId: z.string().describe("Body to update."),
+    color: z
+      .array(z.number())
+      .optional()
+      .describe("RGBA or RGB array (0–1 per channel)."),
+    opacity: z
+      .number()
+      .min(0)
+      .max(1)
+      .optional()
+      .describe("Sets color alpha (0–1). Leaves RGB unchanged."),
+    roughness: z.number().min(0).max(1).optional(),
+    metallic: z.number().min(0).max(1).optional(),
+    name: z.string().optional().describe("Human-readable display name."),
+  },
+  async ({ bodyId, color, opacity, roughness, metallic, name }) =>
+    setAppearance(bodyId, color, opacity, roughness, metallic, name)
+);
+
+// ── compare_versions ────────────────────────────────────────────────────────
+server.tool(
+  "compare_versions",
+  "Diff the current scene against a snapshot from N runs ago. Detects added / " +
+    "removed / appearance-changed / file-changed bodies. Snapshots are taken " +
+    "automatically before each execute_script and scene-mutation call.",
+  {
+    since: z
+      .number()
+      .int()
+      .min(1)
+      .optional()
+      .describe("How many runs back to compare against. Default 1."),
+  },
+  async ({ since }) => compareVersions(since ?? 1)
+);
+
+// ── export_scene ────────────────────────────────────────────────────────────
+server.tool(
+  "export_scene",
+  "Export current scene bodies (or a subset) to a single file in step / iges / " +
+    "brep / stl / obj / gltf / glb format.",
+  {
+    format: z.enum(["step", "iges", "brep", "stl", "obj", "gltf", "glb"]),
+    outputPath: z.string().describe("Absolute path for the exported file."),
+    bodyIds: z
+      .array(z.string())
+      .optional()
+      .describe("Body ids to include. Defaults to all bodies in the scene."),
+  },
+  async ({ format, outputPath, bodyIds }) =>
+    exportScene(format, outputPath, bodyIds)
+);
+
+// ── validate_geometry ──────────────────────────────────────────────────────
+server.tool(
+  "validate_geometry",
+  "Run topology validation on a scene body (or every body if no id given). " +
+    "Wraps occtkit graph-validate per body and returns a per-body report.",
+  {
+    bodyId: z
+      .string()
+      .optional()
+      .describe("Specific body to validate. If omitted, validates every BREP body."),
+  },
+  async ({ bodyId }) => validateGeometry(bodyId)
+);
+
+// ── recognize_features ─────────────────────────────────────────────────────
+server.tool(
+  "recognize_features",
+  "Detect pockets and holes in a scene body via AAG heuristics. Wraps occtkit " +
+    "feature-recognize and resolves the BREP path from the scene manifest.",
+  {
+    bodyId: z.string().describe("Body to analyse."),
+    kinds: z
+      .array(z.enum(["pocket", "hole"]))
+      .optional()
+      .describe("Restrict to certain kinds. Default: both."),
+  },
+  async ({ bodyId, kinds }) => recognizeFeatures(bodyId, kinds)
+);
+
+// ── apply_feature ──────────────────────────────────────────────────────────
+server.tool(
+  "apply_feature",
+  "Apply a single feature (drill / fillet / chamfer / extrude / revolve / " +
+    "boolean / thread) to an existing scene body via occtkit reconstruct. " +
+    "Without outputBodyId, replaces the body in place. With outputBodyId, " +
+    "adds a new body to the scene.",
+  {
+    bodyId: z.string().describe("Body to apply the feature to."),
+    feature: z
+      .object({})
+      .passthrough()
+      .describe(
+        "FeatureSpec object with a 'kind' discriminator (e.g. " +
+          "'hole', 'fillet', 'chamfer', 'extrude', 'revolve', 'thread', 'boolean'). " +
+          "See OCCTSwiftScripts/Sources/occtkit/Commands/Reconstruct.swift for the schema."
+      ),
+    outputBodyId: z
+      .string()
+      .optional()
+      .describe("If set, write a new body under this id instead of replacing in place."),
+  },
+  async ({ bodyId, feature, outputBodyId }) =>
+    applyFeature(bodyId, feature, outputBodyId)
+);
+
+// ── generate_drawing ───────────────────────────────────────────────────────
+server.tool(
+  "generate_drawing",
+  "Generate a multi-view ISO 128-30 technical drawing as DXF for a scene body. " +
+    "Pass a DrawingSpec (sheet, title, views, sections, dimensions, …). The " +
+    "tool injects the body's BREP path and the output DXF path into the spec, " +
+    "then runs occtkit drawing-export.",
+  {
+    bodyId: z.string().describe("Body to draw."),
+    outputPath: z.string().describe("Absolute path for the output DXF."),
+    spec: z
+      .object({})
+      .passthrough()
+      .describe(
+        "DrawingSpec object: { sheet, title?, views, sections?, dimensions?, ... }. " +
+          "See OCCTSwiftScripts/Sources/DrawingComposer/Spec.swift for the schema. " +
+          "The 'shape' and 'output' fields are filled in by this tool."
+      ),
+  },
+  async ({ bodyId, outputPath, spec }) =>
+    generateDrawing(bodyId, outputPath, spec as Record<string, unknown>)
+);
+
+// ── compute_metrics ────────────────────────────────────────────────────────
+server.tool(
+  "compute_metrics",
+  "Compute volume / surface area / center of mass / bounding box / principal " +
+    "axes for a scene body. Wraps occtkit metrics.",
+  {
+    bodyId: z.string().describe("Body to compute metrics for."),
+    metrics: z
+      .array(
+        z.enum(["volume", "surfaceArea", "centerOfMass", "boundingBox", "principalAxes"])
+      )
+      .optional()
+      .describe("Subset to compute. Default: all."),
+  },
+  async ({ bodyId, metrics }) => computeMetrics(bodyId, metrics)
+);
+
+// ── query_topology ─────────────────────────────────────────────────────────
+server.tool(
+  "query_topology",
+  "Find faces / edges / vertices on a body matching criteria. Returns stable " +
+    "IDs (face[N], edge[N], vertex[N]) usable in measure_distance and other " +
+    "tools. Wraps occtkit query-topology.",
+  {
+    bodyId: z.string(),
+    entity: z.enum(["face", "edge", "vertex"]),
+    filter: z
+      .object({})
+      .passthrough()
+      .optional()
+      .describe(
+        "AND-combined filter. face: surfaceType, minArea, maxArea, normalDirection, normalTolerance. edge: curveType, minLength, maxLength."
+      ),
+    limit: z.number().int().positive().optional(),
+  },
+  async ({ bodyId, entity, filter, limit }) =>
+    queryTopology(bodyId, entity, filter as Record<string, unknown> | undefined, limit)
+);
+
+// ── measure_distance ──────────────────────────────────────────────────────
+server.tool(
+  "measure_distance",
+  "Minimum distance and (optionally) contacts between two scene bodies. Wraps " +
+    "occtkit measure-distance.",
+  {
+    fromBodyId: z.string(),
+    toBodyId: z.string(),
+    fromRef: z
+      .string()
+      .optional()
+      .describe('Sub-entity ref or "point:x,y,z". Omit for whole shape.'),
+    toRef: z.string().optional(),
+    computeContacts: z.boolean().optional(),
+  },
+  async ({ fromBodyId, toBodyId, fromRef, toRef, computeContacts }) =>
+    measureDistance(fromBodyId, toBodyId, fromRef, toRef, computeContacts)
+);
+
+// ── check_thickness ───────────────────────────────────────────────────────
+server.tool(
+  "check_thickness",
+  "Wall-thickness analysis (sheet metal / casting / 3D printing). Reports " +
+    "min/max/mean thickness and flags thin-wall regions. Wraps occtkit check-thickness.",
+  {
+    bodyId: z.string(),
+    minAcceptable: z.number().positive().optional(),
+    samplingDensity: z.enum(["coarse", "medium", "fine"]).optional(),
+  },
+  async ({ bodyId, minAcceptable, samplingDensity }) =>
+    checkThickness(bodyId, minAcceptable, samplingDensity)
+);
+
+// ── analyze_clearance ─────────────────────────────────────────────────────
+server.tool(
+  "analyze_clearance",
+  "Pairwise interference / minimum-clearance check between 2+ bodies. Wraps " +
+    "occtkit analyze-clearance.",
+  {
+    bodyIds: z.array(z.string()).min(2),
+    minClearance: z.number().nonnegative().optional(),
+    computeContacts: z.boolean().optional(),
+    maxContacts: z.number().int().positive().optional(),
+  },
+  async ({ bodyIds, minClearance, computeContacts, maxContacts }) =>
+    analyzeClearance(bodyIds, minClearance, computeContacts, maxContacts)
+);
+
+// ── generate_mesh ─────────────────────────────────────────────────────────
+server.tool(
+  "generate_mesh",
+  "Tessellate a scene body into a triangle mesh. Returns triangle/vertex " +
+    "counts + quality metrics; optionally inline geometry or written to a " +
+    "mesh file (.stl / .obj). Wraps occtkit mesh.",
+  {
+    bodyId: z.string(),
+    linearDeflection: z.number().positive().optional(),
+    angularDeflection: z.number().positive().optional(),
+    parallel: z.boolean().optional(),
+    returnGeometry: z
+      .boolean()
+      .optional()
+      .describe("Inline triangle data in the response."),
+    outputPath: z
+      .string()
+      .optional()
+      .describe("If set, write mesh to this file (.stl / .obj)."),
+  },
+  async ({ bodyId, linearDeflection, angularDeflection, parallel, returnGeometry, outputPath }) =>
+    generateMesh(bodyId, linearDeflection, angularDeflection, parallel, returnGeometry, outputPath)
+);
+
+// ── transform_body ────────────────────────────────────────────────────────
+server.tool(
+  "transform_body",
+  "Apply translate / rotate / uniform-scale to a scene body. Without " +
+    "outputBodyId, replaces the body in place. With outputBodyId, adds a new " +
+    "body. Wraps occtkit transform.",
+  {
+    bodyId: z.string(),
+    translate: z.array(z.number()).length(3).optional(),
+    rotateAxisAngle: z
+      .array(z.number())
+      .length(4)
+      .optional()
+      .describe("[axisX, axisY, axisZ, radians]"),
+    rotateEulerXyz: z.array(z.number()).length(3).optional(),
+    scale: z.number().optional().describe("Uniform scale factor."),
+    inPlace: z.boolean().optional(),
+    outputBodyId: z.string().optional(),
+  },
+  async ({ bodyId, translate, rotateAxisAngle, rotateEulerXyz, scale, inPlace, outputBodyId }) =>
+    transformBody(bodyId, translate, rotateAxisAngle, rotateEulerXyz, scale, inPlace, outputBodyId)
+);
+
+// ── boolean_op ────────────────────────────────────────────────────────────
+server.tool(
+  "boolean_op",
+  "Boolean op (union / subtract / intersect / split) between two scene " +
+    "bodies. Output is added as a new body. Wraps occtkit boolean.",
+  {
+    op: z.enum(["union", "subtract", "intersect", "split"]),
+    aBodyId: z.string(),
+    bBodyId: z.string(),
+    outputBodyId: z
+      .string()
+      .optional()
+      .describe("Defaults to '<op>-<a>-<b>'."),
+    removeInputs: z.boolean().optional(),
+  },
+  async ({ op, aBodyId, bBodyId, outputBodyId, removeInputs }) =>
+    booleanOp(op, aBodyId, bBodyId, outputBodyId, removeInputs)
+);
+
+// ── mirror_or_pattern ─────────────────────────────────────────────────────
+server.tool(
+  "mirror_or_pattern",
+  "Mirror / linear / circular pattern of a body. Output is N new bodies in " +
+    "the scene. Wraps occtkit pattern.",
+  {
+    bodyId: z.string(),
+    kind: z.enum(["mirror", "linear", "circular"]),
+    params: z
+      .object({
+        plane: z.string().optional().describe("mirror: 'xy'|'yz'|'zx'"),
+        planeOrigin: z.array(z.number()).length(3).optional(),
+        planeNormal: z.array(z.number()).length(3).optional(),
+        direction: z.array(z.number()).length(3).optional().describe("linear"),
+        spacing: z.number().optional().describe("linear"),
+        count: z.number().int().positive().optional().describe("linear"),
+        axisOrigin: z.array(z.number()).length(3).optional().describe("circular"),
+        axisDirection: z.array(z.number()).length(3).optional().describe("circular"),
+        totalCount: z.number().int().positive().optional().describe("circular"),
+        totalAngle: z.number().optional().describe("circular (radians)"),
+      })
+      .passthrough(),
+    outputBodyIdPrefix: z.string().optional(),
+  },
+  async ({ bodyId, kind, params, outputBodyIdPrefix }) =>
+    mirrorOrPattern(bodyId, kind, params, outputBodyIdPrefix)
+);
+
+// ── heal_shape ────────────────────────────────────────────────────────────
+server.tool(
+  "heal_shape",
+  "Heal imported / non-watertight geometry. Returns before/after stats. " +
+    "Wraps occtkit heal.",
+  {
+    bodyId: z.string(),
+    options: z
+      .object({
+        tolerance: z.number().optional(),
+        maxTolerance: z.number().optional(),
+        minTolerance: z.number().optional(),
+        fixSmallEdges: z.boolean().optional(),
+        fixSmallFaces: z.boolean().optional(),
+        fixGaps: z.boolean().optional(),
+        fixSelfIntersection: z.boolean().optional(),
+        fixOrientation: z.boolean().optional(),
+        unifyDomain: z.boolean().optional(),
+      })
+      .optional(),
+    outputBodyId: z
+      .string()
+      .optional()
+      .describe("If set, write a new body. Otherwise heals in place."),
+  },
+  async ({ bodyId, options, outputBodyId }) => healShape(bodyId, options, outputBodyId)
+);
+
+// ── read_brep ─────────────────────────────────────────────────────────────
+server.tool(
+  "read_brep",
+  "Load a .brep from disk into the scene as a new body. Wraps occtkit load-brep.",
+  {
+    inputPath: z.string(),
+    bodyId: z.string().optional(),
+    color: z.string().optional().describe("'#rrggbb' or '#rrggbbaa'."),
+  },
+  async ({ inputPath, bodyId, color }) => readBrep(inputPath, bodyId, color)
+);
+
+// ── import_file ───────────────────────────────────────────────────────────
+server.tool(
+  "import_file",
+  "Multi-format CAD import (STEP / IGES / STL / OBJ) into the scene. Wraps " +
+    "occtkit import.",
+  {
+    inputPath: z.string(),
+    format: z.enum(["auto", "step", "iges", "stl", "obj"]).optional(),
+    idPrefix: z.string().optional(),
+    preserveAssembly: z
+      .boolean()
+      .optional()
+      .describe("STEP only: walk XCAF and emit one body per leaf node."),
+    healOnImport: z.boolean().optional(),
+  },
+  async ({ inputPath, format, idPrefix, preserveAssembly, healOnImport }) =>
+    importFile(inputPath, format, idPrefix, preserveAssembly, healOnImport)
+);
+
+// ── render_preview ────────────────────────────────────────────────────────
+server.tool(
+  "render_preview",
+  "Render a PNG preview of the current scene (or a subset of bodies). Wraps " +
+    "occtkit render-preview.",
+  {
+    outputPath: z.string().describe("Absolute path for the output PNG."),
+    bodyIds: z
+      .array(z.string())
+      .optional()
+      .describe("Restrict to these bodies. Default: all bodies."),
+    options: z
+      .object({
+        camera: z
+          .enum(["iso", "front", "back", "top", "bottom", "left", "right"])
+          .optional(),
+        cameraPosition: z.array(z.number()).length(3).optional(),
+        cameraTarget: z.array(z.number()).length(3).optional(),
+        cameraUp: z.array(z.number()).length(3).optional(),
+        width: z.number().int().positive().optional(),
+        height: z.number().int().positive().optional(),
+        displayMode: z
+          .enum(["shaded", "wireframe", "shaded-with-edges", "flat", "xray", "rendered"])
+          .optional(),
+        background: z.string().optional(),
+      })
+      .optional(),
+  },
+  async ({ outputPath, bodyIds, options }) =>
+    renderPreview(outputPath, bodyIds, options)
+);
+
+// ── inspect_assembly ──────────────────────────────────────────────────────
+server.tool(
+  "inspect_assembly",
+  "Walk an XCAF assembly hierarchy: components, instances, names, colors, " +
+    "materials, transforms. Pass either a scene bodyId (BREP — degenerate " +
+    "response since BREPs carry no XCAF metadata) or an inputPath (STEP / " +
+    "IGES / XBF for the full tree). Wraps occtkit inspect-assembly.",
+  {
+    bodyId: z.string().optional(),
+    inputPath: z
+      .string()
+      .optional()
+      .describe("STEP / IGES / XBF / BREP file path. Mutually exclusive with bodyId."),
+    depth: z.number().int().nonnegative().optional(),
+  },
+  async ({ bodyId, inputPath, depth }) => inspectAssembly(bodyId, inputPath, depth)
+);
+
+// ── set_assembly_metadata ────────────────────────────────────────────────
+server.tool(
+  "set_assembly_metadata",
+  "Modify XCAF document or per-component metadata (title / material / " +
+    "weight / revision / part number / custom attributes). Wraps occtkit " +
+    "set-metadata.",
+  {
+    inputPath: z.string().describe("STEP / IGES / XBF input."),
+    outputPath: z.string().describe("Output XBF (or compatible) path."),
+    scope: z.enum(["document", "component"]).optional(),
+    componentId: z
+      .number()
+      .int()
+      .optional()
+      .describe("XCAF label id (when scope=component)."),
+    metadata: z
+      .object({
+        title: z.string().optional(),
+        drawnBy: z.string().optional(),
+        material: z.string().optional(),
+        weight: z.number().optional(),
+        revision: z.string().optional(),
+        partNumber: z.string().optional(),
+        customAttrs: z.record(z.string(), z.string()).optional(),
+      })
+      .default({}),
+  },
+  async ({ inputPath, outputPath, scope, componentId, metadata }) =>
+    setAssemblyMetadata(inputPath, outputPath, scope, componentId, metadata)
 );
 
 // ── Start ───────────────────────────────────────────────────────────────────

--- a/src/paths.ts
+++ b/src/paths.ts
@@ -11,8 +11,11 @@ export function tempScriptPath(): string {
   return join(tmpdir(), `occtmcp-script-${randomUUID()}.swift`);
 }
 
-/** Output directory — prefers iCloud Drive, falls back to local. */
+/** Output directory — env override > iCloud Drive > local fallback. */
 export function outputDir(): string {
+  const override = process.env.OCCTMCP_OUTPUT_DIR;
+  if (override) return override;
+
   const icloud = join(
     homedir(),
     "Library/Mobile Documents/com~apple~CloudDocs/OCCTSwiftScripts/output"

--- a/src/scene-tools.ts
+++ b/src/scene-tools.ts
@@ -1,0 +1,393 @@
+import { readFile, writeFile, unlink, readdir } from "fs/promises";
+import { existsSync } from "fs";
+import { execFile } from "child_process";
+import { join } from "path";
+import { promisify } from "util";
+import { outputDir, manifestPath, tempScriptPath } from "./paths.js";
+import { resolveOcctkit } from "./occtkit.js";
+
+const execFileAsync = promisify(execFile);
+
+type ToolResult = { content: Array<{ type: "text"; text: string }> };
+
+type Body = {
+  id?: string;
+  file: string;
+  format?: string;
+  name?: string;
+  color?: number[];
+  roughness?: number;
+  metallic?: number;
+};
+
+type Manifest = {
+  version: number;
+  timestamp: string;
+  description?: string;
+  bodies: Body[];
+  graphs?: Array<{ id: string; file: string; sourceBodyId?: string; stats?: object }>;
+  metadata?: object;
+};
+
+// ── history ring buffer (in-memory) ─────────────────────────────────────────
+
+const MAX_SNAPSHOTS = 10;
+const history: Manifest[] = [];
+
+function pushSnapshot(m: Manifest): void {
+  history.push(structuredClone(m));
+  if (history.length > MAX_SNAPSHOTS) history.shift();
+}
+
+/**
+ * Snapshot the current manifest into the history ring. No-op if the manifest
+ * doesn't exist. Called pre-mutation by every scene-mutating tool, and by
+ * `executeScript` so each run leaves a checkpoint.
+ */
+export async function snapshotScene(): Promise<void> {
+  const mp = manifestPath();
+  if (!existsSync(mp)) return;
+  try {
+    const m = JSON.parse(await readFile(mp, "utf-8")) as Manifest;
+    pushSnapshot(m);
+  } catch {
+    // ignore — bad manifest at snapshot time is not the snapshotter's problem
+  }
+}
+
+export function clearHistory(): void {
+  history.length = 0;
+}
+
+// ── manifest helpers ────────────────────────────────────────────────────────
+
+async function readManifest(): Promise<Manifest> {
+  return JSON.parse(await readFile(manifestPath(), "utf-8")) as Manifest;
+}
+
+async function writeManifest(m: Manifest): Promise<void> {
+  m.timestamp = new Date().toISOString();
+  await writeFile(manifestPath(), JSON.stringify(m, null, 2), "utf-8");
+}
+
+function noScene(): ToolResult {
+  return {
+    content: [
+      {
+        type: "text" as const,
+        text: "No scene loaded. Run execute_script first.",
+      },
+    ],
+  };
+}
+
+function text(t: string): ToolResult {
+  return { content: [{ type: "text" as const, text: t }] };
+}
+
+function findBody(m: Manifest, id: string): { idx: number; body: Body } | null {
+  const idx = m.bodies.findIndex((b) => b.id === id);
+  if (idx < 0) return null;
+  return { idx, body: m.bodies[idx]! };
+}
+
+// ── remove_body ─────────────────────────────────────────────────────────────
+
+export async function removeBody(bodyId: string): Promise<ToolResult> {
+  if (!existsSync(manifestPath())) return noScene();
+  await snapshotScene();
+
+  const m = await readManifest();
+  const found = findBody(m, bodyId);
+  if (!found) return text(`Body not found: ${bodyId}`);
+
+  const filePath = join(outputDir(), found.body.file);
+  m.bodies.splice(found.idx, 1);
+  await writeManifest(m);
+  await unlink(filePath).catch(() => {});
+
+  return text(`Removed body "${bodyId}" (file: ${found.body.file}). Remaining: ${m.bodies.length}.`);
+}
+
+// ── clear_scene ─────────────────────────────────────────────────────────────
+
+export async function clearScene(keepHistory: boolean): Promise<ToolResult> {
+  if (!existsSync(manifestPath())) return noScene();
+  await snapshotScene();
+
+  const m = await readManifest();
+  const removedCount = m.bodies.length;
+  const filesToDelete = m.bodies.map((b) => join(outputDir(), b.file));
+
+  m.bodies = [];
+  m.description = "(cleared)";
+  await writeManifest(m);
+
+  await Promise.all(filesToDelete.map((p) => unlink(p).catch(() => {})));
+
+  if (!keepHistory) clearHistory();
+
+  return text(`Cleared ${removedCount} bodies from scene.${keepHistory ? "" : " History reset."}`);
+}
+
+// ── rename_body ─────────────────────────────────────────────────────────────
+
+export async function renameBody(
+  bodyId: string,
+  newBodyId: string
+): Promise<ToolResult> {
+  if (!existsSync(manifestPath())) return noScene();
+  await snapshotScene();
+
+  const m = await readManifest();
+  const found = findBody(m, bodyId);
+  if (!found) return text(`Body not found: ${bodyId}`);
+
+  if (m.bodies.some((b) => b.id === newBodyId)) {
+    return text(`Cannot rename: a body with id "${newBodyId}" already exists.`);
+  }
+
+  found.body.id = newBodyId;
+  await writeManifest(m);
+
+  return text(`Renamed "${bodyId}" → "${newBodyId}".`);
+}
+
+// ── set_appearance ──────────────────────────────────────────────────────────
+
+export async function setAppearance(
+  bodyId: string,
+  color?: number[],
+  opacity?: number,
+  roughness?: number,
+  metallic?: number,
+  name?: string
+): Promise<ToolResult> {
+  if (!existsSync(manifestPath())) return noScene();
+  await snapshotScene();
+
+  const m = await readManifest();
+  const found = findBody(m, bodyId);
+  if (!found) return text(`Body not found: ${bodyId}`);
+
+  const applied: Record<string, unknown> = {};
+  if (color !== undefined) {
+    if (color.length !== 3 && color.length !== 4) {
+      return text(`color must be [r,g,b] or [r,g,b,a]; got length ${color.length}.`);
+    }
+    const rgba = color.length === 3 ? [...color, found.body.color?.[3] ?? 1] : color;
+    found.body.color = rgba;
+    applied.color = rgba;
+  }
+  if (opacity !== undefined) {
+    const c = found.body.color ?? [0.7, 0.7, 0.7, 1];
+    c[3] = opacity;
+    found.body.color = c;
+    applied.opacity = opacity;
+  }
+  if (roughness !== undefined) {
+    found.body.roughness = roughness;
+    applied.roughness = roughness;
+  }
+  if (metallic !== undefined) {
+    found.body.metallic = metallic;
+    applied.metallic = metallic;
+  }
+  if (name !== undefined) {
+    found.body.name = name;
+    applied.name = name;
+  }
+
+  if (Object.keys(applied).length === 0) {
+    return text(`No appearance fields provided. Pass at least one of: color, opacity, roughness, metallic, name.`);
+  }
+
+  await writeManifest(m);
+  return text(
+    `Updated appearance of "${bodyId}":\n${JSON.stringify(applied, null, 2)}`
+  );
+}
+
+// ── compare_versions ────────────────────────────────────────────────────────
+
+type Diff = {
+  since: number;
+  available: number;
+  added: string[];
+  removed: string[];
+  appearanceChanged: Array<{ id: string; fields: string[] }>;
+  fileChanged: string[];
+  unchanged: string[];
+};
+
+function bodyKey(b: Body): string {
+  return b.id ?? `__noid_${b.file}`;
+}
+
+function appearanceFields(b: Body): Record<string, unknown> {
+  return {
+    color: b.color,
+    name: b.name,
+    roughness: b.roughness,
+    metallic: b.metallic,
+  };
+}
+
+function diffManifests(prev: Manifest, curr: Manifest, since: number): Diff {
+  const prevById = new Map(prev.bodies.map((b) => [bodyKey(b), b]));
+  const currById = new Map(curr.bodies.map((b) => [bodyKey(b), b]));
+
+  const added: string[] = [];
+  const removed: string[] = [];
+  const appearanceChanged: Array<{ id: string; fields: string[] }> = [];
+  const fileChanged: string[] = [];
+  const unchanged: string[] = [];
+
+  for (const [k, b] of currById) {
+    if (!prevById.has(k)) {
+      added.push(k);
+      continue;
+    }
+    const pb = prevById.get(k)!;
+    const fields: string[] = [];
+    const pa = appearanceFields(pb);
+    const ca = appearanceFields(b);
+    for (const f of ["color", "name", "roughness", "metallic"]) {
+      if (JSON.stringify(pa[f]) !== JSON.stringify(ca[f])) fields.push(f);
+    }
+    if (pb.file !== b.file) {
+      fileChanged.push(k);
+    }
+    if (fields.length > 0) {
+      appearanceChanged.push({ id: k, fields });
+    }
+    if (fields.length === 0 && pb.file === b.file) {
+      unchanged.push(k);
+    }
+  }
+
+  for (const k of prevById.keys()) {
+    if (!currById.has(k)) removed.push(k);
+  }
+
+  return { since, available: 0, added, removed, appearanceChanged, fileChanged, unchanged };
+}
+
+export async function compareVersions(since: number): Promise<ToolResult> {
+  if (!existsSync(manifestPath())) return noScene();
+
+  const current = await readManifest();
+  const idx = history.length - since;
+  if (idx < 0) {
+    return text(
+      `Not enough history: requested ${since} runs back, only ${history.length} snapshots available. ` +
+        `Make at least ${since} state changes (execute_script or scene-mutation tools) before comparing.`
+    );
+  }
+  const prev = history[idx]!;
+  const diff = diffManifests(prev, current, since);
+  diff.available = history.length;
+  return text(JSON.stringify(diff, null, 2));
+}
+
+// ── export_scene ────────────────────────────────────────────────────────────
+
+const EXPORTERS: Record<string, (varName: string, urlVar: string) => string> = {
+  step: (s, u) => `try Exporter.writeSTEP(shape: ${s}, to: ${u})`,
+  iges: (s, u) => `try Exporter.writeIGES(shape: ${s}, to: ${u})`,
+  brep: (s, u) => `try Exporter.writeBREP(shape: ${s}, to: ${u})`,
+  stl: (s, u) => `try Exporter.writeSTL(shape: ${s}, to: ${u})`,
+  obj: (s, u) => `try Exporter.writeOBJ(shape: ${s}, to: ${u})`,
+  gltf: (s, u) => `try Exporter.writeGLTF(shape: ${s}, to: ${u}, binary: false)`,
+  glb: (s, u) => `try Exporter.writeGLTF(shape: ${s}, to: ${u}, binary: true)`,
+};
+
+function swiftStringLiteral(s: string): string {
+  return '"' + s.replace(/\\/g, "\\\\").replace(/"/g, '\\"') + '"';
+}
+
+export async function exportScene(
+  format: string,
+  outputPath: string,
+  bodyIds?: string[]
+): Promise<ToolResult> {
+  const fmt = format.toLowerCase();
+  const exporter = EXPORTERS[fmt];
+  if (!exporter) {
+    return text(
+      `Unknown format: ${format}. Supported: ${Object.keys(EXPORTERS).join(", ")}.`
+    );
+  }
+  if (!existsSync(manifestPath())) return noScene();
+
+  const m = await readManifest();
+  let bodies = m.bodies;
+  if (bodyIds && bodyIds.length > 0) {
+    const idSet = new Set(bodyIds);
+    bodies = bodies.filter((b) => b.id !== undefined && idSet.has(b.id));
+    const found = new Set(bodies.map((b) => b.id));
+    const missing = bodyIds.filter((id) => !found.has(id));
+    if (missing.length > 0) {
+      return text(`Body ids not found in scene: ${missing.join(", ")}`);
+    }
+  }
+  if (bodies.length === 0) {
+    return text("No bodies to export.");
+  }
+
+  const dir = outputDir();
+  const loadLines = bodies.map((b, i) => {
+    const path = swiftStringLiteral(join(dir, b.file));
+    return `let s${i} = try Shape.loadBREP(fromPath: ${path})`;
+  });
+  const arr = bodies.map((_, i) => `s${i}`).join(", ");
+  const compoundOrSingle =
+    bodies.length === 1 ? "let exportShape = s0" :
+      `guard let exportShape = Shape.compound([${arr}]) else {\n    fputs("Failed to build compound\\n", stderr); exit(1)\n}`;
+  const outUrl = swiftStringLiteral(outputPath);
+  const exportCall = exporter("exportShape", `URL(fileURLWithPath: ${outUrl})`);
+
+  const code = [
+    "import OCCTSwift",
+    "import Foundation",
+    "",
+    ...loadLines,
+    compoundOrSingle,
+    exportCall,
+    `print("Wrote ${outputPath}")`,
+    "",
+  ].join("\n");
+
+  const scriptPath = tempScriptPath();
+  await writeFile(scriptPath, code, "utf-8");
+
+  try {
+    const oc = await resolveOcctkit();
+    const { stdout, stderr } = await execFileAsync(
+      oc.command,
+      [...oc.baseArgs, "run", scriptPath],
+      { cwd: oc.cwd, timeout: 180_000, maxBuffer: 10 * 1024 * 1024 }
+    );
+    let fileSize = 0;
+    if (existsSync(outputPath)) {
+      const { statSync } = await import("fs");
+      fileSize = statSync(outputPath).size;
+    }
+    const tail = (stderr || "").trim();
+    return text(
+      `Exported ${bodies.length} bodies → ${outputPath} (${format}, ${fileSize} bytes).\n` +
+        (stdout?.trim() ? `\n${stdout.trim()}` : "") +
+        (tail ? `\n\nstderr:\n${tail}` : "")
+    );
+  } catch (err: unknown) {
+    const e = err as { stdout?: string; stderr?: string; message?: string };
+    const out = [e.stdout?.trim(), e.stderr?.trim()].filter(Boolean).join("\n");
+    return text(`Export failed.\n\n${out || e.message || "Unknown error"}`);
+  } finally {
+    await unlink(scriptPath).catch(() => {});
+  }
+}
+
+// ── helpers exposed for tests/diagnostics ──────────────────────────────────
+
+export const __test = { history };

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -11,6 +11,7 @@ import {
   serveDisabled,
   type ServeEnvelope,
 } from "./occtkit-serve.js";
+import { snapshotScene } from "./scene-tools.js";
 
 const execFileAsync = promisify(execFile);
 
@@ -57,6 +58,7 @@ export async function executeScript(
   code: string,
   description?: string
 ): Promise<ToolResult> {
+  await snapshotScene();
   const scriptPath = tempScriptPath();
   await writeFile(scriptPath, code, "utf-8");
   lastScriptCode = code;

--- a/src/verb-tools.ts
+++ b/src/verb-tools.ts
@@ -1,0 +1,682 @@
+import { execFile } from "child_process";
+import { readFile, writeFile, unlink, rename, stat } from "fs/promises";
+import { existsSync, mkdirSync } from "fs";
+import { join, basename, extname, dirname } from "path";
+import { tmpdir } from "os";
+import { promisify } from "util";
+import { randomUUID } from "crypto";
+import { outputDir, manifestPath } from "./paths.js";
+import { resolveOcctkit } from "./occtkit.js";
+import { snapshotScene } from "./scene-tools.js";
+
+const execFileAsync = promisify(execFile);
+
+type ToolResult = { content: Array<{ type: "text"; text: string }> };
+
+type Body = {
+  id?: string;
+  file: string;
+  format?: string;
+  name?: string;
+  color?: number[];
+  roughness?: number;
+  metallic?: number;
+};
+
+type Manifest = {
+  version: number;
+  timestamp: string;
+  description?: string;
+  bodies: Body[];
+  graphs?: unknown[];
+  metadata?: unknown;
+};
+
+function text(t: string): ToolResult {
+  return { content: [{ type: "text" as const, text: t }] };
+}
+
+async function readManifest(): Promise<Manifest | null> {
+  if (!existsSync(manifestPath())) return null;
+  return JSON.parse(await readFile(manifestPath(), "utf-8")) as Manifest;
+}
+
+async function writeManifest(m: Manifest): Promise<void> {
+  m.timestamp = new Date().toISOString();
+  await writeFile(manifestPath(), JSON.stringify(m, null, 2), "utf-8");
+}
+
+function findBody(m: Manifest, bodyId: string): Body | null {
+  return m.bodies.find((b) => b.id === bodyId) ?? null;
+}
+
+function bodyPath(b: Body): string {
+  return join(outputDir(), b.file);
+}
+
+async function runVerbJSON(
+  verb: string,
+  request: Record<string, unknown>,
+  timeoutMs = 120_000
+): Promise<{ ok: true; stdout: string } | { ok: false; error: string; stderr: string }> {
+  const oc = await resolveOcctkit();
+  const reqPath = join(tmpdir(), `occtmcp-${verb}-${randomUUID()}.json`);
+  await writeFile(reqPath, JSON.stringify(request), "utf-8");
+  try {
+    const { stdout } = await execFileAsync(
+      oc.command,
+      [...oc.baseArgs, verb, reqPath],
+      { cwd: oc.cwd, timeout: timeoutMs, maxBuffer: 50 * 1024 * 1024 }
+    );
+    return { ok: true, stdout: stdout.trim() };
+  } catch (err: unknown) {
+    const e = err as { stderr?: string; message?: string };
+    return { ok: false, error: e.message ?? "unknown error", stderr: (e.stderr ?? "").trim() };
+  } finally {
+    await unlink(reqPath).catch(() => {});
+  }
+}
+
+async function runVerbArgs(
+  verb: string,
+  args: string[],
+  timeoutMs = 120_000
+): Promise<{ ok: true; stdout: string } | { ok: false; error: string; stderr: string }> {
+  const oc = await resolveOcctkit();
+  try {
+    const { stdout } = await execFileAsync(
+      oc.command,
+      [...oc.baseArgs, verb, ...args],
+      { cwd: oc.cwd, timeout: timeoutMs, maxBuffer: 50 * 1024 * 1024 }
+    );
+    return { ok: true, stdout: stdout.trim() };
+  } catch (err: unknown) {
+    const e = err as { stderr?: string; message?: string };
+    return { ok: false, error: e.message ?? "unknown error", stderr: (e.stderr ?? "").trim() };
+  }
+}
+
+function passthroughResult(
+  verb: string,
+  r: Awaited<ReturnType<typeof runVerbJSON>>
+): ToolResult {
+  if (!r.ok) {
+    return text(`occtkit ${verb} failed.\n\n${r.error}\n${r.stderr}`);
+  }
+  return text(r.stdout);
+}
+
+function freshBrepPath(stem: string): string {
+  return join(outputDir(), `${stem}-${randomUUID().slice(0, 8)}.brep`);
+}
+
+// ── compute_metrics ────────────────────────────────────────────────────────
+
+export async function computeMetrics(
+  bodyId: string,
+  metrics?: string[]
+): Promise<ToolResult> {
+  const m = await readManifest();
+  if (!m) return text("No scene loaded. Run execute_script first.");
+  const body = findBody(m, bodyId);
+  if (!body) return text(`Body not found: ${bodyId}`);
+
+  const req: Record<string, unknown> = { inputBrep: bodyPath(body) };
+  if (metrics && metrics.length > 0) req.metrics = metrics;
+  return passthroughResult("metrics", await runVerbJSON("metrics", req));
+}
+
+// ── query_topology ─────────────────────────────────────────────────────────
+
+export async function queryTopology(
+  bodyId: string,
+  entity: "face" | "edge" | "vertex",
+  filter?: Record<string, unknown>,
+  limit?: number
+): Promise<ToolResult> {
+  const m = await readManifest();
+  if (!m) return text("No scene loaded. Run execute_script first.");
+  const body = findBody(m, bodyId);
+  if (!body) return text(`Body not found: ${bodyId}`);
+
+  const req: Record<string, unknown> = { inputBrep: bodyPath(body), entity };
+  if (filter) req.filter = filter;
+  if (limit !== undefined) req.limit = limit;
+  return passthroughResult("query-topology", await runVerbJSON("query-topology", req));
+}
+
+// ── measure_distance ───────────────────────────────────────────────────────
+
+export async function measureDistance(
+  fromBodyId: string,
+  toBodyId: string,
+  fromRef?: string,
+  toRef?: string,
+  computeContacts?: boolean
+): Promise<ToolResult> {
+  const m = await readManifest();
+  if (!m) return text("No scene loaded. Run execute_script first.");
+  const a = findBody(m, fromBodyId);
+  const b = findBody(m, toBodyId);
+  if (!a) return text(`Body not found: ${fromBodyId}`);
+  if (!b) return text(`Body not found: ${toBodyId}`);
+
+  const req: Record<string, unknown> = { a: bodyPath(a), b: bodyPath(b) };
+  if (fromRef !== undefined) req.fromRef = fromRef;
+  if (toRef !== undefined) req.toRef = toRef;
+  if (computeContacts !== undefined) req.computeContacts = computeContacts;
+  return passthroughResult("measure-distance", await runVerbJSON("measure-distance", req));
+}
+
+// ── check_thickness ────────────────────────────────────────────────────────
+
+export async function checkThickness(
+  bodyId: string,
+  minAcceptable?: number,
+  samplingDensity?: "coarse" | "medium" | "fine"
+): Promise<ToolResult> {
+  const m = await readManifest();
+  if (!m) return text("No scene loaded. Run execute_script first.");
+  const body = findBody(m, bodyId);
+  if (!body) return text(`Body not found: ${bodyId}`);
+
+  const req: Record<string, unknown> = { inputBrep: bodyPath(body) };
+  if (minAcceptable !== undefined) req.minAcceptable = minAcceptable;
+  if (samplingDensity !== undefined) req.samplingDensity = samplingDensity;
+  return passthroughResult("check-thickness", await runVerbJSON("check-thickness", req, 240_000));
+}
+
+// ── analyze_clearance ──────────────────────────────────────────────────────
+
+export async function analyzeClearance(
+  bodyIds: string[],
+  minClearance?: number,
+  computeContacts?: boolean,
+  maxContacts?: number
+): Promise<ToolResult> {
+  if (bodyIds.length < 2) return text(`analyze_clearance needs at least 2 body ids; got ${bodyIds.length}.`);
+  const m = await readManifest();
+  if (!m) return text("No scene loaded. Run execute_script first.");
+  const paths: string[] = [];
+  for (const id of bodyIds) {
+    const b = findBody(m, id);
+    if (!b) return text(`Body not found: ${id}`);
+    paths.push(bodyPath(b));
+  }
+
+  const req: Record<string, unknown> = { inputs: paths };
+  if (minClearance !== undefined) req.minClearance = minClearance;
+  if (computeContacts !== undefined) req.computeContacts = computeContacts;
+  if (maxContacts !== undefined) req.maxContacts = maxContacts;
+  return passthroughResult("analyze-clearance", await runVerbJSON("analyze-clearance", req));
+}
+
+// ── generate_mesh ──────────────────────────────────────────────────────────
+
+export async function generateMesh(
+  bodyId: string,
+  linearDeflection?: number,
+  angularDeflection?: number,
+  parallel?: boolean,
+  returnGeometry?: boolean,
+  outputPath?: string
+): Promise<ToolResult> {
+  const m = await readManifest();
+  if (!m) return text("No scene loaded. Run execute_script first.");
+  const body = findBody(m, bodyId);
+  if (!body) return text(`Body not found: ${bodyId}`);
+
+  const req: Record<string, unknown> = { inputBrep: bodyPath(body) };
+  if (linearDeflection !== undefined) req.linearDeflection = linearDeflection;
+  if (angularDeflection !== undefined) req.angularDeflection = angularDeflection;
+  if (parallel !== undefined) req.parallel = parallel;
+  if (returnGeometry !== undefined) req.returnGeometry = returnGeometry;
+  if (outputPath !== undefined) req.outputPath = outputPath;
+  return passthroughResult("mesh", await runVerbJSON("mesh", req, 240_000));
+}
+
+// ── transform_body ─────────────────────────────────────────────────────────
+
+export async function transformBody(
+  bodyId: string,
+  translate?: number[],
+  rotateAxisAngle?: number[],
+  rotateEulerXyz?: number[],
+  scale?: number,
+  inPlace?: boolean,
+  outputBodyId?: string
+): Promise<ToolResult> {
+  const m = await readManifest();
+  if (!m) return text("No scene loaded. Run execute_script first.");
+  const body = findBody(m, bodyId);
+  if (!body) return text(`Body not found: ${bodyId}`);
+
+  const inputPath = bodyPath(body);
+  const isInPlace = inPlace ?? !outputBodyId;
+  if (!isInPlace && outputBodyId && m.bodies.some((x) => x.id === outputBodyId)) {
+    return text(`Output body id "${outputBodyId}" already exists.`);
+  }
+  const outputPath = isInPlace ? inputPath : freshBrepPath(`xform-${outputBodyId ?? bodyId}`);
+
+  const req: Record<string, unknown> = { inputBrep: inputPath, outputPath };
+  if (translate !== undefined) req.translate = translate;
+  if (rotateAxisAngle !== undefined) req.rotateAxisAngle = rotateAxisAngle;
+  if (rotateEulerXyz !== undefined) req.rotateEulerXyz = rotateEulerXyz;
+  if (scale !== undefined) req.scale = scale;
+
+  await snapshotScene();
+  const r = await runVerbJSON("transform", req);
+  if (!r.ok) return text(`occtkit transform failed.\n\n${r.error}\n${r.stderr}`);
+
+  if (!isInPlace && outputBodyId) {
+    m.bodies.push({
+      id: outputBodyId,
+      file: basename(outputPath),
+      format: "brep",
+      color: body.color,
+      name: body.name,
+    });
+    await writeManifest(m);
+  } else {
+    await writeManifest(m);
+  }
+
+  return text(
+    `Transformed "${bodyId}" → ${isInPlace ? `(in place) ${body.file}` : `new body "${outputBodyId}" → ${basename(outputPath)}`}\n\n${r.stdout}`
+  );
+}
+
+// ── boolean_op ─────────────────────────────────────────────────────────────
+
+export async function booleanOp(
+  op: "union" | "subtract" | "intersect" | "split",
+  aBodyId: string,
+  bBodyId: string,
+  outputBodyId?: string,
+  removeInputs?: boolean
+): Promise<ToolResult> {
+  const m = await readManifest();
+  if (!m) return text("No scene loaded. Run execute_script first.");
+  const a = findBody(m, aBodyId);
+  const b = findBody(m, bBodyId);
+  if (!a) return text(`Body not found: ${aBodyId}`);
+  if (!b) return text(`Body not found: ${bBodyId}`);
+
+  const outId = outputBodyId ?? `${op}-${aBodyId}-${bBodyId}`;
+  if (m.bodies.some((x) => x.id === outId && x.id !== aBodyId && x.id !== bBodyId)) {
+    return text(`Output body id "${outId}" already exists. Pass a different outputBodyId.`);
+  }
+
+  const outputPath = freshBrepPath(outId);
+  const req = { op, a: bodyPath(a), b: bodyPath(b), outputPath };
+
+  await snapshotScene();
+  const r = await runVerbJSON("boolean", req);
+  if (!r.ok) return text(`occtkit boolean failed.\n\n${r.error}\n${r.stderr}`);
+
+  m.bodies.push({
+    id: outId,
+    file: basename(outputPath),
+    format: "brep",
+    color: a.color,
+    name: a.name ? `${op} ${a.name}` : undefined,
+  });
+
+  if (removeInputs) {
+    for (const id of [aBodyId, bBodyId]) {
+      const idx = m.bodies.findIndex((x) => x.id === id);
+      if (idx >= 0) {
+        const b2 = m.bodies[idx]!;
+        await unlink(bodyPath(b2)).catch(() => {});
+        m.bodies.splice(idx, 1);
+      }
+    }
+  }
+
+  await writeManifest(m);
+  return text(
+    `Boolean ${op}(${aBodyId}, ${bBodyId}) → "${outId}" (${basename(outputPath)})${removeInputs ? "; inputs removed" : ""}.\n\n${r.stdout}`
+  );
+}
+
+// ── mirror_or_pattern ──────────────────────────────────────────────────────
+
+type PatternParams = {
+  plane?: string;
+  planeOrigin?: number[];
+  planeNormal?: number[];
+  direction?: number[];
+  spacing?: number;
+  count?: number;
+  axisOrigin?: number[];
+  axisDirection?: number[];
+  totalCount?: number;
+  totalAngle?: number;
+};
+
+export async function mirrorOrPattern(
+  bodyId: string,
+  kind: "mirror" | "linear" | "circular",
+  params: PatternParams,
+  outputBodyIdPrefix?: string
+): Promise<ToolResult> {
+  const m = await readManifest();
+  if (!m) return text("No scene loaded. Run execute_script first.");
+  const body = findBody(m, bodyId);
+  if (!body) return text(`Body not found: ${bodyId}`);
+
+  const stagingDir = join(tmpdir(), `occtmcp-pattern-${randomUUID()}`);
+  mkdirSync(stagingDir, { recursive: true });
+
+  const req: Record<string, unknown> = {
+    inputBrep: bodyPath(body),
+    outputDir: stagingDir,
+    kind,
+    ...params,
+  };
+
+  await snapshotScene();
+  const r = await runVerbJSON("pattern", req);
+  if (!r.ok) return text(`occtkit pattern failed.\n\n${r.error}\n${r.stderr}`);
+
+  let parsed: { outputPaths?: string[]; totalCount?: number };
+  try {
+    parsed = JSON.parse(r.stdout);
+  } catch {
+    return text(`Could not parse pattern output:\n\n${r.stdout}`);
+  }
+  const outputs = parsed.outputPaths ?? [];
+
+  const prefix = outputBodyIdPrefix ?? `${kind}-${bodyId}`;
+  const sceneDir = outputDir();
+  const newIds: string[] = [];
+  for (let i = 0; i < outputs.length; i++) {
+    const stagedPath = outputs[i]!;
+    const finalName = `${prefix}-${i}-${randomUUID().slice(0, 4)}.brep`;
+    const finalPath = join(sceneDir, finalName);
+    await rename(stagedPath, finalPath).catch(async () => {
+      const data = await readFile(stagedPath);
+      await writeFile(finalPath, data);
+      await unlink(stagedPath).catch(() => {});
+    });
+    const newId = `${prefix}-${i}`;
+    newIds.push(newId);
+    m.bodies.push({
+      id: newId,
+      file: finalName,
+      format: "brep",
+      color: body.color,
+      name: body.name ? `${body.name} (${kind} ${i})` : undefined,
+    });
+  }
+  await writeManifest(m);
+  await unlink(stagingDir).catch(() => {});
+
+  return text(
+    `Pattern ${kind} on "${bodyId}" → ${newIds.length} bodies: ${newIds.join(", ")}\n\n${r.stdout}`
+  );
+}
+
+// ── heal_shape ─────────────────────────────────────────────────────────────
+
+export async function healShape(
+  bodyId: string,
+  options?: {
+    tolerance?: number;
+    maxTolerance?: number;
+    minTolerance?: number;
+    fixSmallEdges?: boolean;
+    fixSmallFaces?: boolean;
+    fixGaps?: boolean;
+    fixSelfIntersection?: boolean;
+    fixOrientation?: boolean;
+    unifyDomain?: boolean;
+  },
+  outputBodyId?: string
+): Promise<ToolResult> {
+  const m = await readManifest();
+  if (!m) return text("No scene loaded. Run execute_script first.");
+  const body = findBody(m, bodyId);
+  if (!body) return text(`Body not found: ${bodyId}`);
+
+  const inputPath = bodyPath(body);
+  const isInPlace = !outputBodyId || outputBodyId === bodyId;
+  if (!isInPlace && outputBodyId && m.bodies.some((x) => x.id === outputBodyId)) {
+    return text(`Output body id "${outputBodyId}" already exists.`);
+  }
+  const outputPath = isInPlace ? inputPath : freshBrepPath(`heal-${outputBodyId}`);
+
+  const req: Record<string, unknown> = { inputBrep: inputPath, outputPath, ...(options ?? {}) };
+
+  await snapshotScene();
+  const r = await runVerbJSON("heal", req, 240_000);
+  if (!r.ok) return text(`occtkit heal failed.\n\n${r.error}\n${r.stderr}`);
+
+  if (!isInPlace && outputBodyId) {
+    m.bodies.push({
+      id: outputBodyId,
+      file: basename(outputPath),
+      format: "brep",
+      color: body.color,
+      name: body.name,
+    });
+  }
+  await writeManifest(m);
+
+  return text(
+    `Healed "${bodyId}" → ${isInPlace ? `(in place) ${body.file}` : `new body "${outputBodyId}"`}\n\n${r.stdout}`
+  );
+}
+
+/**
+ * load-brep / import write a fresh manifest in their --emit-manifest dir,
+ * which would clobber the live scene. So we point the verb at a staging dir,
+ * read the staging manifest's bodies, copy each BREP into the live output
+ * dir, and append the entries to the live manifest. Snapshot is taken first
+ * so compare_versions can see the import.
+ */
+async function mergeStagedImport(
+  verb: "load-brep" | "import",
+  req: Record<string, unknown>,
+  timeoutMs: number
+): Promise<ToolResult> {
+  await snapshotScene();
+  const staging = join(tmpdir(), `occtmcp-${verb}-${randomUUID()}`);
+  mkdirSync(staging, { recursive: true });
+  req.emitManifest = staging;
+
+  const r = await runVerbJSON(verb, req, timeoutMs);
+  if (!r.ok) return text(`occtkit ${verb} failed.\n\n${r.error}\n${r.stderr}`);
+
+  const stagedManifestPath = join(staging, "manifest.json");
+  if (!existsSync(stagedManifestPath)) {
+    return text(`${verb} did not emit a manifest at ${stagedManifestPath}.\n\n${r.stdout}`);
+  }
+  const staged = JSON.parse(await readFile(stagedManifestPath, "utf-8")) as Manifest;
+
+  const live = (await readManifest()) ?? {
+    version: 1,
+    timestamp: new Date().toISOString(),
+    description: undefined,
+    bodies: [],
+  };
+
+  const sceneDir = outputDir();
+  const importedIds: string[] = [];
+  const conflicts: string[] = [];
+
+  for (const sb of staged.bodies) {
+    if (sb.id && live.bodies.some((x) => x.id === sb.id)) {
+      conflicts.push(sb.id);
+      continue;
+    }
+    const stagedBrep = join(staging, sb.file);
+    const liveBrep = join(sceneDir, sb.file);
+    if (existsSync(liveBrep)) {
+      // collision on filename — pick a fresh one
+      const stem = basename(sb.file, extname(sb.file));
+      const fresh = `${stem}-${randomUUID().slice(0, 8)}${extname(sb.file)}`;
+      sb.file = fresh;
+    }
+    await rename(stagedBrep, join(sceneDir, sb.file)).catch(async () => {
+      const data = await readFile(stagedBrep);
+      await writeFile(join(sceneDir, sb.file), data);
+      await unlink(stagedBrep).catch(() => {});
+    });
+    live.bodies.push(sb);
+    if (sb.id) importedIds.push(sb.id);
+  }
+
+  await writeManifest(live);
+  await unlink(stagedManifestPath).catch(() => {});
+
+  const summary = [
+    `Imported ${importedIds.length} bodies via ${verb}: ${importedIds.join(", ")}.`,
+  ];
+  if (conflicts.length > 0) {
+    summary.push(`Skipped (id conflict): ${conflicts.join(", ")}.`);
+  }
+  return text(`${summary.join(" ")}\n\n${r.stdout}`);
+}
+
+// ── read_brep ──────────────────────────────────────────────────────────────
+
+export async function readBrep(
+  inputPath: string,
+  bodyId?: string,
+  color?: string
+): Promise<ToolResult> {
+  if (!existsSync(inputPath)) return text(`BREP file not found: ${inputPath}`);
+  const req: Record<string, unknown> = { inputBrep: inputPath };
+  if (bodyId !== undefined) req.id = bodyId;
+  if (color !== undefined) req.color = color;
+  return mergeStagedImport("load-brep", req, 60_000);
+}
+
+// ── import_file ────────────────────────────────────────────────────────────
+
+export async function importFile(
+  inputPath: string,
+  format?: "auto" | "step" | "iges" | "stl" | "obj",
+  idPrefix?: string,
+  preserveAssembly?: boolean,
+  healOnImport?: boolean
+): Promise<ToolResult> {
+  if (!existsSync(inputPath)) return text(`File not found: ${inputPath}`);
+  const req: Record<string, unknown> = { inputPath };
+  if (format !== undefined) req.format = format;
+  if (idPrefix !== undefined) req.idPrefix = idPrefix;
+  if (preserveAssembly !== undefined) req.preserveAssembly = preserveAssembly;
+  if (healOnImport !== undefined) req.healOnImport = healOnImport;
+  return mergeStagedImport("import", req, 240_000);
+}
+
+// ── inspect_assembly ──────────────────────────────────────────────────────
+
+export async function inspectAssembly(
+  bodyId?: string,
+  inputPath?: string,
+  depth?: number
+): Promise<ToolResult> {
+  let path: string;
+  if (inputPath) {
+    if (!existsSync(inputPath)) return text(`File not found: ${inputPath}`);
+    path = inputPath;
+  } else if (bodyId) {
+    const m = await readManifest();
+    if (!m) return text("No scene loaded. Run execute_script first.");
+    const body = findBody(m, bodyId);
+    if (!body) return text(`Body not found: ${bodyId}`);
+    path = bodyPath(body);
+  } else {
+    return text("inspect_assembly requires either bodyId or inputPath.");
+  }
+
+  const req: Record<string, unknown> = { inputPath: path };
+  if (depth !== undefined) req.depth = depth;
+  return passthroughResult("inspect-assembly", await runVerbJSON("inspect-assembly", req));
+}
+
+// ── set_assembly_metadata ─────────────────────────────────────────────────
+
+type AssemblyMetadata = {
+  title?: string;
+  drawnBy?: string;
+  material?: string;
+  weight?: number;
+  revision?: string;
+  partNumber?: string;
+  customAttrs?: Record<string, string>;
+};
+
+export async function setAssemblyMetadata(
+  inputPath: string,
+  outputPath: string,
+  scope: "document" | "component" | undefined,
+  componentId: number | undefined,
+  metadata: AssemblyMetadata
+): Promise<ToolResult> {
+  if (!existsSync(inputPath)) return text(`File not found: ${inputPath}`);
+
+  const req: Record<string, unknown> = { inputPath, outputPath, ...metadata };
+  if (scope !== undefined) req.scope = scope;
+  if (componentId !== undefined) req.componentId = componentId;
+
+  const r = await runVerbJSON("set-metadata", req);
+  if (!r.ok) return text(`occtkit set-metadata failed.\n\n${r.error}\n${r.stderr}`);
+
+  let size = 0;
+  try {
+    size = (await stat(outputPath)).size;
+  } catch {
+    // ignore
+  }
+  return text(`Wrote metadata → ${outputPath} (${size} bytes).\n\n${r.stdout}`);
+}
+
+// ── render_preview ─────────────────────────────────────────────────────────
+
+export async function renderPreview(
+  outputPath: string,
+  bodyIds?: string[],
+  options?: {
+    camera?: string;
+    cameraPosition?: number[];
+    cameraTarget?: number[];
+    cameraUp?: number[];
+    width?: number;
+    height?: number;
+    displayMode?: string;
+    background?: string;
+  }
+): Promise<ToolResult> {
+  const m = await readManifest();
+  if (!m) return text("No scene loaded. Run execute_script first.");
+
+  const targets = bodyIds && bodyIds.length > 0
+    ? bodyIds.map((id) => {
+        const b = findBody(m, id);
+        if (!b) throw new Error(`Body not found: ${id}`);
+        return bodyPath(b);
+      })
+    : m.bodies.map(bodyPath);
+
+  if (targets.length === 0) return text("No bodies to render.");
+
+  const req: Record<string, unknown> = {
+    inputs: targets,
+    outputPath,
+    ...(options ?? {}),
+  };
+
+  const r = await runVerbJSON("render-preview", req, 120_000);
+  if (!r.ok) return text(`occtkit render-preview failed.\n\n${r.error}\n${r.stderr}`);
+
+  let size = 0;
+  try {
+    size = (await stat(outputPath)).size;
+  } catch {
+    // ignore
+  }
+  return text(`Rendered → ${outputPath} (${size} bytes).\n\n${r.stdout}`);
+}

--- a/tests/integration/canonical-chain.test.mjs
+++ b/tests/integration/canonical-chain.test.mjs
@@ -1,0 +1,255 @@
+/**
+ * Integration test: exercises the canonical end-to-end chain across every
+ * Phase 2 + Phase 3 tool against a real occtkit subprocess.
+ *
+ * Slow (~30–120s depending on whether occtkit needs a rebuild). Run with:
+ *   npm run test:integration
+ *
+ * Setup: copies the user's existing BREP from iCloud (or from a fixture
+ * shipped in tests/fixtures/) into a fresh tempdir, points
+ * OCCTMCP_OUTPUT_DIR at it, and runs the chain. No live scene is touched.
+ *
+ * Tools exercised: validate_geometry, recognize_features, compute_metrics,
+ * query_topology, transform_body, measure_distance, analyze_clearance,
+ * boolean_op, mirror_or_pattern, heal_shape, check_thickness,
+ * generate_mesh, render_preview, export_scene, inspect_assembly,
+ * remove_body, clear_scene, compare_versions.
+ *
+ * Tools NOT exercised here (need carefully constructed schemas — separate
+ * tests): apply_feature (FeatureSpec), generate_drawing (DrawingSpec),
+ * read_brep (covered indirectly via export_scene + import_file would be
+ * the natural pair), import_file (would clobber if mis-pointed; covered
+ * once we have a fixture STEP), set_assembly_metadata.
+ */
+
+import { describe, it, before, after } from "node:test";
+import assert from "node:assert/strict";
+import {
+  mkdtempSync,
+  rmSync,
+  existsSync,
+  copyFileSync,
+  writeFileSync,
+  readFileSync,
+  statSync,
+} from "node:fs";
+import { tmpdir, homedir } from "node:os";
+import { join } from "node:path";
+
+const ICLOUD_BREP = join(
+  homedir(),
+  "Library/Mobile Documents/com~apple~CloudDocs/OCCTSwiftScripts/output/body-0.brep"
+);
+const FIXTURE_BREP = join(
+  process.cwd(),
+  "tests/fixtures/cylinder.brep"
+);
+
+let SCENE_DIR;
+let scene;
+let verb;
+let api;
+
+function pickStarterBrep() {
+  if (existsSync(ICLOUD_BREP)) return ICLOUD_BREP;
+  if (existsSync(FIXTURE_BREP)) return FIXTURE_BREP;
+  return null;
+}
+
+before(async () => {
+  const starter = pickStarterBrep();
+  if (!starter) {
+    throw new Error(
+      `No starter BREP found. Expected one of:\n  ${ICLOUD_BREP}\n  ${FIXTURE_BREP}`
+    );
+  }
+
+  SCENE_DIR = mkdtempSync(join(tmpdir(), "occtmcp-itest-"));
+  process.env.OCCTMCP_OUTPUT_DIR = SCENE_DIR;
+
+  // Seed the scene with a single body called "cyl"
+  copyFileSync(starter, join(SCENE_DIR, "body-0.brep"));
+  const manifest = {
+    version: 1,
+    timestamp: new Date().toISOString(),
+    description: "Integration-test scene",
+    bodies: [
+      { id: "cyl", file: "body-0.brep", format: "brep", color: [0.8, 0.7, 0.3, 1] },
+    ],
+  };
+  writeFileSync(join(SCENE_DIR, "manifest.json"), JSON.stringify(manifest, null, 2));
+
+  // Import the modules — relies on dist/ already being built
+  scene = await import("../../dist/scene-tools.js");
+  verb = await import("../../dist/verb-tools.js");
+  api = await import("../../dist/api-tools.js");
+});
+
+after(() => {
+  if (SCENE_DIR && existsSync(SCENE_DIR)) {
+    rmSync(SCENE_DIR, { recursive: true, force: true });
+  }
+});
+
+function parseJSON(toolResult) {
+  return JSON.parse(toolResult.content[0].text);
+}
+
+function trailingJSON(toolResult) {
+  // Tools that prefix with a human-readable line then dump JSON. Find the
+  // first '{' and parse from there.
+  const t = toolResult.content[0].text;
+  const i = t.indexOf("{");
+  assert.ok(i >= 0, `no JSON found in tool output:\n${t}`);
+  return JSON.parse(t.slice(i));
+}
+
+describe("canonical chain", () => {
+  it("compute_metrics returns volume + bbox + principal axes", async () => {
+    const r = await verb.computeMetrics("cyl");
+    const data = parseJSON(r);
+    assert.ok(data.volume > 0, "volume should be positive");
+    assert.ok(Array.isArray(data.boundingBox.min));
+    assert.ok(Array.isArray(data.boundingBox.max));
+    assert.ok(Array.isArray(data.principalAxes.moments));
+  });
+
+  it("validate_geometry reports per-body health", async () => {
+    const r = await api.validateGeometry();
+    const data = parseJSON(r);
+    assert.ok(Array.isArray(data.bodies));
+    assert.equal(data.bodies.length, 1);
+    assert.equal(data.bodies[0].id, "cyl");
+    assert.equal(data.bodies[0].isValid, true);
+  });
+
+  it("query_topology returns face IDs", async () => {
+    const r = await verb.queryTopology("cyl", "face");
+    const data = parseJSON(r);
+    assert.equal(data.entity, "face");
+    assert.ok(data.results.length >= 3, "cylinder has 3 faces (lateral + 2 caps)");
+    for (const f of data.results) {
+      assert.match(f.id, /^face\[\d+\]$/);
+    }
+  });
+
+  it("recognize_features returns pockets/holes (likely empty for plain cyl)", async () => {
+    const r = await api.recognizeFeatures("cyl");
+    const data = parseJSON(r);
+    assert.equal(data.bodyId, "cyl");
+    assert.ok(Array.isArray(data.pockets));
+    assert.ok(Array.isArray(data.holes));
+  });
+
+  it("transform_body creates a translated copy", async () => {
+    const r = await verb.transformBody("cyl", [40, 0, 0], undefined, undefined, undefined, false, "cyl2");
+    const data = trailingJSON(r);
+    assert.ok(data.outputPath.endsWith(".brep"));
+    assert.deepEqual(data.trsf.slice(12, 15), [40, 0, 0]);
+  });
+
+  it("measure_distance between cyl and cyl2 is non-negative", async () => {
+    const r = await verb.measureDistance("cyl", "cyl2");
+    const data = parseJSON(r);
+    assert.ok(typeof data.minDistance === "number");
+    assert.ok(data.minDistance >= 0);
+  });
+
+  it("analyze_clearance produces pair entries", async () => {
+    const r = await verb.analyzeClearance(["cyl", "cyl2"]);
+    const data = parseJSON(r);
+    assert.equal(data.pairs.length, 1);
+    assert.ok(typeof data.pairs[0].minDistance === "number");
+  });
+
+  it("boolean_op union produces a new body", async () => {
+    const r = await verb.booleanOp("union", "cyl", "cyl2", "merged");
+    const text = r.content[0].text;
+    assert.match(text, /Boolean union/);
+    const data = trailingJSON(r);
+    assert.equal(data.isValid, true);
+  });
+
+  it("mirror_or_pattern linear produces 3 bodies", async () => {
+    const r = await verb.mirrorOrPattern(
+      "cyl",
+      "linear",
+      { direction: [0, 1, 0], spacing: 30, count: 3 },
+      "row"
+    );
+    const text = r.content[0].text;
+    assert.match(text, /3 bodies/);
+  });
+
+  it("heal_shape produces before/after stats", async () => {
+    const r = await verb.healShape("cyl", undefined, "cyl_healed");
+    const data = trailingJSON(r);
+    assert.ok(data.before);
+    assert.ok(data.after);
+    assert.ok(data.outputPath.endsWith(".brep"));
+  });
+
+  it("check_thickness returns sample stats", async () => {
+    const r = await verb.checkThickness("cyl");
+    const data = parseJSON(r);
+    assert.ok(typeof data.samples === "number");
+    assert.ok(data.samples >= 0);
+  });
+
+  it("generate_mesh returns triangle counts", async () => {
+    const r = await verb.generateMesh("cyl", undefined, undefined, undefined, false);
+    const data = parseJSON(r);
+    assert.ok(data.triangleCount > 0);
+    assert.ok(data.vertexCount > 0);
+    assert.ok(data.quality);
+  });
+
+  it("render_preview writes a non-empty PNG", async () => {
+    const png = join(SCENE_DIR, "preview.png");
+    const r = await verb.renderPreview(png, undefined, { camera: "iso", width: 400, height: 300 });
+    assert.match(r.content[0].text, /Rendered/);
+    assert.ok(existsSync(png));
+    assert.ok(statSync(png).size > 0);
+  });
+
+  it("export_scene writes a STEP file", async () => {
+    const step = join(SCENE_DIR, "scene.step");
+    const r = await scene.exportScene("step", step, ["cyl"]);
+    assert.match(r.content[0].text, /Exported/);
+    assert.ok(existsSync(step));
+    assert.ok(statSync(step).size > 0);
+  });
+
+  it("inspect_assembly walks the exported STEP", async () => {
+    const step = join(SCENE_DIR, "scene.step");
+    const r = await verb.inspectAssembly(undefined, step);
+    const data = parseJSON(r);
+    assert.ok(data.root);
+    assert.ok(typeof data.totalComponents === "number");
+  });
+
+  it("compare_versions sees the bodies added across the chain", async () => {
+    const r = await scene.compareVersions(1);
+    const text = r.content[0].text;
+    // After the chain, the most recent mutation was heal_shape (added cyl_healed)
+    // or mirror_or_pattern. compare_versions(since=1) compares current vs the
+    // prior snapshot, so we just check the structure parses.
+    const data = JSON.parse(text);
+    assert.ok("added" in data);
+    assert.ok("removed" in data);
+  });
+
+  it("remove_body cleans the merged body", async () => {
+    const r = await scene.removeBody("merged");
+    assert.match(r.content[0].text, /Removed body "merged"/);
+  });
+
+  it("clear_scene wipes everything", async () => {
+    const r = await scene.clearScene(false);
+    assert.match(r.content[0].text, /Cleared/);
+    const finalManifest = JSON.parse(
+      readFileSync(join(SCENE_DIR, "manifest.json"), "utf-8")
+    );
+    assert.equal(finalManifest.bodies.length, 0);
+  });
+});

--- a/tests/unit/scene-mutation.test.mjs
+++ b/tests/unit/scene-mutation.test.mjs
@@ -1,0 +1,222 @@
+/**
+ * Unit tests for the pure-TS scene-mutation tools (Phase 1).
+ *
+ * These exercise manifest read/modify/write logic only — no occtkit
+ * subprocess. Each test points OCCTMCP_OUTPUT_DIR at a fresh tempdir.
+ *
+ * Run with:  node --test tests/unit/
+ */
+
+import { describe, it, before, after, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync, writeFileSync, readFileSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+let SCENE_DIR;
+let MANIFEST;
+let BREP_A;
+let BREP_B;
+
+const SAMPLE_MANIFEST = {
+  version: 1,
+  timestamp: "2026-04-29T00:00:00Z",
+  description: "Test scene",
+  bodies: [
+    { id: "alpha", file: "alpha.brep", format: "brep", color: [1, 0, 0, 1] },
+    { id: "beta", file: "beta.brep", format: "brep", color: [0, 1, 0, 1] },
+  ],
+};
+
+function freshScene() {
+  if (SCENE_DIR && existsSync(SCENE_DIR)) {
+    rmSync(SCENE_DIR, { recursive: true, force: true });
+  }
+  const dir = mkdtempSync(join(tmpdir(), "occtmcp-test-"));
+  SCENE_DIR = dir;
+  MANIFEST = join(dir, "manifest.json");
+  BREP_A = join(dir, "alpha.brep");
+  BREP_B = join(dir, "beta.brep");
+  writeFileSync(MANIFEST, JSON.stringify(SAMPLE_MANIFEST, null, 2));
+  writeFileSync(BREP_A, "DUMMY-BREP-A");
+  writeFileSync(BREP_B, "DUMMY-BREP-B");
+  process.env.OCCTMCP_OUTPUT_DIR = dir;
+}
+
+function cleanup() {
+  if (SCENE_DIR && existsSync(SCENE_DIR)) {
+    rmSync(SCENE_DIR, { recursive: true, force: true });
+  }
+}
+
+function readManifest() {
+  return JSON.parse(readFileSync(MANIFEST, "utf-8"));
+}
+
+let sceneTools;
+
+before(async () => {
+  // Initialise the env var BEFORE importing scene-tools so its captured
+  // module state (history ring) is seeded against a stable tmpdir parent.
+  process.env.OCCTMCP_OUTPUT_DIR = mkdtempSync(join(tmpdir(), "occtmcp-init-"));
+  sceneTools = await import("../../dist/scene-tools.js");
+});
+
+after(() => {
+  cleanup();
+});
+
+beforeEach(() => {
+  freshScene();
+  sceneTools.clearHistory();
+});
+
+describe("remove_body", () => {
+  it("removes the body from manifest and deletes its BREP", async () => {
+    const r = await sceneTools.removeBody("alpha");
+    assert.match(r.content[0].text, /Removed body "alpha"/);
+
+    const m = readManifest();
+    assert.equal(m.bodies.length, 1);
+    assert.equal(m.bodies[0].id, "beta");
+    assert.equal(existsSync(BREP_A), false);
+    assert.equal(existsSync(BREP_B), true);
+  });
+
+  it("errors when bodyId is unknown", async () => {
+    const r = await sceneTools.removeBody("nope");
+    assert.match(r.content[0].text, /Body not found: nope/);
+    assert.equal(readManifest().bodies.length, 2);
+  });
+});
+
+describe("clear_scene", () => {
+  it("removes every body and its BREP", async () => {
+    const r = await sceneTools.clearScene(false);
+    assert.match(r.content[0].text, /Cleared 2 bodies/);
+    assert.equal(readManifest().bodies.length, 0);
+    assert.equal(existsSync(BREP_A), false);
+    assert.equal(existsSync(BREP_B), false);
+  });
+
+  it("keepHistory=true preserves the history ring", async () => {
+    await sceneTools.removeBody("alpha"); // pushes a snapshot
+    await sceneTools.clearScene(true);
+    // History should still hold pre-clear snapshot. compare_versions(1)
+    // should compare current (empty) vs the previous snapshot.
+    const diff = JSON.parse((await sceneTools.compareVersions(1)).content[0].text);
+    assert.ok(diff.available > 0);
+  });
+
+  it("keepHistory=false (default) clears the ring", async () => {
+    await sceneTools.removeBody("alpha");
+    await sceneTools.clearScene(false);
+    const out = (await sceneTools.compareVersions(1)).content[0].text;
+    assert.match(out, /Not enough history/);
+  });
+});
+
+describe("rename_body", () => {
+  it("renames the id in the manifest", async () => {
+    const r = await sceneTools.renameBody("alpha", "alpha2");
+    assert.match(r.content[0].text, /Renamed "alpha" → "alpha2"/);
+    const m = readManifest();
+    assert.equal(m.bodies.find((b) => b.file === "alpha.brep").id, "alpha2");
+  });
+
+  it("rejects collisions with an existing id", async () => {
+    const r = await sceneTools.renameBody("alpha", "beta");
+    assert.match(r.content[0].text, /already exists/);
+    const m = readManifest();
+    assert.equal(m.bodies[0].id, "alpha");
+  });
+
+  it("errors when bodyId is unknown", async () => {
+    const r = await sceneTools.renameBody("missing", "anything");
+    assert.match(r.content[0].text, /Body not found/);
+  });
+});
+
+describe("set_appearance", () => {
+  it("updates color, opacity, name, roughness, metallic", async () => {
+    const r = await sceneTools.setAppearance(
+      "alpha",
+      [0.2, 0.4, 0.6],
+      0.5,
+      0.8,
+      0.1,
+      "Alpha part"
+    );
+    assert.match(r.content[0].text, /Updated appearance of "alpha"/);
+    const m = readManifest();
+    const body = m.bodies.find((b) => b.id === "alpha");
+    assert.deepEqual(body.color, [0.2, 0.4, 0.6, 0.5]);
+    assert.equal(body.roughness, 0.8);
+    assert.equal(body.metallic, 0.1);
+    assert.equal(body.name, "Alpha part");
+  });
+
+  it("opacity alone updates only the alpha channel", async () => {
+    await sceneTools.setAppearance("alpha", undefined, 0.3);
+    const body = readManifest().bodies.find((b) => b.id === "alpha");
+    // original colour was [1,0,0,1]; alpha is now 0.3, RGB unchanged
+    assert.equal(body.color[0], 1);
+    assert.equal(body.color[1], 0);
+    assert.equal(body.color[2], 0);
+    assert.equal(body.color[3], 0.3);
+  });
+
+  it("rejects color arrays of wrong length", async () => {
+    const r = await sceneTools.setAppearance("alpha", [1, 0]);
+    assert.match(r.content[0].text, /must be \[r,g,b\]/);
+  });
+
+  it("complains when no fields are provided", async () => {
+    const r = await sceneTools.setAppearance("alpha");
+    assert.match(r.content[0].text, /No appearance fields provided/);
+  });
+
+  it("errors on unknown bodyId", async () => {
+    const r = await sceneTools.setAppearance("nope", [1, 1, 1]);
+    assert.match(r.content[0].text, /Body not found/);
+  });
+});
+
+describe("compare_versions", () => {
+  it("reports added when a new body appears", async () => {
+    await sceneTools.snapshotScene();
+    // mutate after snapshot — add a body manually
+    const m = readManifest();
+    m.bodies.push({ id: "gamma", file: "gamma.brep", format: "brep" });
+    writeFileSync(MANIFEST, JSON.stringify(m));
+    const diff = JSON.parse((await sceneTools.compareVersions(1)).content[0].text);
+    assert.deepEqual(diff.added, ["gamma"]);
+    assert.deepEqual(diff.removed, []);
+  });
+
+  it("reports removed when a body is deleted", async () => {
+    await sceneTools.removeBody("alpha"); // snapshots first, then removes
+    const diff = JSON.parse((await sceneTools.compareVersions(1)).content[0].text);
+    assert.deepEqual(diff.removed, ["alpha"]);
+    assert.deepEqual(diff.added, []);
+  });
+
+  it("reports appearanceChanged when color changes", async () => {
+    await sceneTools.setAppearance("alpha", [0.5, 0.5, 0.5]);
+    const diff = JSON.parse((await sceneTools.compareVersions(1)).content[0].text);
+    assert.equal(diff.appearanceChanged.length, 1);
+    assert.equal(diff.appearanceChanged[0].id, "alpha");
+    assert.ok(diff.appearanceChanged[0].fields.includes("color"));
+  });
+
+  it("reports unchanged for untouched bodies", async () => {
+    await sceneTools.removeBody("alpha"); // snapshots and removes
+    const diff = JSON.parse((await sceneTools.compareVersions(1)).content[0].text);
+    assert.ok(diff.unchanged.includes("beta"));
+  });
+
+  it("returns 'not enough history' when ring is shallower than `since`", async () => {
+    const r = await sceneTools.compareVersions(5);
+    assert.match(r.content[0].text, /Not enough history/);
+  });
+});


### PR DESCRIPTION
## Summary

- Expands MCP tool surface from 10 → 35 by wrapping the new occtkit verbs that shipped in [gsdali/OCCTSwiftScripts#18–#24](https://github.com/gsdali/OCCTSwiftScripts/issues), plus pure-TS scene-mutation tools.
- 25 of the 26 tools proposed in #6 are now built — only `simplify_mesh` remains, blocked on the `occtkit simplify-mesh` verb wiring (decimation algorithm itself is ready in [OCCTSwiftMesh v0.1.0](https://github.com/gsdali/OCCTSwiftMesh)).
- Adds unit tests (fast, no occtkit) and an integration test (full canonical chain through a real occtkit subprocess).

Closes #6 (modulo `simplify_mesh`).

## New tools by category

| Category | Tools |
|---|---|
| **Scene mutation** | `remove_body`, `clear_scene`, `rename_body`, `set_appearance`, `compare_versions` |
| **Introspection** | `validate_geometry`, `compute_metrics`, `query_topology`, `measure_distance`, `recognize_features`, `inspect_assembly` |
| **Construction** | `apply_feature`, `transform_body`, `boolean_op`, `mirror_or_pattern` |
| **Engineering analysis** | `check_thickness`, `analyze_clearance`, `heal_shape` |
| **I/O** | `read_brep`, `import_file`, `export_scene`, `set_assembly_metadata` |
| **Mesh & viz** | `generate_mesh`, `render_preview`, `generate_drawing` |

## Architecture notes

- `src/scene-tools.ts` — pure-TS manifest mutation; runs an in-memory snapshot ring buffer (max 10) that `executeScript` and every mutator pushes into, so `compare_versions` has history.
- `src/api-tools.ts` — wrappers around verbs that pre-existed this batch (`validate_geometry`, `recognize_features`, `apply_feature`, `generate_drawing`).
- `src/verb-tools.ts` — wrappers around the 13 verbs shipped in #18–#24. `read_brep` and `import_file` are non-trivial: `load-brep` / `import` write a fresh manifest in their `--emit-manifest` dir, which would clobber the live scene; the wrappers point the verb at a staging tmpdir, then merge the staged bodies into the live manifest.
- `src/paths.ts` — adds `OCCTMCP_OUTPUT_DIR` env override (used by the test suite; falls through to the existing iCloud → local resolution).

## Test plan

- [x] `npm test` — 18 unit tests passing in ~100 ms (manifest mutation logic via tempdir)
- [x] `npm run test:integration` — 18 integration tests passing in ~100 s (full canonical chain through occtkit; cold start dominated by SwiftPM build, subsequent calls ~500 ms)
- [x] `npm run build` — clean tsc compile
- [x] Smoke-tested every tool against the live `cyl` scene during development

## Out of scope / follow-ups

- `simplify_mesh` — wire once OCCTSwiftScripts#22's `simplify-mesh` verb lands.
- `apply_feature` / `generate_drawing` — exercised via direct calls during dev but not in the integration test (FeatureSpec / DrawingSpec are rich; would need fixture specs to make assertions stable). Worth a focused test once representative shapes exist.
- `get_api_reference` doesn't yet enumerate the new MCP tools' schemas — that's a separate piece of work (the current generator scrapes OCCTSwift, not the MCP server's own zod schemas).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
