### PR TITLE
Wire simplify_mesh, expand integration tests, expose tool catalog

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,7 +25,7 @@ Tests under `tests/unit/` exercise the pure-TS scene-mutation code against a tem
 
 The server is a single-process Node.js app (ESM, strict TypeScript):
 
-- `src/index.ts` — Creates `McpServer`, registers every tool with zod schemas, connects stdio transport
+- `src/index.ts` — Exports `createServer()` factory (which registers every tool with zod schemas) and connects stdio transport when run directly. Tests import `createServer()` to introspect the tool registry without binding stdio. The `get_api_reference` tool's `mcp_tools` category dumps the live registry as JSON Schema for LLM auto-discovery
 - `src/tools.ts` — Core tool implementations (`execute_script`, `get_scene`, `get_script`, `export_model`, `get_api_reference`): writes Swift code to a tempfile, sends it to a long-lived `occtkit run --serve` child by default, falls back to one-shot `occtkit run <path>` if serve mode is unavailable. `executeScript` calls `snapshotScene()` before running so `compare_versions` has history
 - `src/scene-tools.ts` — Pure-TS scene-mutation tools (`remove_body`, `clear_scene`, `rename_body`, `set_appearance`, `compare_versions`, `export_scene`). Read/modify/write `manifest.json` directly; OCCTSwiftViewport's ScriptWatcher reloads on the write. `export_scene` is the exception: it generates a one-shot Swift script that loads the bodies' BREPs and calls `Exporter.writeXxx`, run via `occtkit run`. Maintains an in-memory ring buffer of the last 10 manifest snapshots for `compare_versions`
 - `src/api-tools.ts` — Thin wrappers around existing occtkit verbs (`validate_geometry` → `graph-validate`, `recognize_features` → `feature-recognize`, `apply_feature` → `reconstruct`, `generate_drawing` → `drawing-export`). Each resolves a `bodyId` against the scene manifest, passes the BREP path to the verb, returns the verb's JSON output
@@ -98,6 +98,7 @@ The 2 min timeout is per-request in both paths. On serve-mode timeout the child 
 | `heal_shape` | Heal imported / non-watertight geometry — wraps `occtkit heal` |
 | `read_brep` | Add a `.brep` from disk to the scene — wraps `occtkit load-brep` (staged + merged) |
 | `import_file` | STEP / IGES / STL / OBJ import — wraps `occtkit import` (staged + merged) |
+| `simplify_mesh` | QEM mesh decimation to .stl/.obj — wraps `occtkit simplify-mesh` (which wraps OCCTSwiftMesh's `Mesh.simplified`, vendoring meshoptimizer) |
 | `render_preview` | One-shot PNG render of the scene — wraps `occtkit render-preview` |
 | `inspect_assembly` | Walk an XCAF assembly tree — wraps `occtkit inspect-assembly` |
 | `set_assembly_metadata` | Modify XCAF document or per-component metadata — wraps `occtkit set-metadata` |
@@ -106,7 +107,7 @@ The five graph/feature tools (`graph_*`, `feature_recognize`) are thin one-shot 
 
 The scene-mutation tools (`remove_body`, `clear_scene`, `rename_body`, `set_appearance`, `compare_versions`) are pure manifest manipulation — they don't shell out to occtkit at all. `export_scene` is the exception: it generates a small templated Swift program that loads the relevant BREPs and calls `Exporter.writeXxx`, run via `occtkit run` (one-shot, not serve). The `validate_geometry` / `recognize_features` / `apply_feature` / `generate_drawing` tools resolve a `bodyId` against the manifest and delegate to the corresponding occtkit verb.
 
-Only one tool from [#6](https://github.com/gsdali/OCCTMCP/issues/6) remains unbuilt: `simplify_mesh`, blocked on the `occtkit simplify-mesh` verb in OCCTSwiftScripts#22. The decimation algorithm is ready in [OCCTSwiftMesh v0.1.0](https://github.com/gsdali/OCCTSwiftMesh/releases/tag/v0.1.0) (QEM via vendored meshoptimizer); the verb just needs wiring. Once the verb lands, the MCP wrapper is a thin pass-through — same pattern as `generate_mesh`.
+All 26 tools from [#6](https://github.com/gsdali/OCCTMCP/issues/6) are built. Mesh-domain algorithms beyond decimation live in [OCCTSwiftMesh](https://github.com/gsdali/OCCTSwiftMesh) (sibling to OCCTSwift, vendors permissive implementations because OCCT-Open ships only mesh generation, not post-processing). As more verbs land in OCCTSwiftMesh → OCCTSwiftScripts (smoothing, repair, remeshing, subdivision per the OCCTSwiftMesh roadmap), wire them as additional MCP tools using the same `runVerbJSON` pattern.
 
 ## Script Template
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ The LLM has full access to OCCTSwift's 900+ CAD operations: primitives, booleans
 
 ## Tools
 
-35 tools, organized below. Most LLM flows can answer "what's the volume?", "make it red", "boolean-subtract these", "render a preview", "export to STEP", and "draw this" without ever round-tripping through `execute_script` — that's reserved for novel geometry the typed tools don't cover.
+36 tools, organized below. Call `get_api_reference({ category: "mcp_tools" })` to dump every tool's JSON Schema in one shot — useful for LLM auto-discovery. Most LLM flows can answer "what's the volume?", "make it red", "boolean-subtract these", "render a preview", "export to STEP", and "draw this" without ever round-tripping through `execute_script` — that's reserved for novel geometry the typed tools don't cover.
 
 ### Authoring
 
@@ -84,6 +84,7 @@ The LLM has full access to OCCTSwift's 900+ CAD operations: primitives, booleans
 | Tool | Purpose |
 |------|---------|
 | `generate_mesh` | Tessellate to triangles + quality metrics |
+| `simplify_mesh` | QEM mesh decimation to .stl/.obj — wraps OCCTSwiftMesh's `Mesh.simplified` (vendored meshoptimizer) |
 | `render_preview` | One-shot PNG render |
 | `generate_drawing` | Multi-view ISO 128-30 DXF technical drawing |
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -41,12 +41,19 @@ import {
   renderPreview,
   inspectAssembly,
   setAssemblyMetadata,
+  simplifyMesh,
 } from "./verb-tools.js";
 
-const server = new McpServer({
-  name: "occtmcp",
-  version: "0.1.0",
-});
+export function createServer(): McpServer {
+  const server = new McpServer({
+    name: "occtmcp",
+    version: "0.1.0",
+  });
+  registerTools(server);
+  return server;
+}
+
+function registerTools(server: McpServer): void {
 
 // ── execute_script ──────────────────────────────────────────────────────────
 // The core tool: write Swift CAD code, compile & run it via OCCTSwiftScripts.
@@ -115,8 +122,10 @@ server.tool(
 // Quick reference for the OCCTSwift API surface.
 server.tool(
   "get_api_reference",
-  "Get a reference guide for OCCTSwift API operations. " +
-    "Use this to look up available methods before writing a script.",
+  "Get a reference guide for OCCTSwift API operations, OR a catalog of every " +
+    "MCP tool this server exposes (category=mcp_tools). " +
+    "Use this to look up available methods before writing a script, or to " +
+    "discover what tools you can call directly without writing Swift.",
   {
     category: z
       .enum([
@@ -134,13 +143,51 @@ server.tool(
         "topology_graph",
         "topology_graph_builder",
         "all",
+        "mcp_tools",
       ])
-      .describe("API category to look up"),
+      .describe("API category to look up. Use 'mcp_tools' for the MCP tool catalog."),
   },
   async ({ category }) => {
+    if (category === "mcp_tools") return mcpToolsCatalog();
     return getApiReference(category);
   }
 );
+
+function mcpToolsCatalog() {
+  // Walk the McpServer's private tool registry. Shape per RegisteredTool in
+  // @modelcontextprotocol/sdk: { description, inputSchema (zod), ... }.
+  const reg = (server as unknown as {
+    _registeredTools: Record<string, {
+      description?: string;
+      inputSchema?: unknown;
+      enabled: boolean;
+    }>;
+  })._registeredTools;
+
+  const entries = Object.entries(reg)
+    .filter(([, t]) => t.enabled)
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([name, t]) => {
+      let inputSchema: unknown = {};
+      if (t.inputSchema) {
+        try {
+          inputSchema = z.toJSONSchema(t.inputSchema as z.ZodType);
+        } catch {
+          inputSchema = { _note: "schema introspection failed" };
+        }
+      }
+      return { name, description: t.description ?? "", inputSchema };
+    });
+
+  return {
+    content: [
+      {
+        type: "text" as const,
+        text: JSON.stringify({ tools: entries, count: entries.length }, null, 2),
+      },
+    ],
+  };
+}
 
 // ── graph_validate ──────────────────────────────────────────────────────────
 // Run BRepGraph validation on a BREP file and return the report JSON.
@@ -678,6 +725,42 @@ server.tool(
     renderPreview(outputPath, bodyIds, options)
 );
 
+// ── simplify_mesh ─────────────────────────────────────────────────────────
+server.tool(
+  "simplify_mesh",
+  "Decimate a body's mesh to a target triangle count via QEM " +
+    "(meshoptimizer, vendored in OCCTSwiftMesh). Outputs an .stl or .obj " +
+    "file plus before/after counts and Hausdorff distance. Wraps " +
+    "occtkit simplify-mesh.",
+  {
+    bodyId: z.string(),
+    outputPath: z.string().describe("Output mesh path (.stl or .obj)."),
+    targetTriangleCount: z
+      .number()
+      .int()
+      .positive()
+      .optional()
+      .describe("Target triangle count. Mutually exclusive with targetReduction."),
+    targetReduction: z
+      .number()
+      .gt(0)
+      .lt(1)
+      .optional()
+      .describe("Fraction to remove (e.g. 0.9 = 90% reduction). Mutually exclusive with targetTriangleCount."),
+    preserveBoundary: z.boolean().optional().describe("Default true."),
+    preserveTopology: z.boolean().optional().describe("Default true."),
+    maxHausdorffDistance: z
+      .number()
+      .positive()
+      .optional()
+      .describe("Cap deviation from the input mesh (in input units)."),
+    linearDeflection: z.number().positive().optional().describe("Tessellation deflection. Default 0.1."),
+    angularDeflection: z.number().positive().optional().describe("Default 0.5 rad."),
+  },
+  async ({ bodyId, outputPath, ...options }) =>
+    simplifyMesh(bodyId, outputPath, options)
+);
+
 // ── inspect_assembly ──────────────────────────────────────────────────────
 server.tool(
   "inspect_assembly",
@@ -727,6 +810,15 @@ server.tool(
     setAssemblyMetadata(inputPath, outputPath, scope, componentId, metadata)
 );
 
-// ── Start ───────────────────────────────────────────────────────────────────
-const transport = new StdioServerTransport();
-await server.connect(transport);
+}
+
+// ── Start (skipped during in-process imports such as tests) ──────────────────
+const isMain =
+  import.meta.url === `file://${process.argv[1]}` ||
+  import.meta.url.endsWith(process.argv[1]?.replace(/^.*?\/dist\//, "/dist/") ?? "");
+
+if (isMain) {
+  const server = createServer();
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+}

--- a/src/verb-tools.ts
+++ b/src/verb-tools.ts
@@ -235,6 +235,55 @@ export async function generateMesh(
   return passthroughResult("mesh", await runVerbJSON("mesh", req, 240_000));
 }
 
+// ── simplify_mesh ──────────────────────────────────────────────────────────
+
+export async function simplifyMesh(
+  bodyId: string,
+  outputPath: string,
+  options: {
+    targetTriangleCount?: number;
+    targetReduction?: number;
+    preserveBoundary?: boolean;
+    preserveTopology?: boolean;
+    maxHausdorffDistance?: number;
+    linearDeflection?: number;
+    angularDeflection?: number;
+  }
+): Promise<ToolResult> {
+  if (
+    options.targetTriangleCount === undefined &&
+    options.targetReduction === undefined
+  ) {
+    return text(
+      "simplify_mesh requires exactly one of targetTriangleCount or targetReduction."
+    );
+  }
+  if (
+    options.targetTriangleCount !== undefined &&
+    options.targetReduction !== undefined
+  ) {
+    return text(
+      "simplify_mesh: pass exactly one of targetTriangleCount or targetReduction, not both."
+    );
+  }
+  const ext = outputPath.toLowerCase();
+  if (!ext.endsWith(".stl") && !ext.endsWith(".obj")) {
+    return text(`simplify_mesh: outputPath must end in .stl or .obj (got ${outputPath}).`);
+  }
+
+  const m = await readManifest();
+  if (!m) return text("No scene loaded. Run execute_script first.");
+  const body = findBody(m, bodyId);
+  if (!body) return text(`Body not found: ${bodyId}`);
+
+  const req: Record<string, unknown> = {
+    inputBrep: bodyPath(body),
+    outputPath,
+    ...options,
+  };
+  return passthroughResult("simplify-mesh", await runVerbJSON("simplify-mesh", req, 240_000));
+}
+
 // ── transform_body ─────────────────────────────────────────────────────────
 
 export async function transformBody(

--- a/tests/integration/canonical-chain.test.mjs
+++ b/tests/integration/canonical-chain.test.mjs
@@ -12,14 +12,13 @@
  * Tools exercised: validate_geometry, recognize_features, compute_metrics,
  * query_topology, transform_body, measure_distance, analyze_clearance,
  * boolean_op, mirror_or_pattern, heal_shape, check_thickness,
- * generate_mesh, render_preview, export_scene, inspect_assembly,
- * remove_body, clear_scene, compare_versions.
+ * generate_mesh, simplify_mesh, render_preview, export_scene,
+ * inspect_assembly, apply_feature, generate_drawing, remove_body,
+ * clear_scene, compare_versions.
  *
- * Tools NOT exercised here (need carefully constructed schemas — separate
- * tests): apply_feature (FeatureSpec), generate_drawing (DrawingSpec),
- * read_brep (covered indirectly via export_scene + import_file would be
- * the natural pair), import_file (would clobber if mis-pointed; covered
- * once we have a fixture STEP), set_assembly_metadata.
+ * Tools NOT exercised here: read_brep / import_file (would clobber if
+ * mis-pointed; covered once we have a fixture STEP), set_assembly_metadata
+ * (writes XBF; covered once we have a multi-component fixture).
  */
 
 import { describe, it, before, after } from "node:test";
@@ -96,12 +95,14 @@ function parseJSON(toolResult) {
 }
 
 function trailingJSON(toolResult) {
-  // Tools that prefix with a human-readable line then dump JSON. Find the
-  // first '{' and parse from there.
+  // Tools that prefix with a human-readable line then dump multi-line JSON.
+  // Match the last "\n{" (the start of a top-level block) — the preamble
+  // may itself embed inline JSON like `{"kind":"fillet"}`, so first-{
+  // doesn't cut it.
   const t = toolResult.content[0].text;
-  const i = t.indexOf("{");
-  assert.ok(i >= 0, `no JSON found in tool output:\n${t}`);
-  return JSON.parse(t.slice(i));
+  const i = t.lastIndexOf("\n{");
+  assert.ok(i >= 0, `no trailing JSON block found in tool output:\n${t}`);
+  return JSON.parse(t.slice(i + 1));
 }
 
 describe("canonical chain", () => {
@@ -202,6 +203,47 @@ describe("canonical chain", () => {
     assert.ok(data.triangleCount > 0);
     assert.ok(data.vertexCount > 0);
     assert.ok(data.quality);
+  });
+
+  it("simplify_mesh decimates to a target triangle count", async () => {
+    const stl = join(SCENE_DIR, "simplified.stl");
+    const r = await verb.simplifyMesh("cyl", stl, { targetTriangleCount: 40 });
+    const data = parseJSON(r);
+    assert.ok(data.beforeTriangleCount > data.afterTriangleCount);
+    assert.equal(data.afterTriangleCount, 40);
+    assert.ok(data.qualityDelta);
+    assert.ok(typeof data.qualityDelta.hausdorffDistance === "number");
+    assert.ok(existsSync(stl));
+    assert.ok(statSync(stl).size > 0);
+  });
+
+  it("apply_feature applies a fillet to all edges (in-place)", async () => {
+    const r = await api.applyFeature("cyl", { kind: "fillet", id: "f1", radius: 0.5 });
+    const text = r.content[0].text;
+    assert.match(text, /Applied feature/);
+    // The reconstruct verb returns shape: <path>, fulfilled: [...], skipped: [...]
+    const data = trailingJSON(r);
+    assert.ok(data.shape, "reconstruct should produce a shape path");
+    assert.ok(Array.isArray(data.fulfilled));
+    assert.ok(data.fulfilled.includes("f1"), `f1 should be fulfilled, got: ${JSON.stringify(data.fulfilled)}`);
+  });
+
+  it("generate_drawing produces a DXF for the cylinder", async () => {
+    const dxf = join(SCENE_DIR, "drawing.dxf");
+    const spec = {
+      sheet: { size: "a4", orientation: "landscape", projection: "third", scale: "auto" },
+      views: [
+        { name: "front", direction: [0, -1, 0] },
+        { name: "top", direction: [0, 0, -1] },
+      ],
+    };
+    const r = await api.generateDrawing("cyl", dxf, spec);
+    const text = r.content[0].text;
+    assert.match(text, /Drawing exported/);
+    assert.ok(existsSync(dxf));
+    assert.ok(statSync(dxf).size > 0);
+    const data = trailingJSON(r);
+    assert.equal(data.viewCount, 2);
   });
 
   it("render_preview writes a non-empty PNG", async () => {

--- a/tests/unit/mcp-catalog.test.mjs
+++ b/tests/unit/mcp-catalog.test.mjs
@@ -1,0 +1,70 @@
+/**
+ * Unit tests for the get_api_reference(category="mcp_tools") catalog —
+ * verifies that every tool registered in src/index.ts shows up with a
+ * description and an introspectable JSON Schema for its input.
+ *
+ * Pure import-time check; no occtkit, no scene state.
+ */
+
+import { describe, it, before } from "node:test";
+import assert from "node:assert/strict";
+
+let server;
+let catalog;
+
+before(async () => {
+  const { createServer } = await import("../../dist/index.js");
+  server = createServer();
+  const tool = server._registeredTools.get_api_reference;
+  const result = await tool.handler({ category: "mcp_tools" }, {});
+  catalog = JSON.parse(result.content[0].text);
+});
+
+describe("mcp_tools catalog", () => {
+  it("enumerates every registered tool", () => {
+    const registeredCount = Object.keys(server._registeredTools).filter(
+      (k) => server._registeredTools[k].enabled
+    ).length;
+    assert.equal(catalog.count, registeredCount);
+    assert.ok(catalog.count >= 30, `expected >= 30 tools, got ${catalog.count}`);
+  });
+
+  it("includes the core tools", () => {
+    const names = catalog.tools.map((t) => t.name);
+    for (const expected of [
+      "execute_script",
+      "get_scene",
+      "get_api_reference",
+      "compute_metrics",
+      "transform_body",
+      "boolean_op",
+      "render_preview",
+      "simplify_mesh",
+      "inspect_assembly",
+    ]) {
+      assert.ok(names.includes(expected), `missing tool: ${expected}`);
+    }
+  });
+
+  it("every entry has a name, description, and inputSchema", () => {
+    for (const t of catalog.tools) {
+      assert.ok(typeof t.name === "string" && t.name.length > 0);
+      assert.ok(typeof t.description === "string" && t.description.length > 0, `tool ${t.name} missing description`);
+      assert.ok(typeof t.inputSchema === "object" && t.inputSchema !== null);
+    }
+  });
+
+  it("input schemas have the JSON Schema 'type' marker", () => {
+    // Empty-input tools may have minimal schema; richer ones should advertise type
+    const xform = catalog.tools.find((t) => t.name === "transform_body");
+    assert.equal(xform.inputSchema.type, "object");
+    assert.ok(xform.inputSchema.properties.bodyId);
+    assert.ok(xform.inputSchema.required.includes("bodyId"));
+  });
+
+  it("tools are sorted alphabetically", () => {
+    const names = catalog.tools.map((t) => t.name);
+    const sorted = [...names].sort();
+    assert.deepEqual(names, sorted);
+  });
+});


### PR DESCRIPTION
## Summary

Closes the remaining open items from #6.

- **`simplify_mesh`** — wraps `occtkit simplify-mesh`, which wraps [OCCTSwiftMesh](https://github.com/gsdali/OCCTSwiftMesh)'s `Mesh.simplified(_:)` (QEM via vendored meshoptimizer). Outputs `.stl` / `.obj`.
- **Integration tests** — added fixture-based coverage for `apply_feature` (fillet) and `generate_drawing` (minimal A4 spec) plus `simplify_mesh`. 21 integration tests now, all green in ~16 s on warm cache.
- **`mcp_tools` catalog** — `get_api_reference({ category: "mcp_tools" })` dumps every registered tool as `{ name, description, inputSchema }` via zod 4's `toJSONSchema`. Lets an LLM discover the tool surface programmatically.

## Architecture notes

### simplify_mesh

OCCTSwiftMesh is a sibling package, not bolted into OCCTSwift, on purpose: OCCT-Open ships `BRepMesh_*` for mesh **generation** but no decimation / smoothing / repair (the paywalled OCCT-Components Mesh Decimation module fills that role upstream). OCCTSwiftMesh keeps OCCTSwift focused on the kernel and vendors permissive implementations (meshoptimizer is BSD-2-Clause). The MCP wrapper is a thin pass-through over `occtkit simplify-mesh` — same `runVerbJSON` pattern as the other verbs, with client-side validation of `targetTriangleCount` xor `targetReduction` and the `.stl|.obj` output extension.

### Tool-catalog refactor

`src/index.ts` now exports `createServer()` so tests can introspect the tool registry without binding stdio. The connect() call is guarded by an `import.meta.url`-vs-`process.argv[1]` check so the file remains directly runnable. The catalog handler walks `server._registeredTools` and runs each tool's zod schema through `z.toJSONSchema()`.

### Test helper fix

`trailingJSON` now uses `lastIndexOf("\n{")` instead of `indexOf("{")` — `apply_feature`'s response embeds the FeatureSpec JSON in its preamble (`Applied feature {"kind":"fillet"}...`), which broke the old first-`{` scan.

## Test plan

- [x] `npm test` — 23 unit tests (was 18) passing in ~165 ms
- [x] `npm run test:integration` — 21 integration tests (was 18) passing in ~16 s on warm cache
- [x] `npm run build` — clean tsc compile
- [x] Smoke-tested `simplify_mesh` (cyl 124 → 40 triangles, hausdorff 0.54) and the `mcp_tools` catalog (36 tools enumerated)

## Counts

- 36 MCP tools (was 35) — adds `simplify_mesh`
- 23 unit tests + 21 integration tests = **44 passing tests** (was 36)
- All 26 tools from #6 are now built

🤖 Generated with [Claude Code](https://claude.com/claude-code)
