### PR TITLE
Port OCCTMCP to Swift MCP SDK (Swift Package Index–publishable)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,8 @@ node_modules/
 dist/
 *.js.map
 .DS_Store
+
+# Swift / SPM
+.build/
+.swiftpm/
+*.xcodeproj/

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "ade341498f1c57d8dde00422d084ad293a55be884b246a39206018b4bda8ca6d",
+  "originHash" : "3df91dd4f914c866163734d74da4febbeee15cee747232b3325f7a944cda6d06",
   "pins" : [
     {
       "identity" : "eventsource",
@@ -26,6 +26,24 @@
       "state" : {
         "revision" : "ceb6b91cec80a2988fd5ef08f908e379d4179ac3",
         "version" : "0.1.0"
+      }
+    },
+    {
+      "identity" : "occtswiftscripts",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/gsdali/OCCTSwiftScripts.git",
+      "state" : {
+        "revision" : "c8494d4a5c3ec2daf58a59e81845f3e12b5bffa7",
+        "version" : "0.8.1"
+      }
+    },
+    {
+      "identity" : "occtswiftviewport",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/gsdali/OCCTSwiftViewport.git",
+      "state" : {
+        "revision" : "aeac1d0d411614603fe34448e2e9befdaed0e032",
+        "version" : "0.50.0"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,0 +1,87 @@
+{
+  "originHash" : "ade341498f1c57d8dde00422d084ad293a55be884b246a39206018b4bda8ca6d",
+  "pins" : [
+    {
+      "identity" : "eventsource",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/mattt/eventsource.git",
+      "state" : {
+        "revision" : "a3a85a85214caf642abaa96ae664e4c772a59f6e",
+        "version" : "1.4.1"
+      }
+    },
+    {
+      "identity" : "occtswift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/gsdali/OCCTSwift.git",
+      "state" : {
+        "revision" : "23e753e555afb5ab691574cfc7402f4db42057fa",
+        "version" : "0.167.0"
+      }
+    },
+    {
+      "identity" : "occtswiftmesh",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/gsdali/OCCTSwiftMesh.git",
+      "state" : {
+        "revision" : "ceb6b91cec80a2988fd5ef08f908e379d4179ac3",
+        "version" : "0.1.0"
+      }
+    },
+    {
+      "identity" : "swift-atomics",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-atomics.git",
+      "state" : {
+        "revision" : "b601256eab081c0f92f059e12818ac1d4f178ff7",
+        "version" : "1.3.0"
+      }
+    },
+    {
+      "identity" : "swift-collections",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-collections.git",
+      "state" : {
+        "revision" : "6675bc0ff86e61436e615df6fc5174e043e57924",
+        "version" : "1.4.1"
+      }
+    },
+    {
+      "identity" : "swift-log",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-log.git",
+      "state" : {
+        "revision" : "5073617dac96330a486245e4c0179cb0a6fd2256",
+        "version" : "1.12.0"
+      }
+    },
+    {
+      "identity" : "swift-nio",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio.git",
+      "state" : {
+        "revision" : "f71c8d2a5e74a2c6d11a0fbe324774b5d6084237",
+        "version" : "2.99.0"
+      }
+    },
+    {
+      "identity" : "swift-sdk",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/modelcontextprotocol/swift-sdk.git",
+      "state" : {
+        "revision" : "6132fd4b5b4217ce4717c4775e4607f5c3120129",
+        "version" : "0.12.0"
+      }
+    },
+    {
+      "identity" : "swift-system",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-system.git",
+      "state" : {
+        "revision" : "7c6ad0fc39d0763e0b699210e4124afd5041c5df",
+        "version" : "1.6.4"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/Package.swift
+++ b/Package.swift
@@ -22,8 +22,15 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/modelcontextprotocol/swift-sdk.git", from: "0.11.0"),
-        .package(url: "https://github.com/gsdali/OCCTSwift.git", from: "0.156.3"),
+        // Floor 0.165.0 matches OCCTSwiftScripts' own pin (binary-target URL
+        // fix in OCCTSwift#97). Soak window for OCCT 8.0.0 beta1; bump to
+        // 1.0.0 on GA day.
+        .package(url: "https://github.com/gsdali/OCCTSwift.git", from: "0.165.0"),
         .package(url: "https://github.com/gsdali/OCCTSwiftMesh.git", from: "0.1.0"),
+        // ScriptHarness: ScriptManifest + BodyDescriptor types shared with
+        // occtkit. DrawingComposer: DrawingSpec + Composer.render for the
+        // generate_drawing tool.
+        .package(url: "https://github.com/gsdali/OCCTSwiftScripts.git", from: "0.8.1"),
     ],
     targets: [
         .target(
@@ -32,6 +39,8 @@ let package = Package(
                 .product(name: "MCP", package: "swift-sdk"),
                 .product(name: "OCCTSwift", package: "OCCTSwift"),
                 .product(name: "OCCTSwiftMesh", package: "OCCTSwiftMesh"),
+                .product(name: "ScriptHarness", package: "OCCTSwiftScripts"),
+                .product(name: "DrawingComposer", package: "OCCTSwiftScripts"),
             ],
             swiftSettings: [.swiftLanguageMode(.v6)]
         ),

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,53 @@
+// swift-tools-version: 6.0
+//
+// OCCTMCP — Swift port of the Node MCP server. Coexists with the original
+// TypeScript implementation under src/ during the migration; once feature
+// parity is reached the Node code can be removed.
+//
+// SwiftPM expects test sources under Tests/<TargetName>, but this repo's
+// existing TypeScript test directory is `tests/` and the volume is
+// case-insensitive (APFS default), so we point SPM at SwiftTests/ to avoid
+// the clash.
+
+import PackageDescription
+
+let package = Package(
+    name: "OCCTMCP",
+    platforms: [
+        .macOS(.v15),
+    ],
+    products: [
+        .library(name: "OCCTMCPCore", targets: ["OCCTMCPCore"]),
+        .executable(name: "occtmcp-server", targets: ["OCCTMCPServer"]),
+    ],
+    dependencies: [
+        .package(url: "https://github.com/modelcontextprotocol/swift-sdk.git", from: "0.11.0"),
+        .package(url: "https://github.com/gsdali/OCCTSwift.git", from: "0.156.3"),
+        .package(url: "https://github.com/gsdali/OCCTSwiftMesh.git", from: "0.1.0"),
+    ],
+    targets: [
+        .target(
+            name: "OCCTMCPCore",
+            dependencies: [
+                .product(name: "MCP", package: "swift-sdk"),
+                .product(name: "OCCTSwift", package: "OCCTSwift"),
+                .product(name: "OCCTSwiftMesh", package: "OCCTSwiftMesh"),
+            ],
+            swiftSettings: [.swiftLanguageMode(.v6)]
+        ),
+        .executableTarget(
+            name: "OCCTMCPServer",
+            dependencies: [
+                "OCCTMCPCore",
+                .product(name: "MCP", package: "swift-sdk"),
+            ],
+            swiftSettings: [.swiftLanguageMode(.v6)]
+        ),
+        .testTarget(
+            name: "OCCTMCPCoreTests",
+            dependencies: ["OCCTMCPCore"],
+            path: "SwiftTests/OCCTMCPCoreTests",
+            swiftSettings: [.swiftLanguageMode(.v6)]
+        ),
+    ]
+)

--- a/README.md
+++ b/README.md
@@ -108,6 +108,15 @@ The LLM has full access to OCCTSwift's 900+ CAD operations: primitives, booleans
 
 ## Setup
 
+Two implementations live in this repo, side-by-side:
+
+- **Node / TypeScript** (`src/`, `dist/`) — the production server. Shells out to the `occtkit` CLI for everything Swift-side. 36 tools, including `execute_script`.
+- **Swift** (`Sources/`, `Package.swift`) — an in-process port using the [official Swift MCP SDK](https://swiftpackageindex.com/modelcontextprotocol/swift-sdk). Currently 32 of 36 tools, all running directly against OCCTSwift / OCCTSwiftMesh / DrawingComposer with no subprocess. `execute_script`, `set_assembly_metadata`, `render_preview`, `check_thickness`, and `graph_ml` are still pending.
+
+Pick whichever fits your platform: Node runs anywhere; the Swift binary is macOS-only (since OCCT.xcframework targets arm64 macOS 12+ / iOS 15+) but eliminates the cold-start of the SwiftPM workspace and the JSONL marshalling overhead.
+
+### Node implementation
+
 ```bash
 git clone https://github.com/gsdali/OCCTMCP.git
 cd OCCTMCP
@@ -115,9 +124,7 @@ npm install
 npm run build
 ```
 
-### Add to Claude Code
-
-Create or edit `.mcp.json` in your project:
+In Claude Code's `.mcp.json`:
 
 ```json
 {
@@ -129,6 +136,26 @@ Create or edit `.mcp.json` in your project:
   }
 }
 ```
+
+### Swift implementation
+
+```bash
+swift build -c release
+```
+
+In `.mcp.json`:
+
+```json
+{
+  "mcpServers": {
+    "occtmcp": {
+      "command": "/path/to/OCCTMCP/.build/release/occtmcp-server"
+    }
+  }
+}
+```
+
+The Swift package is intended for [Swift Package Index](https://swiftpackageindex.com) publication once `execute_script` lands and the integration test suite is in place. Track progress in [PR #11](https://github.com/gsdali/OCCTMCP/pull/11) and the follow-up Phase 5.4 work.
 
 ## Example
 

--- a/Sources/OCCTMCPCore/Manifest.swift
+++ b/Sources/OCCTMCPCore/Manifest.swift
@@ -1,0 +1,63 @@
+// Manifest helpers — read / write `manifest.json` under the resolved
+// output directory. Re-uses `ScriptManifest` and `BodyDescriptor` from
+// ScriptHarness so the on-disk format is identical to whatever
+// occtkit / ScriptContext write.
+
+import Foundation
+import ScriptHarness
+
+public struct ManifestStore: Sendable {
+    public let path: String
+
+    public init(path: String = OCCTMCPPaths.manifestPath()) {
+        self.path = path
+    }
+
+    /// Load the manifest from disk, or nil if the file does not exist.
+    /// Throws if the file exists but cannot be parsed.
+    public func read() throws -> ScriptManifest? {
+        let url = URL(fileURLWithPath: path)
+        guard FileManager.default.fileExists(atPath: path) else {
+            return nil
+        }
+        let data = try Data(contentsOf: url)
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        return try decoder.decode(ScriptManifest.self, from: data)
+    }
+
+    /// Write the manifest to disk with an updated timestamp.
+    public func write(_ manifest: ScriptManifest) throws {
+        let bumped = manifest.withRefreshedTimestamp()
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        let data = try encoder.encode(bumped)
+        let url = URL(fileURLWithPath: path)
+        try FileManager.default.createDirectory(
+            at: url.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try data.write(to: url, options: .atomic)
+    }
+}
+
+extension ScriptManifest {
+    /// Return a copy with `timestamp` reset to now. The struct is value-
+    /// type and immutable so this is the natural mutation primitive.
+    public func withRefreshedTimestamp() -> ScriptManifest {
+        return ScriptManifest(
+            version: self.version,
+            timestamp: Date(),
+            description: self.description,
+            bodies: self.bodies,
+            graphs: self.graphs,
+            metadata: self.metadata
+        )
+    }
+
+    /// Locate a body by its `id`. Returns nil when not found.
+    public func body(withId id: String) -> BodyDescriptor? {
+        return bodies.first { $0.id == id }
+    }
+}

--- a/Sources/OCCTMCPCore/Paths.swift
+++ b/Sources/OCCTMCPCore/Paths.swift
@@ -1,0 +1,33 @@
+// Paths — output directory and manifest path resolution. Mirrors the
+// Node implementation in src/paths.ts: env override > iCloud Drive >
+// local fallback. Tests redirect via OCCTMCP_OUTPUT_DIR.
+
+import Foundation
+
+public enum OCCTMCPPaths {
+    public static let envOverrideKey = "OCCTMCP_OUTPUT_DIR"
+
+    /// Resolve the output directory for the current process.
+    /// Resolution order:
+    ///   1. `OCCTMCP_OUTPUT_DIR` env var (used by the test suite).
+    ///   2. iCloud Drive container if it exists
+    ///      (`~/Library/Mobile Documents/com~apple~CloudDocs/OCCTSwiftScripts/output`).
+    ///   3. Local fallback (`~/.occtswift-scripts/output`).
+    public static func outputDir(env: [String: String] = ProcessInfo.processInfo.environment) -> String {
+        if let override = env[envOverrideKey], !override.isEmpty {
+            return override
+        }
+        let home = NSString(string: "~").expandingTildeInPath
+        let icloudParent = "\(home)/Library/Mobile Documents/com~apple~CloudDocs"
+        let icloud = "\(icloudParent)/OCCTSwiftScripts/output"
+        if FileManager.default.fileExists(atPath: icloudParent) {
+            return icloud
+        }
+        return "\(home)/.occtswift-scripts/output"
+    }
+
+    /// Path to manifest.json inside the resolved output directory.
+    public static func manifestPath(env: [String: String] = ProcessInfo.processInfo.environment) -> String {
+        return outputDir(env: env) + "/manifest.json"
+    }
+}

--- a/Sources/OCCTMCPCore/SceneHistory.swift
+++ b/Sources/OCCTMCPCore/SceneHistory.swift
@@ -1,0 +1,40 @@
+// SceneHistory — in-memory ring buffer of recent manifest snapshots.
+// `compare_versions` reads from it; every scene-mutating tool (and
+// execute_script once it's ported) calls `snapshot()` *before*
+// mutating so the next compare can diff current vs prior.
+//
+// Singleton wrapped in an actor so it's safe to call from any
+// concurrent tool handler.
+
+import Foundation
+import ScriptHarness
+
+public actor SceneHistory {
+    public static let shared = SceneHistory()
+
+    public static let maxSnapshots = 10
+
+    private var snapshots: [ScriptManifest] = []
+
+    /// Capture the current manifest into the ring. No-op if the
+    /// manifest doesn't exist or fails to parse.
+    public func snapshot(store: ManifestStore = ManifestStore()) async {
+        guard let manifest = try? store.read() else { return }
+        snapshots.append(manifest)
+        if snapshots.count > Self.maxSnapshots {
+            snapshots.removeFirst()
+        }
+    }
+
+    public func count() -> Int { snapshots.count }
+
+    public func clear() { snapshots.removeAll() }
+
+    /// Return the snapshot from `since` runs back, or nil when the
+    /// history is shallower than that.
+    public func snapshot(since: Int) -> ScriptManifest? {
+        let idx = snapshots.count - since
+        guard idx >= 0, idx < snapshots.count else { return nil }
+        return snapshots[idx]
+    }
+}

--- a/Sources/OCCTMCPCore/SceneHistory.swift
+++ b/Sources/OCCTMCPCore/SceneHistory.swift
@@ -14,6 +14,8 @@ public actor SceneHistory {
 
     public static let maxSnapshots = 10
 
+    public init() {}
+
     private var snapshots: [ScriptManifest] = []
 
     /// Capture the current manifest into the ring. No-op if the

--- a/Sources/OCCTMCPCore/Server.swift
+++ b/Sources/OCCTMCPCore/Server.swift
@@ -170,6 +170,56 @@ func catalogTools() -> [Tool] {
             ])
         ),
         Tool(
+            name: "transform_body",
+            description: "Apply translate / rotate / uniform-scale to a scene body. Without outputBodyId, replaces in place; with outputBodyId, adds a new body.",
+            inputSchema: .object([
+                "type": .string("object"),
+                "properties": .object([
+                    "bodyId": .object(["type": .string("string")]),
+                    "translate": .object([
+                        "type": .string("array"),
+                        "items": .object(["type": .string("number")]),
+                        "minItems": .int(3), "maxItems": .int(3),
+                    ]),
+                    "rotateAxisAngle": .object([
+                        "type": .string("array"),
+                        "items": .object(["type": .string("number")]),
+                        "minItems": .int(4), "maxItems": .int(4),
+                        "description": .string("[axisX, axisY, axisZ, radians]"),
+                    ]),
+                    "rotateEulerXyz": .object([
+                        "type": .string("array"),
+                        "items": .object(["type": .string("number")]),
+                        "minItems": .int(3), "maxItems": .int(3),
+                    ]),
+                    "scale": .object(["type": .string("number")]),
+                    "inPlace": .object(["type": .string("boolean")]),
+                    "outputBodyId": .object(["type": .string("string")]),
+                ]),
+                "required": .array([.string("bodyId")]),
+                "additionalProperties": .bool(false),
+            ])
+        ),
+        Tool(
+            name: "boolean_op",
+            description: "Boolean op (union / subtract / intersect / split) between two scene bodies. Output is added as a new body.",
+            inputSchema: .object([
+                "type": .string("object"),
+                "properties": .object([
+                    "op": .object([
+                        "type": .string("string"),
+                        "enum": .array([.string("union"), .string("subtract"), .string("intersect"), .string("split")]),
+                    ]),
+                    "aBodyId": .object(["type": .string("string")]),
+                    "bBodyId": .object(["type": .string("string")]),
+                    "outputBodyId": .object(["type": .string("string")]),
+                    "removeInputs": .object(["type": .string("boolean")]),
+                ]),
+                "required": .array([.string("op"), .string("aBodyId"), .string("bBodyId")]),
+                "additionalProperties": .bool(false),
+            ])
+        ),
+        Tool(
             name: "compare_versions",
             description: "Diff the current scene against a snapshot from N runs ago. Detects added / removed / appearance-changed / file-changed bodies.",
             inputSchema: .object([
@@ -255,6 +305,43 @@ func dispatch(callName: String, arguments: [String: Value]) async -> CallTool.Re
         let computeContacts = arguments["computeContacts"]?.boolValue ?? false
         return await IntrospectionTools.measureDistance(
             fromBodyId: fromId, toBodyId: toId, computeContacts: computeContacts
+        ).asCallToolResult()
+
+    case "transform_body":
+        guard let bodyId = arguments["bodyId"]?.stringValue else {
+            return ToolText("transform_body requires `bodyId`.", isError: true).asCallToolResult()
+        }
+        var opts = ConstructionTools.TransformOptions()
+        if let arr = arguments["translate"]?.arrayValue, arr.count == 3,
+           let x = arr[0].doubleValue, let y = arr[1].doubleValue, let z = arr[2].doubleValue {
+            opts.translate = SIMD3(x, y, z)
+        }
+        if let arr = arguments["rotateAxisAngle"]?.arrayValue, arr.count == 4,
+           let x = arr[0].doubleValue, let y = arr[1].doubleValue, let z = arr[2].doubleValue,
+           let r = arr[3].doubleValue {
+            opts.rotateAxisAngle = (SIMD3(x, y, z), r)
+        }
+        if let arr = arguments["rotateEulerXyz"]?.arrayValue, arr.count == 3,
+           let x = arr[0].doubleValue, let y = arr[1].doubleValue, let z = arr[2].doubleValue {
+            opts.rotateEulerXyz = SIMD3(x, y, z)
+        }
+        opts.scale = arguments["scale"]?.doubleValue
+        opts.inPlace = arguments["inPlace"]?.boolValue
+        opts.outputBodyId = arguments["outputBodyId"]?.stringValue
+        return await ConstructionTools.transformBody(bodyId: bodyId, options: opts).asCallToolResult()
+
+    case "boolean_op":
+        guard let opStr = arguments["op"]?.stringValue,
+              let op = ConstructionTools.BooleanOp(rawValue: opStr),
+              let a = arguments["aBodyId"]?.stringValue,
+              let b = arguments["bBodyId"]?.stringValue else {
+            return ToolText("boolean_op requires `op`, `aBodyId`, `bBodyId`.", isError: true).asCallToolResult()
+        }
+        return await ConstructionTools.booleanOp(
+            op: op,
+            aBodyId: a, bBodyId: b,
+            outputBodyId: arguments["outputBodyId"]?.stringValue,
+            removeInputs: arguments["removeInputs"]?.boolValue ?? false
         ).asCallToolResult()
 
     case "compare_versions":

--- a/Sources/OCCTMCPCore/Server.swift
+++ b/Sources/OCCTMCPCore/Server.swift
@@ -220,6 +220,133 @@ func catalogTools() -> [Tool] {
             ])
         ),
         Tool(
+            name: "mirror_or_pattern",
+            description: "Mirror / linear / circular pattern of a body. Output is a single (possibly compound) body added to the scene.",
+            inputSchema: .object([
+                "type": .string("object"),
+                "properties": .object([
+                    "bodyId": .object(["type": .string("string")]),
+                    "kind": .object([
+                        "type": .string("string"),
+                        "enum": .array([.string("mirror"), .string("linear"), .string("circular")]),
+                    ]),
+                    "params": .object([
+                        "type": .string("object"),
+                        "description": .string("Mirror: planeNormal (required), planeOrigin (optional). Linear: direction, spacing, count. Circular: axisOrigin, axisDirection, totalCount, totalAngle (optional)."),
+                    ]),
+                    "outputBodyId": .object(["type": .string("string")]),
+                ]),
+                "required": .array([.string("bodyId"), .string("kind"), .string("params")]),
+                "additionalProperties": .bool(false),
+            ])
+        ),
+        Tool(
+            name: "generate_mesh",
+            description: "Tessellate a scene body into triangles + quality metrics. Optionally inline geometry or write to .stl/.obj.",
+            inputSchema: .object([
+                "type": .string("object"),
+                "properties": .object([
+                    "bodyId": .object(["type": .string("string")]),
+                    "linearDeflection": .object(["type": .string("number")]),
+                    "angularDeflection": .object(["type": .string("number")]),
+                    "returnGeometry": .object(["type": .string("boolean")]),
+                    "outputPath": .object(["type": .string("string")]),
+                ]),
+                "required": .array([.string("bodyId")]),
+                "additionalProperties": .bool(false),
+            ])
+        ),
+        Tool(
+            name: "simplify_mesh",
+            description: "QEM mesh decimation via OCCTSwiftMesh (vendored meshoptimizer). Outputs .stl or .obj.",
+            inputSchema: .object([
+                "type": .string("object"),
+                "properties": .object([
+                    "bodyId": .object(["type": .string("string")]),
+                    "outputPath": .object(["type": .string("string")]),
+                    "targetTriangleCount": .object(["type": .string("integer"), "minimum": .int(1)]),
+                    "targetReduction": .object(["type": .string("number")]),
+                    "preserveBoundary": .object(["type": .string("boolean")]),
+                    "preserveTopology": .object(["type": .string("boolean")]),
+                    "maxHausdorffDistance": .object(["type": .string("number")]),
+                    "linearDeflection": .object(["type": .string("number")]),
+                    "angularDeflection": .object(["type": .string("number")]),
+                ]),
+                "required": .array([.string("bodyId"), .string("outputPath")]),
+                "additionalProperties": .bool(false),
+            ])
+        ),
+        Tool(
+            name: "heal_shape",
+            description: "Heal imported / non-watertight geometry via OCCT ShapeFix. Returns before/after stats.",
+            inputSchema: .object([
+                "type": .string("object"),
+                "properties": .object([
+                    "bodyId": .object(["type": .string("string")]),
+                    "outputBodyId": .object(["type": .string("string")]),
+                ]),
+                "required": .array([.string("bodyId")]),
+                "additionalProperties": .bool(false),
+            ])
+        ),
+        Tool(
+            name: "read_brep",
+            description: "Add a .brep from disk to the scene as a new body.",
+            inputSchema: .object([
+                "type": .string("object"),
+                "properties": .object([
+                    "inputPath": .object(["type": .string("string")]),
+                    "bodyId": .object(["type": .string("string")]),
+                    "color": .object([
+                        "type": .string("array"),
+                        "items": .object(["type": .string("number")]),
+                    ]),
+                ]),
+                "required": .array([.string("inputPath")]),
+                "additionalProperties": .bool(false),
+            ])
+        ),
+        Tool(
+            name: "import_file",
+            description: "Multi-format CAD import (STEP / IGES / BREP). Adds the imported shape as a single body.",
+            inputSchema: .object([
+                "type": .string("object"),
+                "properties": .object([
+                    "inputPath": .object(["type": .string("string")]),
+                    "format": .object([
+                        "type": .string("string"),
+                        "enum": .array([.string("auto"), .string("step"), .string("iges"), .string("obj"), .string("brep")]),
+                    ]),
+                    "idPrefix": .object(["type": .string("string")]),
+                ]),
+                "required": .array([.string("inputPath")]),
+                "additionalProperties": .bool(false),
+            ])
+        ),
+        Tool(
+            name: "export_scene",
+            description: "Export the current scene (or a subset) to step / iges / brep / stl / obj / gltf / glb.",
+            inputSchema: .object([
+                "type": .string("object"),
+                "properties": .object([
+                    "format": .object([
+                        "type": .string("string"),
+                        "enum": .array([
+                            .string("step"), .string("iges"), .string("brep"),
+                            .string("stl"), .string("obj"), .string("gltf"), .string("glb"),
+                        ]),
+                    ]),
+                    "outputPath": .object(["type": .string("string")]),
+                    "bodyIds": .object([
+                        "type": .string("array"),
+                        "items": .object(["type": .string("string")]),
+                    ]),
+                ]),
+                "required": .array([.string("format"), .string("outputPath")]),
+                "additionalProperties": .bool(false),
+            ])
+        ),
+        Tool(
             name: "compare_versions",
             description: "Diff the current scene against a snapshot from N runs ago. Detects added / removed / appearance-changed / file-changed bodies.",
             inputSchema: .object([
@@ -343,6 +470,112 @@ func dispatch(callName: String, arguments: [String: Value]) async -> CallTool.Re
             outputBodyId: arguments["outputBodyId"]?.stringValue,
             removeInputs: arguments["removeInputs"]?.boolValue ?? false
         ).asCallToolResult()
+
+    case "mirror_or_pattern":
+        guard let bodyId = arguments["bodyId"]?.stringValue,
+              let kindStr = arguments["kind"]?.stringValue,
+              let kind = ConstructionTools.PatternKind(rawValue: kindStr) else {
+            return ToolText("mirror_or_pattern requires `bodyId` and `kind`.", isError: true).asCallToolResult()
+        }
+        var p = ConstructionTools.PatternParams()
+        if case .object(let f)? = arguments["params"] {
+            if let arr = f["planeOrigin"]?.arrayValue, arr.count == 3,
+               let x = arr[0].doubleValue, let y = arr[1].doubleValue, let z = arr[2].doubleValue {
+                p.planeOrigin = SIMD3(x, y, z)
+            }
+            if let arr = f["planeNormal"]?.arrayValue, arr.count == 3,
+               let x = arr[0].doubleValue, let y = arr[1].doubleValue, let z = arr[2].doubleValue {
+                p.planeNormal = SIMD3(x, y, z)
+            }
+            if let arr = f["direction"]?.arrayValue, arr.count == 3,
+               let x = arr[0].doubleValue, let y = arr[1].doubleValue, let z = arr[2].doubleValue {
+                p.direction = SIMD3(x, y, z)
+            }
+            p.spacing = f["spacing"]?.doubleValue
+            p.count = f["count"]?.intValue
+            if let arr = f["axisOrigin"]?.arrayValue, arr.count == 3,
+               let x = arr[0].doubleValue, let y = arr[1].doubleValue, let z = arr[2].doubleValue {
+                p.axisOrigin = SIMD3(x, y, z)
+            }
+            if let arr = f["axisDirection"]?.arrayValue, arr.count == 3,
+               let x = arr[0].doubleValue, let y = arr[1].doubleValue, let z = arr[2].doubleValue {
+                p.axisDirection = SIMD3(x, y, z)
+            }
+            p.totalCount = f["totalCount"]?.intValue
+            p.totalAngle = f["totalAngle"]?.doubleValue
+        }
+        return await ConstructionTools.mirrorOrPattern(
+            bodyId: bodyId, kind: kind, params: p,
+            outputBodyId: arguments["outputBodyId"]?.stringValue
+        ).asCallToolResult()
+
+    case "generate_mesh":
+        guard let bodyId = arguments["bodyId"]?.stringValue else {
+            return ToolText("generate_mesh requires `bodyId`.", isError: true).asCallToolResult()
+        }
+        return await MeshTools.generateMesh(
+            bodyId: bodyId,
+            linearDeflection: arguments["linearDeflection"]?.doubleValue ?? 0.1,
+            angularDeflection: arguments["angularDeflection"]?.doubleValue ?? 0.5,
+            returnGeometry: arguments["returnGeometry"]?.boolValue ?? false,
+            outputPath: arguments["outputPath"]?.stringValue
+        ).asCallToolResult()
+
+    case "simplify_mesh":
+        guard let bodyId = arguments["bodyId"]?.stringValue,
+              let outputPath = arguments["outputPath"]?.stringValue else {
+            return ToolText("simplify_mesh requires `bodyId` and `outputPath`.", isError: true).asCallToolResult()
+        }
+        return await MeshTools.simplifyMesh(
+            bodyId: bodyId, outputPath: outputPath,
+            targetTriangleCount: arguments["targetTriangleCount"]?.intValue,
+            targetReduction: arguments["targetReduction"]?.doubleValue,
+            preserveBoundary: arguments["preserveBoundary"]?.boolValue ?? true,
+            preserveTopology: arguments["preserveTopology"]?.boolValue ?? true,
+            maxHausdorffDistance: arguments["maxHausdorffDistance"]?.doubleValue,
+            linearDeflection: arguments["linearDeflection"]?.doubleValue ?? 0.1,
+            angularDeflection: arguments["angularDeflection"]?.doubleValue ?? 0.5
+        ).asCallToolResult()
+
+    case "heal_shape":
+        guard let bodyId = arguments["bodyId"]?.stringValue else {
+            return ToolText("heal_shape requires `bodyId`.", isError: true).asCallToolResult()
+        }
+        return await HealingTools.healShape(
+            bodyId: bodyId,
+            outputBodyId: arguments["outputBodyId"]?.stringValue
+        ).asCallToolResult()
+
+    case "read_brep":
+        guard let inputPath = arguments["inputPath"]?.stringValue else {
+            return ToolText("read_brep requires `inputPath`.", isError: true).asCallToolResult()
+        }
+        let color = arguments["color"]?.arrayValue?.compactMap { $0.doubleValue.flatMap { Float($0) } }
+        return await IOTools.readBrep(
+            inputPath: inputPath,
+            bodyId: arguments["bodyId"]?.stringValue,
+            color: color
+        ).asCallToolResult()
+
+    case "import_file":
+        guard let inputPath = arguments["inputPath"]?.stringValue else {
+            return ToolText("import_file requires `inputPath`.", isError: true).asCallToolResult()
+        }
+        let format = (arguments["format"]?.stringValue).flatMap(IOTools.ImportFormat.init(rawValue:)) ?? .auto
+        return await IOTools.importFile(
+            inputPath: inputPath,
+            format: format,
+            idPrefix: arguments["idPrefix"]?.stringValue ?? "imported"
+        ).asCallToolResult()
+
+    case "export_scene":
+        guard let formatStr = arguments["format"]?.stringValue,
+              let format = IOTools.ExportFormat(rawValue: formatStr),
+              let outputPath = arguments["outputPath"]?.stringValue else {
+            return ToolText("export_scene requires `format` and `outputPath`.", isError: true).asCallToolResult()
+        }
+        let ids = arguments["bodyIds"]?.arrayValue?.compactMap { $0.stringValue }
+        return await IOTools.exportScene(format: format, outputPath: outputPath, bodyIds: ids).asCallToolResult()
 
     case "compare_versions":
         let since = arguments["since"]?.intValue ?? 1

--- a/Sources/OCCTMCPCore/Server.swift
+++ b/Sources/OCCTMCPCore/Server.swift
@@ -1,0 +1,73 @@
+// OCCTMCPCore — server factory + tool registration for the OCCTMCP MCP
+// server. Tools are registered against a single Server instance via the
+// MCP SDK's withMethodHandler API.
+//
+// During the migration from the Node implementation, this module starts
+// minimal (one `ping` tool to verify wiring) and grows tool by tool as
+// each is ported in subsequent commits.
+
+import Foundation
+import MCP
+
+public enum OCCTMCPVersion {
+    public static let serverName = "occtmcp"
+    public static let serverVersion = "0.1.0"
+}
+
+/// Build a fully-configured MCP server with every OCCTMCP tool registered.
+/// Caller is responsible for `start(transport:)` and `waitUntilCompleted()`.
+public func makeOCCTMCPServer() async -> Server {
+    let server = Server(
+        name: OCCTMCPVersion.serverName,
+        version: OCCTMCPVersion.serverVersion,
+        capabilities: .init(
+            tools: .init(listChanged: false)
+        )
+    )
+    await registerTools(on: server)
+    return server
+}
+
+func registerTools(on server: Server) async {
+    let tools = catalogTools()
+
+    await server.withMethodHandler(ListTools.self) { _ in
+        return .init(tools: tools)
+    }
+
+    await server.withMethodHandler(CallTool.self) { params in
+        return await dispatch(callName: params.name, arguments: params.arguments ?? [:])
+    }
+}
+
+/// The static list of tools the server advertises. Each entry pairs a Tool
+/// descriptor (name + description + JSON-Schema input) with a handler that
+/// the dispatcher in `dispatch(callName:arguments:)` routes to.
+func catalogTools() -> [Tool] {
+    return [
+        Tool(
+            name: "ping",
+            description: "Sanity-check tool — returns 'pong' so callers can verify the OCCTMCP Swift server is alive. Replaced by real OCCTSwift-backed tools as the Swift port progresses.",
+            inputSchema: .object([
+                "type": .string("object"),
+                "properties": .object([:]),
+                "additionalProperties": .bool(false),
+            ])
+        ),
+    ]
+}
+
+func dispatch(callName: String, arguments: [String: Value]) async -> CallTool.Result {
+    switch callName {
+    case "ping":
+        return .init(
+            content: [.text(text: "pong", annotations: nil, _meta: nil)],
+            isError: false
+        )
+    default:
+        return .init(
+            content: [.text(text: "Unknown tool: \(callName)", annotations: nil, _meta: nil)],
+            isError: true
+        )
+    }
+}

--- a/Sources/OCCTMCPCore/Server.swift
+++ b/Sources/OCCTMCPCore/Server.swift
@@ -184,6 +184,53 @@ func catalogTools() -> [Tool] {
             ])
         ),
         Tool(
+            name: "apply_feature",
+            description: "Apply a single feature spec (drill / fillet / chamfer / extrude / revolve / thread / boolean) to a scene body via OCCTSwift's FeatureReconstructor. Without outputBodyId, replaces in place; with outputBodyId, adds a new body.",
+            inputSchema: .object([
+                "type": .string("object"),
+                "properties": .object([
+                    "bodyId": .object(["type": .string("string")]),
+                    "feature": .object([
+                        "type": .string("object"),
+                        "description": .string("FeatureSpec object with a 'kind' discriminator. See OCCTSwift/Sources/OCCTSwift/FeatureReconstructor.swift for the schema."),
+                    ]),
+                    "outputBodyId": .object(["type": .string("string")]),
+                ]),
+                "required": .array([.string("bodyId"), .string("feature")]),
+                "additionalProperties": .bool(false),
+            ])
+        ),
+        Tool(
+            name: "inspect_assembly",
+            description: "Walk an XCAF assembly hierarchy. Pass either a scene bodyId (BREP — degenerate single-node response) or an inputPath (STEP / IGES / XBF for the full tree).",
+            inputSchema: .object([
+                "type": .string("object"),
+                "properties": .object([
+                    "bodyId": .object(["type": .string("string")]),
+                    "inputPath": .object(["type": .string("string")]),
+                    "depth": .object(["type": .string("integer"), "minimum": .int(0)]),
+                ]),
+                "additionalProperties": .bool(false),
+            ])
+        ),
+        Tool(
+            name: "generate_drawing",
+            description: "Render a multi-view ISO 128-30 DXF technical drawing for a scene body. Pass a DrawingSpec object (sheet, title, views, sections, dimensions, ...). The tool injects shape + output into the spec.",
+            inputSchema: .object([
+                "type": .string("object"),
+                "properties": .object([
+                    "bodyId": .object(["type": .string("string")]),
+                    "outputPath": .object(["type": .string("string")]),
+                    "spec": .object([
+                        "type": .string("object"),
+                        "description": .string("DrawingSpec object: { sheet, title?, views, sections?, dimensions?, ... }. See OCCTSwiftScripts/Sources/DrawingComposer/Spec.swift."),
+                    ]),
+                ]),
+                "required": .array([.string("bodyId"), .string("outputPath"), .string("spec")]),
+                "additionalProperties": .bool(false),
+            ])
+        ),
+        Tool(
             name: "ping",
             description: "Sanity-check tool — returns 'pong' so callers can verify the OCCTMCP Swift server is alive.",
             inputSchema: .object([
@@ -514,6 +561,34 @@ func dispatch(callName: String, arguments: [String: Value]) async -> CallTool.Re
     switch callName {
     case "ping":
         return ToolText("pong").asCallToolResult()
+
+    case "apply_feature":
+        guard let bodyId = arguments["bodyId"]?.stringValue,
+              let feature = arguments["feature"] else {
+            return ToolText("apply_feature requires `bodyId` and `feature`.", isError: true).asCallToolResult()
+        }
+        return await FeatureTools.applyFeature(
+            bodyId: bodyId,
+            feature: feature,
+            outputBodyId: arguments["outputBodyId"]?.stringValue
+        ).asCallToolResult()
+
+    case "inspect_assembly":
+        return await AssemblyTools.inspectAssembly(
+            bodyId: arguments["bodyId"]?.stringValue,
+            inputPath: arguments["inputPath"]?.stringValue,
+            depth: arguments["depth"]?.intValue
+        ).asCallToolResult()
+
+    case "generate_drawing":
+        guard let bodyId = arguments["bodyId"]?.stringValue,
+              let outputPath = arguments["outputPath"]?.stringValue,
+              let spec = arguments["spec"] else {
+            return ToolText("generate_drawing requires `bodyId`, `outputPath`, `spec`.", isError: true).asCallToolResult()
+        }
+        return await DrawingTools.generateDrawing(
+            bodyId: bodyId, outputPath: outputPath, spec: spec
+        ).asCallToolResult()
 
     case "get_api_reference":
         let category = arguments["category"]?.stringValue ?? "mcp_tools"

--- a/Sources/OCCTMCPCore/Server.swift
+++ b/Sources/OCCTMCPCore/Server.swift
@@ -43,6 +43,95 @@ func registerTools(on server: Server) async {
 func catalogTools() -> [Tool] {
     return [
         Tool(
+            name: "get_scene",
+            description: "Read the current scene manifest (bodies, colors, materials).",
+            inputSchema: .object([
+                "type": .string("object"),
+                "properties": .object([:]),
+                "additionalProperties": .bool(false),
+            ])
+        ),
+        Tool(
+            name: "get_script",
+            description: "Return the source of the most recent Swift CAD script executed in this session.",
+            inputSchema: .object([
+                "type": .string("object"),
+                "properties": .object([:]),
+                "additionalProperties": .bool(false),
+            ])
+        ),
+        Tool(
+            name: "export_model",
+            description: "List exported model files (BREP, STEP, STL, OBJ, IGES, glTF, JSON) from the current output directory.",
+            inputSchema: .object([
+                "type": .string("object"),
+                "properties": .object([:]),
+                "additionalProperties": .bool(false),
+            ])
+        ),
+        Tool(
+            name: "validate_geometry",
+            description: "Per-body topology validation. Wraps GraphIO + TopologyGraph.validate() in-process.",
+            inputSchema: .object([
+                "type": .string("object"),
+                "properties": .object([
+                    "bodyId": .object([
+                        "type": .string("string"),
+                        "description": .string("Specific body to validate. If omitted, validates every BREP body."),
+                    ]),
+                ]),
+                "additionalProperties": .bool(false),
+            ])
+        ),
+        Tool(
+            name: "recognize_features",
+            description: "Detect pockets and holes via OCCTSwift's AAG heuristics.",
+            inputSchema: .object([
+                "type": .string("object"),
+                "properties": .object([
+                    "bodyId": .object(["type": .string("string")]),
+                    "kinds": .object([
+                        "type": .string("array"),
+                        "items": .object([
+                            "type": .string("string"),
+                            "enum": .array([.string("pocket"), .string("hole")]),
+                        ]),
+                    ]),
+                ]),
+                "required": .array([.string("bodyId")]),
+                "additionalProperties": .bool(false),
+            ])
+        ),
+        Tool(
+            name: "analyze_clearance",
+            description: "Pairwise interference / minimum-clearance check between 2+ bodies. Each pair gets minDistance + (optionally) up to 16 contacts.",
+            inputSchema: .object([
+                "type": .string("object"),
+                "properties": .object([
+                    "bodyIds": .object([
+                        "type": .string("array"),
+                        "minItems": .int(2),
+                        "items": .object(["type": .string("string")]),
+                    ]),
+                    "computeContacts": .object(["type": .string("boolean")]),
+                ]),
+                "required": .array([.string("bodyIds")]),
+                "additionalProperties": .bool(false),
+            ])
+        ),
+        Tool(
+            name: "graph_validate",
+            description: "Raw-path topology validation. Pass an absolute BREP path; use validate_geometry for the scene-aware version.",
+            inputSchema: .object([
+                "type": .string("object"),
+                "properties": .object([
+                    "brep_path": .object(["type": .string("string")]),
+                ]),
+                "required": .array([.string("brep_path")]),
+                "additionalProperties": .bool(false),
+            ])
+        ),
+        Tool(
             name: "ping",
             description: "Sanity-check tool — returns 'pong' so callers can verify the OCCTMCP Swift server is alive.",
             inputSchema: .object([
@@ -368,6 +457,42 @@ func dispatch(callName: String, arguments: [String: Value]) async -> CallTool.Re
     switch callName {
     case "ping":
         return ToolText("pong").asCallToolResult()
+
+    case "get_scene":
+        return await CoreTools.getScene().asCallToolResult()
+
+    case "get_script":
+        return await CoreTools.getScript().asCallToolResult()
+
+    case "export_model":
+        return await CoreTools.exportModel().asCallToolResult()
+
+    case "validate_geometry":
+        return await AnalysisTools.validateGeometry(
+            bodyId: arguments["bodyId"]?.stringValue
+        ).asCallToolResult()
+
+    case "recognize_features":
+        guard let bodyId = arguments["bodyId"]?.stringValue else {
+            return ToolText("recognize_features requires `bodyId`.", isError: true).asCallToolResult()
+        }
+        let kinds = arguments["kinds"]?.arrayValue?.compactMap { $0.stringValue }
+        return await AnalysisTools.recognizeFeatures(bodyId: bodyId, kinds: kinds).asCallToolResult()
+
+    case "analyze_clearance":
+        guard let ids = arguments["bodyIds"]?.arrayValue?.compactMap({ $0.stringValue }), !ids.isEmpty else {
+            return ToolText("analyze_clearance requires `bodyIds` array.", isError: true).asCallToolResult()
+        }
+        return await AnalysisTools.analyzeClearance(
+            bodyIds: ids,
+            computeContacts: arguments["computeContacts"]?.boolValue ?? true
+        ).asCallToolResult()
+
+    case "graph_validate":
+        guard let path = arguments["brep_path"]?.stringValue else {
+            return ToolText("graph_validate requires `brep_path`.", isError: true).asCallToolResult()
+        }
+        return await AnalysisTools.graphValidate(brepPath: path).asCallToolResult()
 
     case "remove_body":
         guard let bodyId = arguments["bodyId"]?.stringValue else {

--- a/Sources/OCCTMCPCore/Server.swift
+++ b/Sources/OCCTMCPCore/Server.swift
@@ -118,6 +118,58 @@ func catalogTools() -> [Tool] {
             ])
         ),
         Tool(
+            name: "compute_metrics",
+            description: "Compute volume / surface area / center of mass / bounding box / principal axes for a scene body. Direct OCCTSwift call, no occtkit subprocess.",
+            inputSchema: .object([
+                "type": .string("object"),
+                "properties": .object([
+                    "bodyId": .object(["type": .string("string")]),
+                    "metrics": .object([
+                        "type": .string("array"),
+                        "items": .object(["type": .string("string")]),
+                        "description": .string("Subset to compute. Default: all. Items: volume, surfaceArea, centerOfMass, boundingBox, principalAxes."),
+                    ]),
+                ]),
+                "required": .array([.string("bodyId")]),
+                "additionalProperties": .bool(false),
+            ])
+        ),
+        Tool(
+            name: "query_topology",
+            description: "Find faces / edges / vertices on a body matching criteria. Returns stable IDs (face[N], edge[N], vertex[N]).",
+            inputSchema: .object([
+                "type": .string("object"),
+                "properties": .object([
+                    "bodyId": .object(["type": .string("string")]),
+                    "entity": .object([
+                        "type": .string("string"),
+                        "enum": .array([.string("face"), .string("edge"), .string("vertex")]),
+                    ]),
+                    "filter": .object([
+                        "type": .string("object"),
+                        "description": .string("Optional: surfaceType, curveType, minArea, maxArea."),
+                    ]),
+                    "limit": .object(["type": .string("integer"), "minimum": .int(1)]),
+                ]),
+                "required": .array([.string("bodyId"), .string("entity")]),
+                "additionalProperties": .bool(false),
+            ])
+        ),
+        Tool(
+            name: "measure_distance",
+            description: "Minimum distance between two scene bodies. Pass computeContacts=true to also return up to 32 contact pairs.",
+            inputSchema: .object([
+                "type": .string("object"),
+                "properties": .object([
+                    "fromBodyId": .object(["type": .string("string")]),
+                    "toBodyId": .object(["type": .string("string")]),
+                    "computeContacts": .object(["type": .string("boolean")]),
+                ]),
+                "required": .array([.string("fromBodyId"), .string("toBodyId")]),
+                "additionalProperties": .bool(false),
+            ])
+        ),
+        Tool(
             name: "compare_versions",
             description: "Diff the current scene against a snapshot from N runs ago. Detects added / removed / appearance-changed / file-changed bodies.",
             inputSchema: .object([
@@ -169,6 +221,41 @@ func dispatch(callName: String, arguments: [String: Value]) async -> CallTool.Re
             name: arguments["name"]?.stringValue
         )
         return await SceneTools.setAppearance(bodyId: bodyId, update: update).asCallToolResult()
+
+    case "compute_metrics":
+        guard let bodyId = arguments["bodyId"]?.stringValue else {
+            return ToolText("compute_metrics requires `bodyId`.", isError: true).asCallToolResult()
+        }
+        let metricsArr = arguments["metrics"]?.arrayValue?.compactMap { $0.stringValue }
+        let metrics: Set<String>? = metricsArr.flatMap { $0.isEmpty ? nil : Set($0) }
+        return await IntrospectionTools.computeMetrics(bodyId: bodyId, metrics: metrics).asCallToolResult()
+
+    case "query_topology":
+        guard let bodyId = arguments["bodyId"]?.stringValue,
+              let entity = arguments["entity"]?.stringValue else {
+            return ToolText("query_topology requires `bodyId` and `entity`.", isError: true).asCallToolResult()
+        }
+        var filter = IntrospectionTools.TopologyFilter()
+        if case .object(let f)? = arguments["filter"] {
+            filter.surfaceType = f["surfaceType"]?.stringValue
+            filter.curveType = f["curveType"]?.stringValue
+            filter.minArea = f["minArea"]?.doubleValue
+            filter.maxArea = f["maxArea"]?.doubleValue
+        }
+        let limit = arguments["limit"]?.intValue
+        return await IntrospectionTools.queryTopology(
+            bodyId: bodyId, entity: entity, filter: filter, limit: limit
+        ).asCallToolResult()
+
+    case "measure_distance":
+        guard let fromId = arguments["fromBodyId"]?.stringValue,
+              let toId = arguments["toBodyId"]?.stringValue else {
+            return ToolText("measure_distance requires `fromBodyId` and `toBodyId`.", isError: true).asCallToolResult()
+        }
+        let computeContacts = arguments["computeContacts"]?.boolValue ?? false
+        return await IntrospectionTools.measureDistance(
+            fromBodyId: fromId, toBodyId: toId, computeContacts: computeContacts
+        ).asCallToolResult()
 
     case "compare_versions":
         let since = arguments["since"]?.intValue ?? 1

--- a/Sources/OCCTMCPCore/Server.swift
+++ b/Sources/OCCTMCPCore/Server.swift
@@ -2,9 +2,9 @@
 // server. Tools are registered against a single Server instance via the
 // MCP SDK's withMethodHandler API.
 //
-// During the migration from the Node implementation, this module starts
-// minimal (one `ping` tool to verify wiring) and grows tool by tool as
-// each is ported in subsequent commits.
+// The Swift port grows tool by tool, mirroring the existing Node
+// implementation under src/. Once the Swift side reaches feature parity
+// the Node code under src/ can be retired.
 
 import Foundation
 import MCP
@@ -40,17 +40,95 @@ func registerTools(on server: Server) async {
     }
 }
 
-/// The static list of tools the server advertises. Each entry pairs a Tool
-/// descriptor (name + description + JSON-Schema input) with a handler that
-/// the dispatcher in `dispatch(callName:arguments:)` routes to.
 func catalogTools() -> [Tool] {
     return [
         Tool(
             name: "ping",
-            description: "Sanity-check tool — returns 'pong' so callers can verify the OCCTMCP Swift server is alive. Replaced by real OCCTSwift-backed tools as the Swift port progresses.",
+            description: "Sanity-check tool — returns 'pong' so callers can verify the OCCTMCP Swift server is alive.",
             inputSchema: .object([
                 "type": .string("object"),
                 "properties": .object([:]),
+                "additionalProperties": .bool(false),
+            ])
+        ),
+        Tool(
+            name: "remove_body",
+            description: "Delete a body from the current scene by id. Removes the body's BREP file from the output directory and re-emits the manifest (triggers viewport reload).",
+            inputSchema: .object([
+                "type": .string("object"),
+                "properties": .object([
+                    "bodyId": .object([
+                        "type": .string("string"),
+                        "description": .string("The id of the body to remove."),
+                    ]),
+                ]),
+                "required": .array([.string("bodyId")]),
+                "additionalProperties": .bool(false),
+            ])
+        ),
+        Tool(
+            name: "clear_scene",
+            description: "Remove every body from the current scene. Optionally preserves the compare_versions history ring buffer.",
+            inputSchema: .object([
+                "type": .string("object"),
+                "properties": .object([
+                    "keepHistory": .object([
+                        "type": .string("boolean"),
+                        "description": .string("If true, keep the compare_versions history ring. Default false."),
+                    ]),
+                ]),
+                "additionalProperties": .bool(false),
+            ])
+        ),
+        Tool(
+            name: "rename_body",
+            description: "Change a body's id in the scene manifest. Fails if the new id is already in use.",
+            inputSchema: .object([
+                "type": .string("object"),
+                "properties": .object([
+                    "bodyId": .object(["type": .string("string")]),
+                    "newBodyId": .object(["type": .string("string")]),
+                ]),
+                "required": .array([.string("bodyId"), .string("newBodyId")]),
+                "additionalProperties": .bool(false),
+            ])
+        ),
+        Tool(
+            name: "set_appearance",
+            description: "Update color / opacity / roughness / metallic / display name for a scene body without re-running a script. The viewport reloads automatically.",
+            inputSchema: .object([
+                "type": .string("object"),
+                "properties": .object([
+                    "bodyId": .object(["type": .string("string")]),
+                    "color": .object([
+                        "type": .string("array"),
+                        "description": .string("RGBA or RGB array (0-1 per channel)."),
+                        "items": .object(["type": .string("number")]),
+                    ]),
+                    "opacity": .object([
+                        "type": .string("number"),
+                        "description": .string("Sets color alpha (0-1). Leaves RGB unchanged."),
+                    ]),
+                    "roughness": .object(["type": .string("number")]),
+                    "metallic": .object(["type": .string("number")]),
+                    "name": .object(["type": .string("string")]),
+                ]),
+                "required": .array([.string("bodyId")]),
+                "additionalProperties": .bool(false),
+            ])
+        ),
+        Tool(
+            name: "compare_versions",
+            description: "Diff the current scene against a snapshot from N runs ago. Detects added / removed / appearance-changed / file-changed bodies.",
+            inputSchema: .object([
+                "type": .string("object"),
+                "properties": .object([
+                    "since": .object([
+                        "type": .string("integer"),
+                        "minimum": .int(1),
+                        "description": .string("How many runs back to compare against. Default 1."),
+                    ]),
+                ]),
                 "additionalProperties": .bool(false),
             ])
         ),
@@ -60,14 +138,43 @@ func catalogTools() -> [Tool] {
 func dispatch(callName: String, arguments: [String: Value]) async -> CallTool.Result {
     switch callName {
     case "ping":
-        return .init(
-            content: [.text(text: "pong", annotations: nil, _meta: nil)],
-            isError: false
+        return ToolText("pong").asCallToolResult()
+
+    case "remove_body":
+        guard let bodyId = arguments["bodyId"]?.stringValue else {
+            return ToolText("remove_body requires `bodyId`.", isError: true).asCallToolResult()
+        }
+        return await SceneTools.removeBody(bodyId: bodyId).asCallToolResult()
+
+    case "clear_scene":
+        let keepHistory = arguments["keepHistory"]?.boolValue ?? false
+        return await SceneTools.clearScene(keepHistory: keepHistory).asCallToolResult()
+
+    case "rename_body":
+        guard let bodyId = arguments["bodyId"]?.stringValue,
+              let newBodyId = arguments["newBodyId"]?.stringValue else {
+            return ToolText("rename_body requires `bodyId` and `newBodyId`.", isError: true).asCallToolResult()
+        }
+        return await SceneTools.renameBody(bodyId: bodyId, newBodyId: newBodyId).asCallToolResult()
+
+    case "set_appearance":
+        guard let bodyId = arguments["bodyId"]?.stringValue else {
+            return ToolText("set_appearance requires `bodyId`.", isError: true).asCallToolResult()
+        }
+        let update = SceneTools.AppearanceUpdate(
+            color: arguments["color"]?.arrayValue?.compactMap { $0.doubleValue.flatMap { Float($0) } },
+            opacity: arguments["opacity"]?.doubleValue.flatMap { Float($0) },
+            roughness: arguments["roughness"]?.doubleValue.flatMap { Float($0) },
+            metallic: arguments["metallic"]?.doubleValue.flatMap { Float($0) },
+            name: arguments["name"]?.stringValue
         )
+        return await SceneTools.setAppearance(bodyId: bodyId, update: update).asCallToolResult()
+
+    case "compare_versions":
+        let since = arguments["since"]?.intValue ?? 1
+        return await SceneTools.compareVersions(since: since).asCallToolResult()
+
     default:
-        return .init(
-            content: [.text(text: "Unknown tool: \(callName)", annotations: nil, _meta: nil)],
-            isError: true
-        )
+        return ToolText("Unknown tool: \(callName)", isError: true).asCallToolResult()
     }
 }

--- a/Sources/OCCTMCPCore/Server.swift
+++ b/Sources/OCCTMCPCore/Server.swift
@@ -132,6 +132,58 @@ func catalogTools() -> [Tool] {
             ])
         ),
         Tool(
+            name: "graph_compact",
+            description: "Compact a BREP's topology graph (drops unreferenced nodes); writes the rebuilt shape to output_path.",
+            inputSchema: .object([
+                "type": .string("object"),
+                "properties": .object([
+                    "brep_path": .object(["type": .string("string")]),
+                    "output_path": .object(["type": .string("string")]),
+                ]),
+                "required": .array([.string("brep_path"), .string("output_path")]),
+                "additionalProperties": .bool(false),
+            ])
+        ),
+        Tool(
+            name: "graph_dedup",
+            description: "Deduplicate shared surface/curve geometry in a BREP's topology graph; writes the rebuilt shape to output_path.",
+            inputSchema: .object([
+                "type": .string("object"),
+                "properties": .object([
+                    "brep_path": .object(["type": .string("string")]),
+                    "output_path": .object(["type": .string("string")]),
+                ]),
+                "required": .array([.string("brep_path"), .string("output_path")]),
+                "additionalProperties": .bool(false),
+            ])
+        ),
+        Tool(
+            name: "feature_recognize",
+            description: "Detect pockets and holes via AAG heuristics. Pass an absolute BREP path; recognize_features is the scene-aware variant.",
+            inputSchema: .object([
+                "type": .string("object"),
+                "properties": .object([
+                    "brep_path": .object(["type": .string("string")]),
+                ]),
+                "required": .array([.string("brep_path")]),
+                "additionalProperties": .bool(false),
+            ])
+        ),
+        Tool(
+            name: "get_api_reference",
+            description: "Returns a catalog of every MCP tool this server exposes (category=mcp_tools), or a pointer to OCCTSwift docs for the OCCT API categories. Use mcp_tools for LLM auto-discovery.",
+            inputSchema: .object([
+                "type": .string("object"),
+                "properties": .object([
+                    "category": .object([
+                        "type": .string("string"),
+                        "description": .string("'mcp_tools' for the live tool catalog; any other value returns a pointer to the OCCTSwift sources / docs."),
+                    ]),
+                ]),
+                "additionalProperties": .bool(false),
+            ])
+        ),
+        Tool(
             name: "ping",
             description: "Sanity-check tool — returns 'pong' so callers can verify the OCCTMCP Swift server is alive.",
             inputSchema: .object([
@@ -453,10 +505,32 @@ func catalogTools() -> [Tool] {
     ]
 }
 
+struct ToolCatalog: Encodable {
+    let tools: [Tool]
+    let count: Int
+}
+
 func dispatch(callName: String, arguments: [String: Value]) async -> CallTool.Result {
     switch callName {
     case "ping":
         return ToolText("pong").asCallToolResult()
+
+    case "get_api_reference":
+        let category = arguments["category"]?.stringValue ?? "mcp_tools"
+        if category == "mcp_tools" {
+            let encoder = JSONEncoder()
+            encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+            let payload = ToolCatalog(tools: catalogTools(), count: catalogTools().count)
+            if let data = try? encoder.encode(payload),
+               let str = String(data: data, encoding: .utf8) {
+                return ToolText(str).asCallToolResult()
+            }
+            return ToolText("Failed to encode tool catalog.", isError: true).asCallToolResult()
+        }
+        return ToolText(
+            "OCCTSwift API documentation lives at https://github.com/gsdali/OCCTSwift — browse the public func declarations there. " +
+                "Pass category=\"mcp_tools\" to get this server's live tool catalog as JSON."
+        ).asCallToolResult()
 
     case "get_scene":
         return await CoreTools.getScene().asCallToolResult()
@@ -493,6 +567,26 @@ func dispatch(callName: String, arguments: [String: Value]) async -> CallTool.Re
             return ToolText("graph_validate requires `brep_path`.", isError: true).asCallToolResult()
         }
         return await AnalysisTools.graphValidate(brepPath: path).asCallToolResult()
+
+    case "graph_compact":
+        guard let inP = arguments["brep_path"]?.stringValue,
+              let outP = arguments["output_path"]?.stringValue else {
+            return ToolText("graph_compact requires `brep_path` and `output_path`.", isError: true).asCallToolResult()
+        }
+        return await AnalysisTools.graphCompact(brepPath: inP, outputPath: outP).asCallToolResult()
+
+    case "graph_dedup":
+        guard let inP = arguments["brep_path"]?.stringValue,
+              let outP = arguments["output_path"]?.stringValue else {
+            return ToolText("graph_dedup requires `brep_path` and `output_path`.", isError: true).asCallToolResult()
+        }
+        return await AnalysisTools.graphDedup(brepPath: inP, outputPath: outP).asCallToolResult()
+
+    case "feature_recognize":
+        guard let path = arguments["brep_path"]?.stringValue else {
+            return ToolText("feature_recognize requires `brep_path`.", isError: true).asCallToolResult()
+        }
+        return await AnalysisTools.featureRecognize(brepPath: path).asCallToolResult()
 
     case "remove_body":
         guard let bodyId = arguments["bodyId"]?.stringValue else {

--- a/Sources/OCCTMCPCore/Tools/AnalysisTools.swift
+++ b/Sources/OCCTMCPCore/Tools/AnalysisTools.swift
@@ -215,4 +215,103 @@ public enum AnalysisTools {
             return .init("graph_validate failed: \(error.localizedDescription)", isError: true)
         }
     }
+
+    public struct GraphCompactPayload: Encodable {
+        public let nodesBefore: Int
+        public let nodesAfter: Int
+        public let removed: Removed
+        public let output: String
+        public struct Removed: Encodable {
+            public let vertices: Int
+            public let edges: Int
+            public let faces: Int
+        }
+    }
+
+    public static func graphCompact(brepPath: String, outputPath: String) async -> ToolText {
+        guard FileManager.default.fileExists(atPath: brepPath) else {
+            return .init("BREP file not found: \(brepPath)")
+        }
+        do {
+            let shape = try Shape.loadBREP(fromPath: brepPath)
+            let graph = try GraphIO.buildGraph(from: shape)
+            let nodesBefore = graph.stats.totalNodes
+            let r = graph.compact()
+            guard let rebuilt = GraphIO.rebuildShape(from: graph) else {
+                return .init("graph_compact failed: rebuild produced nil shape.", isError: true)
+            }
+            try GraphIO.writeBREP(rebuilt, to: outputPath)
+            return IntrospectionTools.encode(GraphCompactPayload(
+                nodesBefore: nodesBefore,
+                nodesAfter: r.nodesAfter,
+                removed: .init(
+                    vertices: r.removedVertices,
+                    edges: r.removedEdges,
+                    faces: r.removedFaces
+                ),
+                output: outputPath
+            ))
+        } catch {
+            return .init("graph_compact failed: \(error.localizedDescription)", isError: true)
+        }
+    }
+
+    public struct GraphDedupPayload: Encodable {
+        public let canonicalSurfaces: Int
+        public let canonicalCurves: Int
+        public let surfaceRewrites: Int
+        public let curveRewrites: Int
+        public let output: String
+    }
+
+    public static func graphDedup(brepPath: String, outputPath: String) async -> ToolText {
+        guard FileManager.default.fileExists(atPath: brepPath) else {
+            return .init("BREP file not found: \(brepPath)")
+        }
+        do {
+            let shape = try Shape.loadBREP(fromPath: brepPath)
+            let graph = try GraphIO.buildGraph(from: shape)
+            let r = graph.deduplicate()
+            guard let rebuilt = GraphIO.rebuildShape(from: graph) else {
+                return .init("graph_dedup failed: rebuild produced nil shape.", isError: true)
+            }
+            try GraphIO.writeBREP(rebuilt, to: outputPath)
+            return IntrospectionTools.encode(GraphDedupPayload(
+                canonicalSurfaces: r.canonicalSurfaces,
+                canonicalCurves: r.canonicalCurves,
+                surfaceRewrites: r.surfaceRewrites,
+                curveRewrites: r.curveRewrites,
+                output: outputPath
+            ))
+        } catch {
+            return .init("graph_dedup failed: \(error.localizedDescription)", isError: true)
+        }
+    }
+
+    public static func featureRecognize(brepPath: String) async -> ToolText {
+        guard FileManager.default.fileExists(atPath: brepPath) else {
+            return .init("BREP file not found: \(brepPath)")
+        }
+        do {
+            let shape = try Shape.loadBREP(fromPath: brepPath)
+            let aag = AAG(shape: shape)
+            return IntrospectionTools.encode(FeatureReport(
+                bodyId: brepPath,
+                pockets: aag.detectPockets().map {
+                    .init(
+                        floorFaceIndex: $0.floorFaceIndex,
+                        wallFaceIndices: $0.wallFaceIndices,
+                        zLevel: $0.zLevel,
+                        depth: $0.depth,
+                        isOpen: $0.isOpen
+                    )
+                },
+                holes: aag.detectHoles().map {
+                    .init(faceIndex: $0.faceIndex, radius: $0.radius, depth: $0.depth)
+                }
+            ))
+        } catch {
+            return .init("feature_recognize failed: \(error.localizedDescription)", isError: true)
+        }
+    }
 }

--- a/Sources/OCCTMCPCore/Tools/AnalysisTools.swift
+++ b/Sources/OCCTMCPCore/Tools/AnalysisTools.swift
@@ -1,0 +1,218 @@
+// AnalysisTools — read-only inspection that goes one level deeper than
+// IntrospectionTools: graph validation, feature recognition, pairwise
+// clearance, plus the raw-path graph_* / feature_recognize tools that
+// match the Node side's lower-level surface.
+
+import Foundation
+import OCCTSwift
+import ScriptHarness
+
+public enum AnalysisTools {
+
+    // ── validate_geometry ──────────────────────────────────────────────
+
+    public struct ValidateReport: Encodable {
+        public let bodies: [BodyRecord]
+
+        public struct BodyRecord: Encodable {
+            public let id: String?
+            public let file: String
+            public let isValid: Bool?
+            public let errorCount: Int?
+            public let warningCount: Int?
+            public let error: String?
+        }
+    }
+
+    public static func validateGeometry(
+        bodyId: String? = nil,
+        store: ManifestStore = ManifestStore()
+    ) async -> ToolText {
+        guard let manifest = try? store.read() else {
+            return .init("No scene loaded. Run execute_script first.")
+        }
+        let outputDir = (store.path as NSString).deletingLastPathComponent
+        let targets: [BodyDescriptor]
+        if let id = bodyId {
+            guard let body = manifest.body(withId: id) else {
+                return .init("Body not found: \(id)")
+            }
+            targets = [body]
+        } else {
+            targets = manifest.bodies.filter { $0.format == "brep" }
+        }
+        if targets.isEmpty {
+            return .init("No BREP bodies in scene.")
+        }
+
+        var records: [ValidateReport.BodyRecord] = []
+        for body in targets {
+            let path = "\(outputDir)/\(body.file)"
+            do {
+                let shape = try Shape.loadBREP(fromPath: path)
+                let graph = try GraphIO.buildGraph(from: shape)
+                let report = GraphIO.ValidationReport(graph.validate())
+                records.append(.init(
+                    id: body.id,
+                    file: body.file,
+                    isValid: report.isValid,
+                    errorCount: report.errorCount,
+                    warningCount: report.warningCount,
+                    error: nil
+                ))
+            } catch {
+                records.append(.init(
+                    id: body.id,
+                    file: body.file,
+                    isValid: nil,
+                    errorCount: nil,
+                    warningCount: nil,
+                    error: error.localizedDescription
+                ))
+            }
+        }
+        return IntrospectionTools.encode(ValidateReport(bodies: records))
+    }
+
+    // ── recognize_features ─────────────────────────────────────────────
+
+    public struct FeatureReport: Encodable {
+        public let bodyId: String
+        public let pockets: [Pocket]
+        public let holes: [Hole]
+
+        public struct Pocket: Encodable {
+            public let floorFaceIndex: Int
+            public let wallFaceIndices: [Int]
+            public let zLevel: Double
+            public let depth: Double
+            public let isOpen: Bool
+        }
+        public struct Hole: Encodable {
+            public let faceIndex: Int
+            public let radius: Double
+            public let depth: Double
+        }
+    }
+
+    public static func recognizeFeatures(
+        bodyId: String,
+        kinds: [String]? = nil,
+        store: ManifestStore = ManifestStore()
+    ) async -> ToolText {
+        let loaded: (manifest: ScriptManifest, body: BodyDescriptor, shape: Shape, path: String)
+        do {
+            loaded = try IntrospectionTools.loadShape(bodyId: bodyId, store: store)
+        } catch {
+            return .init("\(error)")
+        }
+        let aag = AAG(shape: loaded.shape)
+        let wantPockets = kinds.map { $0.contains("pocket") } ?? true
+        let wantHoles = kinds.map { $0.contains("hole") } ?? true
+
+        let pockets = wantPockets ? aag.detectPockets().map {
+            FeatureReport.Pocket(
+                floorFaceIndex: $0.floorFaceIndex,
+                wallFaceIndices: $0.wallFaceIndices,
+                zLevel: $0.zLevel,
+                depth: $0.depth,
+                isOpen: $0.isOpen
+            )
+        } : []
+        let holes = wantHoles ? aag.detectHoles().map {
+            FeatureReport.Hole(faceIndex: $0.faceIndex, radius: $0.radius, depth: $0.depth)
+        } : []
+
+        return IntrospectionTools.encode(FeatureReport(
+            bodyId: bodyId,
+            pockets: pockets,
+            holes: holes
+        ))
+    }
+
+    // ── analyze_clearance ──────────────────────────────────────────────
+
+    public struct ClearanceReport: Encodable {
+        public let pairs: [Pair]
+        public struct Pair: Encodable {
+            public let a: String
+            public let b: String
+            public let minDistance: Double
+            public let intersects: Bool
+            public let contacts: [IntrospectionTools.DistanceReport.Contact]
+        }
+    }
+
+    public static func analyzeClearance(
+        bodyIds: [String],
+        computeContacts: Bool = true,
+        store: ManifestStore = ManifestStore()
+    ) async -> ToolText {
+        if bodyIds.count < 2 {
+            return .init("analyze_clearance needs at least 2 body ids; got \(bodyIds.count).")
+        }
+        var loaded: [(id: String, shape: Shape)] = []
+        for id in bodyIds {
+            do {
+                let l = try IntrospectionTools.loadShape(bodyId: id, store: store)
+                loaded.append((id, l.shape))
+            } catch {
+                return .init("\(error)")
+            }
+        }
+
+        var pairs: [ClearanceReport.Pair] = []
+        for i in 0..<loaded.count {
+            for j in (i + 1)..<loaded.count {
+                let a = loaded[i], b = loaded[j]
+                if computeContacts {
+                    guard let solutions = a.shape.allDistanceSolutions(to: b.shape, maxSolutions: 16) else {
+                        continue
+                    }
+                    let minD = solutions.map(\.distance).min() ?? .infinity
+                    let contacts = solutions.map {
+                        IntrospectionTools.DistanceReport.Contact(
+                            fromPoint: [$0.point1.x, $0.point1.y, $0.point1.z],
+                            toPoint: [$0.point2.x, $0.point2.y, $0.point2.z],
+                            distance: $0.distance
+                        )
+                    }
+                    pairs.append(.init(
+                        a: a.id, b: b.id,
+                        minDistance: minD,
+                        intersects: minD < 1e-9,
+                        contacts: contacts
+                    ))
+                } else {
+                    let minD = a.shape.minDistance(to: b.shape) ?? .infinity
+                    pairs.append(.init(
+                        a: a.id, b: b.id,
+                        minDistance: minD,
+                        intersects: minD < 1e-9,
+                        contacts: []
+                    ))
+                }
+            }
+        }
+        return IntrospectionTools.encode(ClearanceReport(pairs: pairs))
+    }
+
+    // ── graph_validate / graph_compact / graph_dedup ───────────────────
+    // Raw-path counterparts to validate_geometry (and the upstream
+    // graph-* occtkit verbs). Take a BREP path directly, return the
+    // GraphIO report verbatim.
+
+    public static func graphValidate(brepPath: String) async -> ToolText {
+        guard FileManager.default.fileExists(atPath: brepPath) else {
+            return .init("BREP file not found: \(brepPath)")
+        }
+        do {
+            let shape = try Shape.loadBREP(fromPath: brepPath)
+            let graph = try GraphIO.buildGraph(from: shape)
+            let report = GraphIO.ValidationReport(graph.validate())
+            return IntrospectionTools.encode(report)
+        } catch {
+            return .init("graph_validate failed: \(error.localizedDescription)", isError: true)
+        }
+    }
+}

--- a/Sources/OCCTMCPCore/Tools/AssemblyTools.swift
+++ b/Sources/OCCTMCPCore/Tools/AssemblyTools.swift
@@ -1,0 +1,177 @@
+// AssemblyTools — inspect_assembly walks an XCAF Document tree.
+// set_assembly_metadata is intentionally deferred to a follow-up: the
+// Document API in OCCTSwift v0.165 has setColor/setMaterial but no
+// comprehensive metadata-write surface yet.
+
+import Foundation
+import OCCTSwift
+import ScriptHarness
+
+public enum AssemblyTools {
+
+    public struct InspectReport: Encodable {
+        public let root: Node?
+        public let totalComponents: Int
+        public let totalInstances: Int
+        public let totalReferences: Int
+
+        public struct Node: Encodable {
+            public let id: String
+            public let name: String?
+            public let isAssembly: Bool
+            public let transform: [Float]
+            public let color: [Float]?
+            public let children: [Node]
+            public let referredTo: ReferredTo?
+        }
+        public struct ReferredTo: Encodable {
+            public let labelId: String
+            public let name: String?
+        }
+    }
+
+    public static func inspectAssembly(
+        bodyId: String? = nil,
+        inputPath: String? = nil,
+        depth: Int? = nil,
+        store: ManifestStore = ManifestStore()
+    ) async -> ToolText {
+        let path: String
+        if let p = inputPath {
+            guard FileManager.default.fileExists(atPath: p) else {
+                return .init("File not found: \(p)")
+            }
+            path = p
+        } else if let id = bodyId {
+            guard let manifest = try? store.read() else {
+                return .init("No scene loaded.")
+            }
+            guard let body = manifest.body(withId: id) else {
+                return .init("Body not found: \(id)")
+            }
+            let outputDir = (store.path as NSString).deletingLastPathComponent
+            path = "\(outputDir)/\(body.file)"
+        } else {
+            return .init("inspect_assembly requires either bodyId or inputPath.")
+        }
+
+        let ext = (path as NSString).pathExtension.lowercased()
+        // BREP files carry no XCAF metadata — return a degenerate
+        // single-node response so callers don't have to special-case.
+        if ext == "brep" {
+            return IntrospectionTools.encode(InspectReport(
+                root: .init(
+                    id: "label_0",
+                    name: (path as NSString).lastPathComponent,
+                    isAssembly: false,
+                    transform: identityTransform(),
+                    color: nil,
+                    children: [],
+                    referredTo: nil
+                ),
+                totalComponents: 1,
+                totalInstances: 0,
+                totalReferences: 0
+            ))
+        }
+
+        let document: Document
+        switch ext {
+        case "step", "stp":
+            guard let d = Document.loadSTEP(from: URL(fileURLWithPath: path), modes: STEPReaderModes()) else {
+                return .init("Failed to load STEP at \(path).", isError: true)
+            }
+            document = d
+        case "xbf":
+            do {
+                document = try Document.load(from: URL(fileURLWithPath: path))
+            } catch {
+                return .init("Failed to load XBF: \(error.localizedDescription)", isError: true)
+            }
+        default:
+            return .init("Unsupported extension '\(ext)' for inspect_assembly.")
+        }
+
+        var components = 0
+        var instances = 0
+        var references = 0
+        let roots = document.rootNodes
+        let nodes = roots.map { walk($0, currentDepth: 0, maxDepth: depth, components: &components, instances: &instances, references: &references) }
+
+        let root: InspectReport.Node?
+        if nodes.count == 1 {
+            root = nodes[0]
+        } else if !nodes.isEmpty {
+            // Synthetic root that wraps multiple top-level nodes.
+            root = .init(
+                id: "label_0",
+                name: (path as NSString).lastPathComponent,
+                isAssembly: true,
+                transform: identityTransform(),
+                color: nil,
+                children: nodes,
+                referredTo: nil
+            )
+        } else {
+            root = nil
+        }
+        return IntrospectionTools.encode(InspectReport(
+            root: root,
+            totalComponents: components,
+            totalInstances: instances,
+            totalReferences: references
+        ))
+    }
+
+    static func walk(
+        _ node: AssemblyNode,
+        currentDepth: Int,
+        maxDepth: Int?,
+        components: inout Int,
+        instances: inout Int,
+        references: inout Int
+    ) -> InspectReport.Node {
+        components += 1
+        if node.isReference { references += 1 }
+        if !node.isAssembly { instances += 1 }
+
+        let nextDepth = currentDepth + 1
+        let children: [InspectReport.Node]
+        if let m = maxDepth, currentDepth >= m {
+            children = []
+        } else {
+            children = node.children.map { walk($0, currentDepth: nextDepth, maxDepth: maxDepth, components: &components, instances: &instances, references: &references) }
+        }
+
+        let referredTo: InspectReport.ReferredTo? = node.referredNode.map {
+            .init(labelId: "label_\($0.labelId)", name: $0.name)
+        }
+        let colorArr: [Float]? = node.color.map {
+            [Float($0.red), Float($0.green), Float($0.blue), Float($0.alpha)]
+        }
+        return .init(
+            id: "label_\(node.labelId)",
+            name: node.name,
+            isAssembly: node.isAssembly,
+            transform: flatten(node.transform),
+            color: colorArr,
+            children: children,
+            referredTo: referredTo
+        )
+    }
+
+    static func flatten(_ m: simd_float4x4) -> [Float] {
+        return [
+            m.columns.0.x, m.columns.0.y, m.columns.0.z, m.columns.0.w,
+            m.columns.1.x, m.columns.1.y, m.columns.1.z, m.columns.1.w,
+            m.columns.2.x, m.columns.2.y, m.columns.2.z, m.columns.2.w,
+            m.columns.3.x, m.columns.3.y, m.columns.3.z, m.columns.3.w,
+        ]
+    }
+
+    static func identityTransform() -> [Float] {
+        return [1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1]
+    }
+}
+
+import simd

--- a/Sources/OCCTMCPCore/Tools/ConstructionTools.swift
+++ b/Sources/OCCTMCPCore/Tools/ConstructionTools.swift
@@ -1,0 +1,261 @@
+// ConstructionTools — scene-mutating tools that build new shapes from
+// existing ones via direct OCCTSwift calls. Each tool snapshots the
+// scene before mutating so compare_versions has prior state.
+//
+// Phase 5.3b covers transform_body and boolean_op. mirror_or_pattern
+// and apply_feature land alongside Phase 5.3c.
+
+import Foundation
+import OCCTSwift
+import ScriptHarness
+
+public enum ConstructionTools {
+
+    // ── transform_body ─────────────────────────────────────────────────
+
+    public struct TransformOptions {
+        public var translate: SIMD3<Double>?
+        public var rotateAxisAngle: (axis: SIMD3<Double>, radians: Double)?
+        public var rotateEulerXyz: SIMD3<Double>?
+        public var scale: Double?
+        public var inPlace: Bool?
+        public var outputBodyId: String?
+        public init(
+            translate: SIMD3<Double>? = nil,
+            rotateAxisAngle: (axis: SIMD3<Double>, radians: Double)? = nil,
+            rotateEulerXyz: SIMD3<Double>? = nil,
+            scale: Double? = nil,
+            inPlace: Bool? = nil,
+            outputBodyId: String? = nil
+        ) {
+            self.translate = translate
+            self.rotateAxisAngle = rotateAxisAngle
+            self.rotateEulerXyz = rotateEulerXyz
+            self.scale = scale
+            self.inPlace = inPlace
+            self.outputBodyId = outputBodyId
+        }
+    }
+
+    public static func transformBody(
+        bodyId: String,
+        options: TransformOptions,
+        store: ManifestStore = ManifestStore(),
+        history: SceneHistory = .shared
+    ) async -> ToolText {
+        guard let manifest = try? store.read() else {
+            return .init("No scene loaded. Run execute_script first.")
+        }
+        guard let body = manifest.body(withId: bodyId) else {
+            return .init("Body not found: \(bodyId)")
+        }
+        let outputDir = (store.path as NSString).deletingLastPathComponent
+        let inputPath = "\(outputDir)/\(body.file)"
+        guard FileManager.default.fileExists(atPath: inputPath) else {
+            return .init("BREP file missing: \(inputPath)")
+        }
+
+        let isInPlace = options.inPlace ?? (options.outputBodyId == nil)
+        if !isInPlace, let newId = options.outputBodyId,
+           manifest.bodies.contains(where: { $0.id == newId }) {
+            return .init("Output body id \"\(newId)\" already exists.")
+        }
+
+        let inputShape: Shape
+        do {
+            inputShape = try Shape.loadBREP(fromPath: inputPath)
+        } catch {
+            return .init("Failed to load BREP: \(error.localizedDescription)", isError: true)
+        }
+
+        var current: Shape = inputShape
+        if let t = options.translate {
+            guard let next = current.translated(by: t) else {
+                return .init("Translation failed.", isError: true)
+            }
+            current = next
+        }
+        if let r = options.rotateAxisAngle {
+            guard let next = current.rotated(axis: r.axis, angle: r.radians) else {
+                return .init("Rotation failed.", isError: true)
+            }
+            current = next
+        }
+        if let euler = options.rotateEulerXyz {
+            // extrinsic XYZ: Rx then Ry then Rz
+            for (axis, angle) in [
+                (SIMD3<Double>(1, 0, 0), euler.x),
+                (SIMD3<Double>(0, 1, 0), euler.y),
+                (SIMD3<Double>(0, 0, 1), euler.z),
+            ] where angle != 0 {
+                guard let next = current.rotated(axis: axis, angle: angle) else {
+                    return .init("Rotation failed.", isError: true)
+                }
+                current = next
+            }
+        }
+        if let s = options.scale {
+            guard let next = current.scaled(by: s) else {
+                return .init("Scale failed.", isError: true)
+            }
+            current = next
+        }
+
+        let outputPath: String
+        if isInPlace {
+            outputPath = inputPath
+        } else {
+            let id = options.outputBodyId ?? bodyId
+            outputPath = "\(outputDir)/xform-\(id)-\(shortUUID()).brep"
+        }
+        do {
+            try Exporter.writeBREP(shape: current, to: URL(fileURLWithPath: outputPath))
+        } catch {
+            return .init("Failed to write BREP: \(error.localizedDescription)", isError: true)
+        }
+
+        await history.snapshot(store: store)
+        if !isInPlace, let newId = options.outputBodyId {
+            let newFile = (outputPath as NSString).lastPathComponent
+            let newBodies = manifest.bodies + [BodyDescriptor(
+                id: newId,
+                file: newFile,
+                format: body.format,
+                name: body.name,
+                color: body.color,
+                roughness: body.roughness,
+                metallic: body.metallic
+            )]
+            let updated = ScriptManifest(
+                version: manifest.version,
+                timestamp: Date(),
+                description: manifest.description,
+                bodies: newBodies,
+                graphs: manifest.graphs,
+                metadata: manifest.metadata
+            )
+            try? store.write(updated)
+        } else {
+            // Manifest body file unchanged; bump timestamp so the watcher reloads.
+            try? store.write(manifest)
+        }
+
+        let summary = isInPlace
+            ? "Transformed \"\(bodyId)\" in place (\(body.file))."
+            : "Transformed \"\(bodyId)\" → new body \"\(options.outputBodyId!)\" → \((outputPath as NSString).lastPathComponent)"
+        return .init(summary)
+    }
+
+    // ── boolean_op ─────────────────────────────────────────────────────
+
+    public enum BooleanOp: String {
+        case union, subtract, intersect, split
+    }
+
+    public static func booleanOp(
+        op: BooleanOp,
+        aBodyId: String,
+        bBodyId: String,
+        outputBodyId: String? = nil,
+        removeInputs: Bool = false,
+        store: ManifestStore = ManifestStore(),
+        history: SceneHistory = .shared
+    ) async -> ToolText {
+        guard let manifest = try? store.read() else {
+            return .init("No scene loaded. Run execute_script first.")
+        }
+        guard let aBody = manifest.body(withId: aBodyId) else {
+            return .init("Body not found: \(aBodyId)")
+        }
+        guard let bBody = manifest.body(withId: bBodyId) else {
+            return .init("Body not found: \(bBodyId)")
+        }
+        let outId = outputBodyId ?? "\(op.rawValue)-\(aBodyId)-\(bBodyId)"
+        if manifest.bodies.contains(where: { $0.id == outId && $0.id != aBodyId && $0.id != bBodyId }) {
+            return .init("Output body id \"\(outId)\" already exists. Pass a different outputBodyId.")
+        }
+
+        let outputDir = (store.path as NSString).deletingLastPathComponent
+        let aShape: Shape
+        let bShape: Shape
+        do {
+            aShape = try Shape.loadBREP(fromPath: "\(outputDir)/\(aBody.file)")
+            bShape = try Shape.loadBREP(fromPath: "\(outputDir)/\(bBody.file)")
+        } catch {
+            return .init("Failed to load input BREP: \(error.localizedDescription)", isError: true)
+        }
+
+        let result: Shape?
+        switch op {
+        case .union:
+            result = aShape.union(bShape)
+        case .subtract:
+            result = aShape.subtracting(bShape)
+        case .intersect:
+            result = aShape.intersection(bShape)
+        case .split:
+            // OCCTSwift's split(by:) returns [Shape]?; emit a Compound is
+            // not directly supported, so wrap the array in a parent shape
+            // via Shape.compound when available. For v1, fall back to the
+            // first shape and surface a warning if there are multiple.
+            guard let pieces = aShape.split(by: bShape), let first = pieces.first else {
+                return .init("Boolean split failed.", isError: true)
+            }
+            if pieces.count > 1 {
+                result = Shape.compound(pieces) ?? first
+            } else {
+                result = first
+            }
+        }
+        guard let output = result else {
+            return .init("Boolean \(op.rawValue) failed.", isError: true)
+        }
+
+        let outFile = "\(op.rawValue)-\(outId)-\(shortUUID()).brep"
+        let outputPath = "\(outputDir)/\(outFile)"
+        do {
+            try Exporter.writeBREP(shape: output, to: URL(fileURLWithPath: outputPath))
+        } catch {
+            return .init("Failed to write BREP: \(error.localizedDescription)", isError: true)
+        }
+
+        await history.snapshot(store: store)
+
+        var bodies = manifest.bodies
+        bodies.append(BodyDescriptor(
+            id: outId,
+            file: outFile,
+            format: aBody.format,
+            name: aBody.name.map { "\(op.rawValue) \($0)" },
+            color: aBody.color,
+            roughness: aBody.roughness,
+            metallic: aBody.metallic
+        ))
+        if removeInputs {
+            for id in [aBodyId, bBodyId] {
+                if let idx = bodies.firstIndex(where: { $0.id == id }) {
+                    let removed = bodies.remove(at: idx)
+                    try? FileManager.default.removeItem(atPath: "\(outputDir)/\(removed.file)")
+                }
+            }
+        }
+        let updated = ScriptManifest(
+            version: manifest.version,
+            timestamp: Date(),
+            description: manifest.description,
+            bodies: bodies,
+            graphs: manifest.graphs,
+            metadata: manifest.metadata
+        )
+        try? store.write(updated)
+
+        let extra = removeInputs ? "; inputs removed" : ""
+        return .init("Boolean \(op.rawValue)(\(aBodyId), \(bBodyId)) → \"\(outId)\" (\(outFile))\(extra).")
+    }
+
+    // ── helpers ────────────────────────────────────────────────────────
+
+    private static func shortUUID() -> String {
+        return String(UUID().uuidString.prefix(8))
+    }
+}

--- a/Sources/OCCTMCPCore/Tools/ConstructionTools.swift
+++ b/Sources/OCCTMCPCore/Tools/ConstructionTools.swift
@@ -253,9 +253,126 @@ public enum ConstructionTools {
         return .init("Boolean \(op.rawValue)(\(aBodyId), \(bBodyId)) → \"\(outId)\" (\(outFile))\(extra).")
     }
 
+    // ── mirror_or_pattern ──────────────────────────────────────────────
+
+    public enum PatternKind: String {
+        case mirror, linear, circular
+    }
+
+    public struct PatternParams {
+        // mirror
+        public var planeOrigin: SIMD3<Double>?
+        public var planeNormal: SIMD3<Double>?
+        // linear
+        public var direction: SIMD3<Double>?
+        public var spacing: Double?
+        public var count: Int?
+        // circular
+        public var axisOrigin: SIMD3<Double>?
+        public var axisDirection: SIMD3<Double>?
+        public var totalCount: Int?
+        public var totalAngle: Double?
+        public init() {}
+    }
+
+    /// OCCTSwift's pattern primitives return a single (possibly compound)
+    /// Shape — different from the Node implementation which split the
+    /// compound into N separate BREPs/bodies. Emit one body per call;
+    /// callers wanting individual instances can do scene-graph splits in
+    /// a follow-up.
+    public static func mirrorOrPattern(
+        bodyId: String,
+        kind: PatternKind,
+        params: PatternParams,
+        outputBodyId: String? = nil,
+        store: ManifestStore = ManifestStore(),
+        history: SceneHistory = .shared
+    ) async -> ToolText {
+        guard let manifest = try? store.read() else {
+            return .init("No scene loaded. Run execute_script first.")
+        }
+        guard let body = manifest.body(withId: bodyId) else {
+            return .init("Body not found: \(bodyId)")
+        }
+        let outputDir = (store.path as NSString).deletingLastPathComponent
+        let inputPath = "\(outputDir)/\(body.file)"
+        guard FileManager.default.fileExists(atPath: inputPath) else {
+            return .init("BREP file missing: \(inputPath)")
+        }
+        let outId = outputBodyId ?? "\(kind.rawValue)-\(bodyId)"
+        if manifest.bodies.contains(where: { $0.id == outId }) {
+            return .init("Output body id \"\(outId)\" already exists.")
+        }
+
+        let shape: Shape
+        do {
+            shape = try Shape.loadBREP(fromPath: inputPath)
+        } catch {
+            return .init("Failed to load BREP: \(error.localizedDescription)", isError: true)
+        }
+
+        let result: Shape?
+        switch kind {
+        case .mirror:
+            guard let normal = params.planeNormal else {
+                return .init("mirror requires `planeNormal`.")
+            }
+            result = shape.mirrored(planeNormal: normal, planeOrigin: params.planeOrigin ?? .zero)
+        case .linear:
+            guard let dir = params.direction, let spacing = params.spacing, let count = params.count else {
+                return .init("linear requires `direction`, `spacing`, `count`.")
+            }
+            result = shape.linearPattern(direction: dir, spacing: spacing, count: count)
+        case .circular:
+            guard let axisO = params.axisOrigin, let axisD = params.axisDirection, let total = params.totalCount else {
+                return .init("circular requires `axisOrigin`, `axisDirection`, `totalCount`.")
+            }
+            result = shape.circularPattern(
+                axisPoint: axisO,
+                axisDirection: axisD,
+                count: total,
+                angle: params.totalAngle ?? 0
+            )
+        }
+        guard let output = result else {
+            return .init("Pattern \(kind.rawValue) failed.", isError: true)
+        }
+
+        let outFile = "\(kind.rawValue)-\(outId)-\(shortUUID()).brep"
+        let outputPath = "\(outputDir)/\(outFile)"
+        do {
+            try Exporter.writeBREP(shape: output, to: URL(fileURLWithPath: outputPath))
+        } catch {
+            return .init("Failed to write BREP: \(error.localizedDescription)", isError: true)
+        }
+
+        await history.snapshot(store: store)
+        var bodies = manifest.bodies
+        bodies.append(BodyDescriptor(
+            id: outId,
+            file: outFile,
+            format: body.format,
+            name: body.name.map { "\(kind.rawValue) \($0)" },
+            color: body.color,
+            roughness: body.roughness,
+            metallic: body.metallic
+        ))
+        let updated = ScriptManifest(
+            version: manifest.version,
+            timestamp: Date(),
+            description: manifest.description,
+            bodies: bodies,
+            graphs: manifest.graphs,
+            metadata: manifest.metadata
+        )
+        try? store.write(updated)
+
+        return .init("Pattern \(kind.rawValue) on \"\(bodyId)\" → \"\(outId)\" (\(outFile)).")
+    }
+
     // ── helpers ────────────────────────────────────────────────────────
 
-    private static func shortUUID() -> String {
+    static func shortUUID() -> String {
         return String(UUID().uuidString.prefix(8))
     }
 }

--- a/Sources/OCCTMCPCore/Tools/CoreTools.swift
+++ b/Sources/OCCTMCPCore/Tools/CoreTools.swift
@@ -1,0 +1,77 @@
+// CoreTools — get_scene, get_script, export_model, get_api_reference.
+// Pure file-system / process-state operations that don't need OCCTSwift.
+//
+// get_api_reference's `mcp_tools` category is supplied by Server.swift
+// (it needs the live tool registry); the OCCT API categories will be
+// regenerated from OCCTSwift sources in a follow-up — for v1 the tool
+// returns a pointer to the OCCTSwift docs.
+
+import Foundation
+import ScriptHarness
+
+/// Holds the source of the most recent script run in this MCP session.
+/// Updated by the (yet-to-be-ported) execute_script handler in Phase 5.4.
+public actor ScriptHistoryStore {
+    public static let shared = ScriptHistoryStore()
+    private var lastSource: String?
+    public func set(_ source: String) { self.lastSource = source }
+    public func get() -> String? { return lastSource }
+}
+
+public enum CoreTools {
+
+    // ── get_scene ──────────────────────────────────────────────────────
+
+    public static func getScene(
+        store: ManifestStore = ManifestStore()
+    ) async -> ToolText {
+        guard FileManager.default.fileExists(atPath: store.path) else {
+            return .init("No scene loaded. Run execute_script first.")
+        }
+        guard let manifest = try? store.read() else {
+            return .init("Failed to parse manifest at \(store.path).", isError: true)
+        }
+        let outputDir = (store.path as NSString).deletingLastPathComponent
+        let files = (try? FileManager.default.contentsOfDirectory(atPath: outputDir)) ?? []
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        let summary: String
+        if let data = try? encoder.encode(manifest), let str = String(data: data, encoding: .utf8) {
+            summary = str
+        } else {
+            summary = "{}"
+        }
+        return .init("Current scene:\n\(summary)\n\nOutput files: \(files.sorted().joined(separator: ", "))")
+    }
+
+    // ── get_script ─────────────────────────────────────────────────────
+
+    public static func getScript(history: ScriptHistoryStore = .shared) async -> ToolText {
+        if let src = await history.get() {
+            return .init(src)
+        }
+        return .init("No script has been executed in this session. Call execute_script first.")
+    }
+
+    // ── export_model ───────────────────────────────────────────────────
+
+    public static func exportModel(
+        store: ManifestStore = ManifestStore()
+    ) async -> ToolText {
+        let outputDir = (store.path as NSString).deletingLastPathComponent
+        guard FileManager.default.fileExists(atPath: outputDir) else {
+            return .init("No output directory found. Run execute_script first.")
+        }
+        let allFiles = (try? FileManager.default.contentsOfDirectory(atPath: outputDir)) ?? []
+        let exts: Set<String> = ["step", "stp", "brep", "stl", "obj", "json", "iges", "igs", "gltf", "glb"]
+        let modelFiles = allFiles
+            .filter { exts.contains(($0 as NSString).pathExtension.lowercased()) }
+            .sorted()
+        if modelFiles.isEmpty {
+            return .init("No model files found in output.")
+        }
+        let paths = modelFiles.map { "\(outputDir)/\($0)" }
+        return .init("Exported model files:\n\(paths.joined(separator: "\n"))")
+    }
+}

--- a/Sources/OCCTMCPCore/Tools/DrawingTools.swift
+++ b/Sources/OCCTMCPCore/Tools/DrawingTools.swift
@@ -1,0 +1,95 @@
+// DrawingTools — generate_drawing wraps DrawingComposer.Composer.render
+// directly. The MCP tool accepts the canonical DrawingSpec JSON shape
+// and forwards it (with shape + output paths injected) to the composer.
+
+import Foundation
+import MCP
+import OCCTSwift
+import ScriptHarness
+import DrawingComposer
+
+public enum DrawingTools {
+
+    public struct DrawingReport: Encodable {
+        public let outputPath: String
+        public let viewCount: Int
+        public let sectionCount: Int
+        public let detailCount: Int
+        public let scaleLabel: String
+        public let fileSize: Int
+    }
+
+    public static func generateDrawing(
+        bodyId: String,
+        outputPath: String,
+        spec: Value,
+        store: ManifestStore = ManifestStore()
+    ) async -> ToolText {
+        guard let manifest = try? store.read() else {
+            return .init("No scene loaded. Run execute_script first.")
+        }
+        guard let body = manifest.body(withId: bodyId) else {
+            return .init("Body not found: \(bodyId)")
+        }
+        let outputDir = (store.path as NSString).deletingLastPathComponent
+        let inputPath = "\(outputDir)/\(body.file)"
+        guard FileManager.default.fileExists(atPath: inputPath) else {
+            return .init("BREP file missing: \(inputPath)")
+        }
+
+        // Inject shape + output into the spec so callers don't have to.
+        var enriched: Value = spec
+        if case .object(var dict) = enriched {
+            dict["shape"] = .string(inputPath)
+            dict["output"] = .string(outputPath)
+            enriched = .object(dict)
+        } else {
+            return .init("`spec` must be a JSON object.")
+        }
+
+        let specData: Data
+        do {
+            specData = try JSONEncoder().encode(enriched)
+        } catch {
+            return .init("Failed to encode spec: \(error.localizedDescription)", isError: true)
+        }
+        let drawingSpec: DrawingSpec
+        do {
+            drawingSpec = try JSONDecoder().decode(DrawingSpec.self, from: specData)
+        } catch {
+            return .init("Invalid DrawingSpec: \(error.localizedDescription)")
+        }
+
+        let shape: Shape
+        do {
+            shape = try Shape.loadBREP(fromPath: inputPath)
+        } catch {
+            return .init("Failed to load BREP: \(error.localizedDescription)", isError: true)
+        }
+        let result: DrawingComposerResult
+        do {
+            result = try Composer.render(spec: drawingSpec, shape: shape)
+        } catch {
+            return .init("Composer.render failed: \(error.localizedDescription)", isError: true)
+        }
+        do {
+            try result.writer.write(to: URL(fileURLWithPath: outputPath))
+        } catch {
+            return .init("DXF write failed: \(error.localizedDescription)", isError: true)
+        }
+
+        var size = 0
+        if let attrs = try? FileManager.default.attributesOfItem(atPath: outputPath),
+           let n = attrs[.size] as? Int {
+            size = n
+        }
+        return IntrospectionTools.encode(DrawingReport(
+            outputPath: outputPath,
+            viewCount: result.viewCount,
+            sectionCount: result.sectionCount,
+            detailCount: result.detailCount,
+            scaleLabel: result.scaleLabel,
+            fileSize: size
+        ))
+    }
+}

--- a/Sources/OCCTMCPCore/Tools/FeatureTools.swift
+++ b/Sources/OCCTMCPCore/Tools/FeatureTools.swift
@@ -1,0 +1,132 @@
+// FeatureTools — apply_feature. Wraps OCCTSwift's
+// FeatureReconstructor.buildJSON, the JSON-driven dispatcher for the
+// FeatureSpec catalog (drill / fillet / chamfer / extrude / revolve /
+// thread / boolean).
+
+import Foundation
+import MCP
+import OCCTSwift
+import ScriptHarness
+
+public enum FeatureTools {
+
+    public struct ApplyReport: Encodable {
+        public let outputPath: String
+        public let inPlace: Bool
+        public let bodyId: String
+        public let outputBodyId: String?
+        public let fulfilled: [String]
+        public let skipped: [SkippedReport]
+        public let annotations: [AnnotationReport]
+
+        public struct SkippedReport: Encodable {
+            public let id: String
+            public let stage: String
+            public let reason: String
+        }
+        public struct AnnotationReport: Encodable {
+            public let id: String
+            public let kind: String
+        }
+    }
+
+    public static func applyFeature(
+        bodyId: String,
+        feature: Value,
+        outputBodyId: String? = nil,
+        store: ManifestStore = ManifestStore(),
+        history: SceneHistory = .shared
+    ) async -> ToolText {
+        guard let manifest = try? store.read() else {
+            return .init("No scene loaded. Run execute_script first.")
+        }
+        guard let body = manifest.body(withId: bodyId) else {
+            return .init("Body not found: \(bodyId)")
+        }
+        let outputDir = (store.path as NSString).deletingLastPathComponent
+        let inputPath = "\(outputDir)/\(body.file)"
+        guard FileManager.default.fileExists(atPath: inputPath) else {
+            return .init("BREP file missing: \(inputPath)")
+        }
+
+        let inputShape: Shape
+        do {
+            inputShape = try Shape.loadBREP(fromPath: inputPath)
+        } catch {
+            return .init("Failed to load BREP: \(error.localizedDescription)", isError: true)
+        }
+
+        let envelope: Value = .object([
+            "features": .array([feature]),
+        ])
+        let envelopeData: Data
+        do {
+            envelopeData = try JSONEncoder().encode(envelope)
+        } catch {
+            return .init("Failed to encode feature spec: \(error.localizedDescription)", isError: true)
+        }
+
+        let result: FeatureReconstructor.BuildResult
+        do {
+            result = try FeatureReconstructor.buildJSON(envelopeData, inputBody: inputShape)
+        } catch {
+            return .init("FeatureReconstructor failed: \(error.localizedDescription)", isError: true)
+        }
+        guard let outputShape = result.shape else {
+            let skipped = result.skipped.map { "\($0.featureID): \($0.reason)" }.joined(separator: "; ")
+            return .init("FeatureReconstructor produced no shape. Skipped: \(skipped)")
+        }
+
+        let isInPlace = outputBodyId == nil || outputBodyId == bodyId
+        if !isInPlace, let id = outputBodyId, manifest.bodies.contains(where: { $0.id == id }) {
+            return .init("Output body id \"\(id)\" already exists.")
+        }
+        let outputPath = isInPlace
+            ? inputPath
+            : "\(outputDir)/applied-\(outputBodyId!)-\(ConstructionTools.shortUUID()).brep"
+        do {
+            try Exporter.writeBREP(shape: outputShape, to: URL(fileURLWithPath: outputPath))
+        } catch {
+            return .init("Failed to write BREP: \(error.localizedDescription)", isError: true)
+        }
+
+        await history.snapshot(store: store)
+        if !isInPlace, let newId = outputBodyId {
+            let newFile = (outputPath as NSString).lastPathComponent
+            var bodies = manifest.bodies
+            bodies.append(BodyDescriptor(
+                id: newId,
+                file: newFile,
+                format: body.format,
+                name: body.name,
+                color: body.color,
+                roughness: body.roughness,
+                metallic: body.metallic
+            ))
+            try? store.write(ScriptManifest(
+                version: manifest.version,
+                timestamp: Date(),
+                description: manifest.description,
+                bodies: bodies,
+                graphs: manifest.graphs,
+                metadata: manifest.metadata
+            ))
+        } else {
+            try? store.write(manifest)
+        }
+
+        return IntrospectionTools.encode(ApplyReport(
+            outputPath: outputPath,
+            inPlace: isInPlace,
+            bodyId: bodyId,
+            outputBodyId: outputBodyId,
+            fulfilled: result.fulfilled,
+            skipped: result.skipped.map {
+                .init(id: $0.featureID, stage: "\($0.stage)", reason: "\($0.reason)")
+            },
+            annotations: result.annotations.map {
+                .init(id: $0.featureID, kind: "\($0.kind)")
+            }
+        ))
+    }
+}

--- a/Sources/OCCTMCPCore/Tools/HealingTools.swift
+++ b/Sources/OCCTMCPCore/Tools/HealingTools.swift
@@ -1,0 +1,116 @@
+// HealingTools — heal_shape. Wraps Shape.healed() (which dispatches
+// through OCCT's ShapeFix_Shape pipeline).
+
+import Foundation
+import OCCTSwift
+import ScriptHarness
+
+public enum HealingTools {
+
+    public struct HealReport: Encodable {
+        public let outputPath: String
+        public let before: HealthSnapshot
+        public let after: HealthSnapshot
+        public let warnings: [String]
+
+        public struct HealthSnapshot: Encodable {
+            public let faceCount: Int
+            public let edgeCount: Int
+            public let isValid: Bool
+        }
+    }
+
+    public static func healShape(
+        bodyId: String,
+        outputBodyId: String? = nil,
+        store: ManifestStore = ManifestStore(),
+        history: SceneHistory = .shared
+    ) async -> ToolText {
+        guard let manifest = try? store.read() else {
+            return .init("No scene loaded. Run execute_script first.")
+        }
+        guard let body = manifest.body(withId: bodyId) else {
+            return .init("Body not found: \(bodyId)")
+        }
+        let outputDir = (store.path as NSString).deletingLastPathComponent
+        let inputPath = "\(outputDir)/\(body.file)"
+        guard FileManager.default.fileExists(atPath: inputPath) else {
+            return .init("BREP file missing: \(inputPath)")
+        }
+        let isInPlace = outputBodyId == nil || outputBodyId == bodyId
+        if !isInPlace, let id = outputBodyId, manifest.bodies.contains(where: { $0.id == id }) {
+            return .init("Output body id \"\(id)\" already exists.")
+        }
+
+        let inputShape: Shape
+        do {
+            inputShape = try Shape.loadBREP(fromPath: inputPath)
+        } catch {
+            return .init("Failed to load BREP: \(error.localizedDescription)", isError: true)
+        }
+        let before = HealReport.HealthSnapshot(
+            faceCount: inputShape.faces().count,
+            edgeCount: inputShape.edges().count,
+            isValid: inputShape.isValid
+        )
+        guard let healed = inputShape.healed() else {
+            return .init("Healing failed (Shape.healed returned nil).", isError: true)
+        }
+        let after = HealReport.HealthSnapshot(
+            faceCount: healed.faces().count,
+            edgeCount: healed.edges().count,
+            isValid: healed.isValid
+        )
+
+        let outputPath: String
+        if isInPlace {
+            outputPath = inputPath
+        } else {
+            outputPath = "\(outputDir)/heal-\(outputBodyId!)-\(ConstructionTools.shortUUID()).brep"
+        }
+        do {
+            try Exporter.writeBREP(shape: healed, to: URL(fileURLWithPath: outputPath))
+        } catch {
+            return .init("Failed to write BREP: \(error.localizedDescription)", isError: true)
+        }
+
+        await history.snapshot(store: store)
+        var warnings: [String] = []
+        if before.faceCount == after.faceCount &&
+            before.edgeCount == after.edgeCount &&
+            before.isValid == after.isValid {
+            warnings.append("Shape.healed() reported no structural change; before/after may be identical")
+        }
+
+        if !isInPlace, let newId = outputBodyId {
+            let newFile = (outputPath as NSString).lastPathComponent
+            var bodies = manifest.bodies
+            bodies.append(BodyDescriptor(
+                id: newId,
+                file: newFile,
+                format: body.format,
+                name: body.name,
+                color: body.color,
+                roughness: body.roughness,
+                metallic: body.metallic
+            ))
+            try? store.write(ScriptManifest(
+                version: manifest.version,
+                timestamp: Date(),
+                description: manifest.description,
+                bodies: bodies,
+                graphs: manifest.graphs,
+                metadata: manifest.metadata
+            ))
+        } else {
+            try? store.write(manifest)
+        }
+
+        return IntrospectionTools.encode(HealReport(
+            outputPath: outputPath,
+            before: before,
+            after: after,
+            warnings: warnings
+        ))
+    }
+}

--- a/Sources/OCCTMCPCore/Tools/IOTools.swift
+++ b/Sources/OCCTMCPCore/Tools/IOTools.swift
@@ -1,0 +1,288 @@
+// IOTools — read_brep, import_file, export_scene. All three are direct
+// OCCTSwift calls now: Shape.loadBREP / .loadSTEP / .loadIGES,
+// Exporter.writeSTEP / .writeIGES / .writeBREP / .writeSTL / .writeOBJ /
+// .writeGLTF.
+
+import Foundation
+import OCCTSwift
+import ScriptHarness
+
+public enum IOTools {
+
+    // ── read_brep ──────────────────────────────────────────────────────
+
+    public struct LoadReport: Encodable {
+        public let bodyId: String
+        public let isValid: Bool
+        public let shapeType: String
+        public let faceCount: Int
+        public let edgeCount: Int
+        public let vertexCount: Int
+        public let boundingBox: IntrospectionTools.MetricsReport.BBox
+    }
+
+    public static func readBrep(
+        inputPath: String,
+        bodyId: String? = nil,
+        color: [Float]? = nil,
+        store: ManifestStore = ManifestStore(),
+        history: SceneHistory = .shared
+    ) async -> ToolText {
+        guard FileManager.default.fileExists(atPath: inputPath) else {
+            return .init("BREP file not found: \(inputPath)")
+        }
+        let manifestExists = (try? store.read()) != nil
+        let manifest: ScriptManifest = (manifestExists ? (try? store.read()) ?? nil : nil) ?? ScriptManifest(
+            description: "Imported via read_brep",
+            bodies: []
+        )
+
+        let resolvedId = bodyId ?? defaultBodyId(from: inputPath)
+        if manifest.bodies.contains(where: { $0.id == resolvedId }) {
+            return .init("Body id \"\(resolvedId)\" already exists. Pass a different bodyId.")
+        }
+        let shape: Shape
+        do {
+            shape = try Shape.loadBREP(fromPath: inputPath)
+        } catch {
+            return .init("Failed to load BREP: \(error.localizedDescription)", isError: true)
+        }
+
+        let outputDir = (store.path as NSString).deletingLastPathComponent
+        try? FileManager.default.createDirectory(atPath: outputDir, withIntermediateDirectories: true)
+        let outFile = "\(resolvedId).brep"
+        let outPath = "\(outputDir)/\(outFile)"
+        do {
+            try Exporter.writeBREP(shape: shape, to: URL(fileURLWithPath: outPath))
+        } catch {
+            return .init("Failed to copy BREP: \(error.localizedDescription)", isError: true)
+        }
+
+        await history.snapshot(store: store)
+        var bodies = manifest.bodies
+        bodies.append(BodyDescriptor(
+            id: resolvedId,
+            file: outFile,
+            color: color
+        ))
+        try? store.write(ScriptManifest(
+            version: manifest.version,
+            timestamp: Date(),
+            description: manifest.description ?? "Imported via read_brep",
+            bodies: bodies,
+            graphs: manifest.graphs,
+            metadata: manifest.metadata
+        ))
+
+        let bb = shape.bounds
+        return IntrospectionTools.encode(LoadReport(
+            bodyId: resolvedId,
+            isValid: shape.isValid,
+            shapeType: String(describing: shape.shapeType),
+            faceCount: shape.faces().count,
+            edgeCount: shape.edges().count,
+            vertexCount: shape.vertices().count,
+            boundingBox: .init(
+                min: [bb.min.x, bb.min.y, bb.min.z],
+                max: [bb.max.x, bb.max.y, bb.max.z]
+            )
+        ))
+    }
+
+    // ── import_file ────────────────────────────────────────────────────
+
+    public enum ImportFormat: String {
+        case auto, step, iges, obj, brep
+        // STL deferred — Shape.loadSTL is not in OCCTSwift; STL is a mesh
+        // format and would round-trip via OCCTSwiftMesh.
+
+        static func resolve(path: String, hint: ImportFormat) -> ImportFormat? {
+            if hint != .auto { return hint }
+            let ext = (path as NSString).pathExtension.lowercased()
+            switch ext {
+            case "step", "stp": return .step
+            case "iges", "igs": return .iges
+            case "obj": return .obj
+            case "brep": return .brep
+            default: return nil
+            }
+        }
+    }
+
+    public struct ImportReport: Encodable {
+        public let addedBodyIds: [String]
+        public let warnings: [String]
+    }
+
+    public static func importFile(
+        inputPath: String,
+        format: ImportFormat = .auto,
+        idPrefix: String = "imported",
+        store: ManifestStore = ManifestStore(),
+        history: SceneHistory = .shared
+    ) async -> ToolText {
+        guard FileManager.default.fileExists(atPath: inputPath) else {
+            return .init("File not found: \(inputPath)")
+        }
+        guard let resolved = ImportFormat.resolve(path: inputPath, hint: format) else {
+            return .init("Could not determine format from extension. Pass `format` explicitly.")
+        }
+
+        let shape: Shape
+        do {
+            switch resolved {
+            case .step:
+                // 0.001 m = mm, the typical CAD-model length unit. STEP files
+                // also encode their own unit, but OCCT requires a fallback.
+                shape = try Shape.loadSTEP(fromPath: inputPath, unitInMeters: 0.001)
+            case .iges:
+                shape = try Shape.loadIGES(fromPath: inputPath)
+            case .brep:
+                shape = try Shape.loadBREP(fromPath: inputPath)
+            case .obj:
+                return .init("OBJ import goes through Document.loadOBJ; use the Document-aware path (TBD).")
+            case .auto:
+                return .init("Format auto-detection failed.")
+            }
+        } catch {
+            return .init("Import failed: \(error.localizedDescription)", isError: true)
+        }
+
+        let manifest: ScriptManifest = (try? store.read()) ?? ScriptManifest(
+            description: "Imported via import_file",
+            bodies: []
+        )
+        let id = uniqueBodyId(prefix: idPrefix, manifest: manifest)
+        let outputDir = (store.path as NSString).deletingLastPathComponent
+        try? FileManager.default.createDirectory(atPath: outputDir, withIntermediateDirectories: true)
+        let outFile = "\(id).brep"
+        let outPath = "\(outputDir)/\(outFile)"
+        do {
+            try Exporter.writeBREP(shape: shape, to: URL(fileURLWithPath: outPath))
+        } catch {
+            return .init("Failed to write BREP: \(error.localizedDescription)", isError: true)
+        }
+
+        await history.snapshot(store: store)
+        var bodies = manifest.bodies
+        bodies.append(BodyDescriptor(id: id, file: outFile))
+        try? store.write(ScriptManifest(
+            version: manifest.version,
+            timestamp: Date(),
+            description: manifest.description ?? "Imported via import_file",
+            bodies: bodies,
+            graphs: manifest.graphs,
+            metadata: manifest.metadata
+        ))
+
+        return IntrospectionTools.encode(ImportReport(
+            addedBodyIds: [id],
+            warnings: []
+        ))
+    }
+
+    // ── export_scene ───────────────────────────────────────────────────
+
+    public enum ExportFormat: String {
+        case step, iges, brep, stl, obj, gltf, glb
+    }
+
+    public static func exportScene(
+        format: ExportFormat,
+        outputPath: String,
+        bodyIds: [String]? = nil,
+        store: ManifestStore = ManifestStore()
+    ) async -> ToolText {
+        guard let manifest = try? store.read() else {
+            return .init("No scene loaded. Run execute_script first.")
+        }
+        let outputDir = (store.path as NSString).deletingLastPathComponent
+        let bodies: [BodyDescriptor]
+        if let ids = bodyIds, !ids.isEmpty {
+            let idSet = Set(ids)
+            bodies = manifest.bodies.filter { $0.id.flatMap { idSet.contains($0) } ?? false }
+            let found = Set(bodies.compactMap { $0.id })
+            let missing = ids.filter { !found.contains($0) }
+            if !missing.isEmpty {
+                return .init("Body ids not found: \(missing.joined(separator: ", "))")
+            }
+        } else {
+            bodies = manifest.bodies
+        }
+        if bodies.isEmpty {
+            return .init("No bodies to export.")
+        }
+
+        var shapes: [Shape] = []
+        for body in bodies {
+            do {
+                let s = try Shape.loadBREP(fromPath: "\(outputDir)/\(body.file)")
+                shapes.append(s)
+            } catch {
+                return .init(
+                    "Failed to load body \(body.id ?? body.file): \(error.localizedDescription)",
+                    isError: true
+                )
+            }
+        }
+        let combined: Shape
+        if shapes.count == 1 {
+            combined = shapes[0]
+        } else if let compound = Shape.compound(shapes) {
+            combined = compound
+        } else {
+            return .init("Failed to build compound for \(shapes.count) bodies.", isError: true)
+        }
+
+        let outURL = URL(fileURLWithPath: outputPath)
+        try? FileManager.default.createDirectory(
+            at: outURL.deletingLastPathComponent(), withIntermediateDirectories: true)
+        do {
+            switch format {
+            case .step:
+                try Exporter.writeSTEP(shape: combined, to: outURL)
+            case .iges:
+                try Exporter.writeIGES(shape: combined, to: outURL)
+            case .brep:
+                try Exporter.writeBREP(shape: combined, to: outURL)
+            case .stl:
+                try Exporter.writeSTL(shape: combined, to: outURL)
+            case .obj:
+                try Exporter.writeOBJ(shape: combined, to: outURL)
+            case .gltf:
+                try Exporter.writeGLTF(shape: combined, to: outURL, binary: false)
+            case .glb:
+                try Exporter.writeGLTF(shape: combined, to: outURL, binary: true)
+            }
+        } catch {
+            return .init("Export failed: \(error.localizedDescription)", isError: true)
+        }
+        var fileSize = 0
+        if let attrs = try? FileManager.default.attributesOfItem(atPath: outputPath),
+           let size = attrs[.size] as? Int {
+            fileSize = size
+        }
+        return .init(
+            "Exported \(shapes.count) bodies → \(outputPath) (\(format.rawValue), \(fileSize) bytes)."
+        )
+    }
+
+    // ── helpers ────────────────────────────────────────────────────────
+
+    static func defaultBodyId(from path: String) -> String {
+        let base = (path as NSString).lastPathComponent
+        let stem = (base as NSString).deletingPathExtension
+        return stem.isEmpty ? "imported" : stem
+    }
+
+    static func uniqueBodyId(prefix: String, manifest: ScriptManifest) -> String {
+        var i = 0
+        while true {
+            let candidate = i == 0 ? prefix : "\(prefix)_\(i)"
+            if !manifest.bodies.contains(where: { $0.id == candidate }) {
+                return candidate
+            }
+            i += 1
+        }
+    }
+}

--- a/Sources/OCCTMCPCore/Tools/IntrospectionTools.swift
+++ b/Sources/OCCTMCPCore/Tools/IntrospectionTools.swift
@@ -1,0 +1,287 @@
+// IntrospectionTools — pure-read tools backed by direct OCCTSwift calls
+// (no occtkit subprocess). Phase 5.3a covers compute_metrics,
+// query_topology, measure_distance. Each resolves a bodyId against the
+// scene manifest, loads the body's BREP via Shape.loadBREP(fromPath:),
+// and runs the OCCT query in-process.
+
+import Foundation
+import OCCTSwift
+import ScriptHarness
+
+public enum IntrospectionTools {
+
+    // ── shared body resolver ────────────────────────────────────────────
+
+    static func loadShape(
+        bodyId: String,
+        store: ManifestStore
+    ) throws -> (manifest: ScriptManifest, body: BodyDescriptor, shape: Shape, path: String) {
+        guard let manifest = try store.read() else {
+            throw ToolError.noScene
+        }
+        guard let body = manifest.body(withId: bodyId) else {
+            throw ToolError.bodyNotFound(bodyId)
+        }
+        let outputDir = (store.path as NSString).deletingLastPathComponent
+        let path = "\(outputDir)/\(body.file)"
+        guard FileManager.default.fileExists(atPath: path) else {
+            throw ToolError.brepMissing(path)
+        }
+        let shape = try Shape.loadBREP(fromPath: path)
+        return (manifest, body, shape, path)
+    }
+
+    public enum ToolError: Error, CustomStringConvertible {
+        case noScene
+        case bodyNotFound(String)
+        case brepMissing(String)
+
+        public var description: String {
+            switch self {
+            case .noScene:
+                return "No scene loaded. Run execute_script first."
+            case .bodyNotFound(let id):
+                return "Body not found: \(id)"
+            case .brepMissing(let path):
+                return "BREP file missing: \(path)"
+            }
+        }
+    }
+
+    // ── compute_metrics ────────────────────────────────────────────────
+
+    public struct MetricsReport: Encodable {
+        public var volume: Double?
+        public var surfaceArea: Double?
+        public var centerOfMass: [Double]?
+        public var boundingBox: BBox?
+        public var principalAxes: PrincipalAxes?
+
+        public struct BBox: Encodable {
+            public let min: [Double]
+            public let max: [Double]
+        }
+        public struct PrincipalAxes: Encodable {
+            public let axes: [[Double]]
+            public let moments: [Double]
+        }
+    }
+
+    public static func computeMetrics(
+        bodyId: String,
+        metrics: Set<String>? = nil,
+        store: ManifestStore = ManifestStore()
+    ) async -> ToolText {
+        let loaded: (manifest: ScriptManifest, body: BodyDescriptor, shape: Shape, path: String)
+        do {
+            loaded = try loadShape(bodyId: bodyId, store: store)
+        } catch {
+            return .init("\(error)")
+        }
+        let shape = loaded.shape
+
+        func wants(_ name: String) -> Bool {
+            return metrics == nil || metrics!.contains(name)
+        }
+
+        var report = MetricsReport()
+        let inertia = (wants("volume") || wants("centerOfMass") || wants("principalAxes"))
+            ? shape.volumeInertia : nil
+
+        if wants("volume") { report.volume = inertia?.volume }
+        if wants("surfaceArea") { report.surfaceArea = shape.surfaceArea }
+        if wants("centerOfMass"), let i = inertia {
+            report.centerOfMass = [i.centerOfMass.x, i.centerOfMass.y, i.centerOfMass.z]
+        }
+        if wants("boundingBox") {
+            let b = shape.bounds
+            report.boundingBox = .init(
+                min: [b.min.x, b.min.y, b.min.z],
+                max: [b.max.x, b.max.y, b.max.z]
+            )
+        }
+        if wants("principalAxes"), let i = inertia {
+            report.principalAxes = .init(
+                axes: [
+                    [i.principalAxes.0.x, i.principalAxes.0.y, i.principalAxes.0.z],
+                    [i.principalAxes.1.x, i.principalAxes.1.y, i.principalAxes.1.z],
+                    [i.principalAxes.2.x, i.principalAxes.2.y, i.principalAxes.2.z],
+                ],
+                moments: [i.principalMoments.x, i.principalMoments.y, i.principalMoments.z]
+            )
+        }
+        return encode(report)
+    }
+
+    // ── query_topology ─────────────────────────────────────────────────
+
+    public struct QueryReport: Encodable {
+        public let entity: String
+        public let results: [Result]
+        public let total: Int
+        public let truncated: Bool
+
+        public struct Result: Encodable {
+            public let id: String
+            public let surfaceType: String?
+            public let curveType: String?
+            public let area: Double?
+            public let boundingBox: MetricsReport.BBox?
+        }
+    }
+
+    public struct TopologyFilter {
+        public var surfaceType: String?
+        public var curveType: String?
+        public var minArea: Double?
+        public var maxArea: Double?
+        public init(
+            surfaceType: String? = nil,
+            curveType: String? = nil,
+            minArea: Double? = nil,
+            maxArea: Double? = nil
+        ) {
+            self.surfaceType = surfaceType
+            self.curveType = curveType
+            self.minArea = minArea
+            self.maxArea = maxArea
+        }
+    }
+
+    public static func queryTopology(
+        bodyId: String,
+        entity: String,
+        filter: TopologyFilter = .init(),
+        limit: Int? = nil,
+        store: ManifestStore = ManifestStore()
+    ) async -> ToolText {
+        let loaded: (manifest: ScriptManifest, body: BodyDescriptor, shape: Shape, path: String)
+        do {
+            loaded = try loadShape(bodyId: bodyId, store: store)
+        } catch {
+            return .init("\(error)")
+        }
+        let shape = loaded.shape
+
+        var results: [QueryReport.Result] = []
+        var totalScanned = 0
+
+        switch entity {
+        case "face":
+            for (i, face) in shape.faces().enumerated() {
+                totalScanned += 1
+                let kind = String(describing: face.surfaceType)
+                if let want = filter.surfaceType, want != kind { continue }
+                let a = face.area()
+                if let lo = filter.minArea, a < lo { continue }
+                if let hi = filter.maxArea, a > hi { continue }
+                results.append(.init(
+                    id: "face[\(i)]",
+                    surfaceType: kind,
+                    curveType: nil,
+                    area: a,
+                    boundingBox: nil
+                ))
+            }
+        case "edge":
+            for (i, edge) in shape.edges().enumerated() {
+                totalScanned += 1
+                let kind = String(describing: edge.curveType)
+                if let want = filter.curveType, want != kind { continue }
+                results.append(.init(
+                    id: "edge[\(i)]",
+                    surfaceType: nil,
+                    curveType: kind,
+                    area: nil,
+                    boundingBox: nil
+                ))
+            }
+        case "vertex":
+            for (i, _) in shape.vertices().enumerated() {
+                totalScanned += 1
+                results.append(.init(
+                    id: "vertex[\(i)]",
+                    surfaceType: nil,
+                    curveType: nil,
+                    area: nil,
+                    boundingBox: nil
+                ))
+            }
+        default:
+            return .init("Unknown entity '\(entity)'. Expected one of: face, edge, vertex.")
+        }
+
+        let truncated = limit.map { results.count > $0 } ?? false
+        if let n = limit { results = Array(results.prefix(n)) }
+
+        return encode(QueryReport(
+            entity: entity,
+            results: results,
+            total: totalScanned,
+            truncated: truncated
+        ))
+    }
+
+    // ── measure_distance ───────────────────────────────────────────────
+
+    public struct DistanceReport: Encodable {
+        public let minDistance: Double
+        public let isParallel: Bool
+        public let contacts: [Contact]
+
+        public struct Contact: Encodable {
+            public let fromPoint: [Double]
+            public let toPoint: [Double]
+            public let distance: Double
+        }
+    }
+
+    public static func measureDistance(
+        fromBodyId: String,
+        toBodyId: String,
+        computeContacts: Bool = false,
+        store: ManifestStore = ManifestStore()
+    ) async -> ToolText {
+        let from: (manifest: ScriptManifest, body: BodyDescriptor, shape: Shape, path: String)
+        let to: (manifest: ScriptManifest, body: BodyDescriptor, shape: Shape, path: String)
+        do {
+            from = try loadShape(bodyId: fromBodyId, store: store)
+            to = try loadShape(bodyId: toBodyId, store: store)
+        } catch {
+            return .init("\(error)")
+        }
+
+        if !computeContacts {
+            guard let dist = from.shape.minDistance(to: to.shape) else {
+                return .init("Distance computation failed.", isError: true)
+            }
+            return encode(DistanceReport(minDistance: dist, isParallel: false, contacts: []))
+        }
+
+        guard let solutions = from.shape.allDistanceSolutions(to: to.shape, maxSolutions: 32) else {
+            return .init("Distance computation failed.", isError: true)
+        }
+        let minD = solutions.map(\.distance).min() ?? .infinity
+        let contacts = solutions.map {
+            DistanceReport.Contact(
+                fromPoint: [$0.point1.x, $0.point1.y, $0.point1.z],
+                toPoint: [$0.point2.x, $0.point2.y, $0.point2.z],
+                distance: $0.distance
+            )
+        }
+        return encode(DistanceReport(minDistance: minD, isParallel: false, contacts: contacts))
+    }
+
+    // ── shared encoder ─────────────────────────────────────────────────
+
+    static func encode<T: Encodable>(_ value: T) -> ToolText {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        do {
+            let data = try encoder.encode(value)
+            return .init(String(data: data, encoding: .utf8) ?? "{}")
+        } catch {
+            return .init("Failed to encode result: \(error.localizedDescription)", isError: true)
+        }
+    }
+}

--- a/Sources/OCCTMCPCore/Tools/MeshTools.swift
+++ b/Sources/OCCTMCPCore/Tools/MeshTools.swift
@@ -1,0 +1,244 @@
+// MeshTools — generate_mesh and simplify_mesh, both backed by direct
+// OCCTSwift / OCCTSwiftMesh calls.
+
+import Foundation
+import OCCTSwift
+import OCCTSwiftMesh
+import ScriptHarness
+
+public enum MeshTools {
+
+    // ── generate_mesh ──────────────────────────────────────────────────
+
+    public struct MeshReport: Encodable {
+        public let triangleCount: Int
+        public let vertexCount: Int
+        public let quality: Quality
+        public let geometry: Geometry?
+        public let outputPath: String?
+
+        public struct Quality: Encodable {
+            public let minAspectRatio: Double
+            public let meanAspectRatio: Double
+            public let degenerateTriangles: Int
+            public let nonManifoldEdges: Int
+        }
+        public struct Geometry: Encodable {
+            public let vertices: [Float]
+            public let indices: [UInt32]
+        }
+    }
+
+    public static func generateMesh(
+        bodyId: String,
+        linearDeflection: Double = 0.1,
+        angularDeflection: Double = 0.5,
+        returnGeometry: Bool = false,
+        outputPath: String? = nil,
+        store: ManifestStore = ManifestStore()
+    ) async -> ToolText {
+        let loaded: (manifest: ScriptManifest, body: BodyDescriptor, shape: Shape, path: String)
+        do {
+            loaded = try IntrospectionTools.loadShape(bodyId: bodyId, store: store)
+        } catch {
+            return .init("\(error)")
+        }
+        var params = MeshParameters.default
+        params.deflection = linearDeflection
+        params.angle = angularDeflection
+        guard let mesh = loaded.shape.mesh(parameters: params) else {
+            return .init("Mesh generation failed.", isError: true)
+        }
+        let quality = computeQuality(mesh)
+
+        var geometry: MeshReport.Geometry?
+        if returnGeometry {
+            let verts = mesh.vertices
+            let flat = verts.flatMap { [$0.x, $0.y, $0.z] }
+            geometry = .init(vertices: flat, indices: mesh.indices)
+        }
+
+        if let path = outputPath {
+            do {
+                try writeMesh(mesh: mesh, path: path)
+            } catch {
+                return .init("Failed to write mesh: \(error.localizedDescription)", isError: true)
+            }
+        }
+
+        let report = MeshReport(
+            triangleCount: mesh.triangleCount,
+            vertexCount: mesh.vertexCount,
+            quality: quality,
+            geometry: geometry,
+            outputPath: outputPath
+        )
+        return IntrospectionTools.encode(report)
+    }
+
+    // ── simplify_mesh ──────────────────────────────────────────────────
+
+    public struct SimplifyReport: Encodable {
+        public let beforeTriangleCount: Int
+        public let afterTriangleCount: Int
+        public let qualityDelta: QualityDelta
+        public let outputPath: String
+
+        public struct QualityDelta: Encodable {
+            public let meanAspectRatioDelta: Double
+            public let hausdorffDistance: Double
+        }
+    }
+
+    public static func simplifyMesh(
+        bodyId: String,
+        outputPath: String,
+        targetTriangleCount: Int? = nil,
+        targetReduction: Double? = nil,
+        preserveBoundary: Bool = true,
+        preserveTopology: Bool = true,
+        maxHausdorffDistance: Double? = nil,
+        linearDeflection: Double = 0.1,
+        angularDeflection: Double = 0.5,
+        store: ManifestStore = ManifestStore()
+    ) async -> ToolText {
+        if (targetTriangleCount == nil) == (targetReduction == nil) {
+            return .init("Pass exactly one of targetTriangleCount or targetReduction.")
+        }
+        let ext = (outputPath as NSString).pathExtension.lowercased()
+        guard ext == "stl" || ext == "obj" else {
+            return .init("outputPath must end in .stl or .obj (got .\(ext)).")
+        }
+
+        let loaded: (manifest: ScriptManifest, body: BodyDescriptor, shape: Shape, path: String)
+        do {
+            loaded = try IntrospectionTools.loadShape(bodyId: bodyId, store: store)
+        } catch {
+            return .init("\(error)")
+        }
+        var params = MeshParameters.default
+        params.deflection = linearDeflection
+        params.angle = angularDeflection
+        guard let inputMesh = loaded.shape.mesh(parameters: params) else {
+            return .init("Mesh generation failed.", isError: true)
+        }
+        let beforeMean = meanAspectRatio(of: inputMesh)
+
+        let options = Mesh.SimplifyOptions(
+            targetTriangleCount: targetTriangleCount,
+            targetReduction: targetReduction,
+            preserveBoundary: preserveBoundary,
+            preserveTopology: preserveTopology,
+            maxHausdorffDistance: maxHausdorffDistance
+        )
+        guard let simplified = inputMesh.simplified(options) else {
+            return .init("Simplification failed — check options.", isError: true)
+        }
+        let afterMean = meanAspectRatio(of: simplified.mesh)
+
+        do {
+            try writeMesh(mesh: simplified.mesh, path: outputPath)
+        } catch {
+            return .init("Failed to write mesh: \(error.localizedDescription)", isError: true)
+        }
+
+        return IntrospectionTools.encode(SimplifyReport(
+            beforeTriangleCount: simplified.beforeTriangleCount,
+            afterTriangleCount: simplified.afterTriangleCount,
+            qualityDelta: .init(
+                meanAspectRatioDelta: afterMean - beforeMean,
+                hausdorffDistance: simplified.hausdorffDistance
+            ),
+            outputPath: outputPath
+        ))
+    }
+
+    // ── shared mesh quality + writers ──────────────────────────────────
+
+    static func computeQuality(_ mesh: Mesh) -> MeshReport.Quality {
+        let verts = mesh.vertices
+        let idx = mesh.indices
+        var sum = 0.0
+        var minR = Double.infinity
+        var degenerates = 0
+        let triCount = idx.count / 3
+        for t in 0..<triCount {
+            let i0 = Int(idx[t * 3]), i1 = Int(idx[t * 3 + 1]), i2 = Int(idx[t * 3 + 2])
+            guard i0 < verts.count, i1 < verts.count, i2 < verts.count else { continue }
+            let a = verts[i0], b = verts[i1], c = verts[i2]
+            let e0 = simdLength(b - a), e1 = simdLength(c - b), e2 = simdLength(a - c)
+            let mn = min(e0, min(e1, e2))
+            let mx = max(e0, max(e1, e2))
+            if mn <= 1e-9 { degenerates += 1; continue }
+            let r = Double(mx / mn)
+            sum += r
+            if r < minR { minR = r }
+        }
+        let counted = max(triCount - degenerates, 1)
+        return .init(
+            minAspectRatio: minR.isFinite ? minR : 1,
+            meanAspectRatio: sum / Double(counted),
+            degenerateTriangles: degenerates,
+            nonManifoldEdges: 0   // not computed in v1; needs an edge map
+        )
+    }
+
+    static func meanAspectRatio(of mesh: Mesh) -> Double {
+        return computeQuality(mesh).meanAspectRatio
+    }
+
+    static func writeMesh(mesh: Mesh, path: String) throws {
+        let url = URL(fileURLWithPath: path)
+        try? FileManager.default.createDirectory(
+            at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
+        let ext = url.pathExtension.lowercased()
+        let verts = mesh.vertices
+        let idx = mesh.indices
+        switch ext {
+        case "stl":
+            var out = "solid generated\n"
+            for t in 0..<(idx.count / 3) {
+                let i0 = Int(idx[t * 3]), i1 = Int(idx[t * 3 + 1]), i2 = Int(idx[t * 3 + 2])
+                guard i0 < verts.count, i1 < verts.count, i2 < verts.count else { continue }
+                let a = verts[i0], b = verts[i1], c = verts[i2]
+                let n = simdNormalize(simdCross(b - a, c - a))
+                out += "  facet normal \(n.x) \(n.y) \(n.z)\n"
+                out += "    outer loop\n"
+                out += "      vertex \(a.x) \(a.y) \(a.z)\n"
+                out += "      vertex \(b.x) \(b.y) \(b.z)\n"
+                out += "      vertex \(c.x) \(c.y) \(c.z)\n"
+                out += "    endloop\n  endfacet\n"
+            }
+            out += "endsolid generated\n"
+            try out.write(to: url, atomically: true, encoding: .utf8)
+        case "obj":
+            var out = "# OCCTMCP generate_mesh\n"
+            for v in verts { out += "v \(v.x) \(v.y) \(v.z)\n" }
+            for t in 0..<(idx.count / 3) {
+                let i0 = idx[t * 3] + 1
+                let i1 = idx[t * 3 + 1] + 1
+                let i2 = idx[t * 3 + 2] + 1
+                out += "f \(i0) \(i1) \(i2)\n"
+            }
+            try out.write(to: url, atomically: true, encoding: .utf8)
+        default:
+            throw MeshError.unsupportedExtension(ext)
+        }
+    }
+
+    enum MeshError: Error, CustomStringConvertible {
+        case unsupportedExtension(String)
+        var description: String {
+            switch self {
+            case .unsupportedExtension(let ext):
+                return "Unsupported mesh extension '.\(ext)'; use .stl or .obj"
+            }
+        }
+    }
+}
+
+// Tiny SIMD helpers so the file doesn't have to import simd.
+import simd
+private func simdLength(_ v: SIMD3<Float>) -> Float { simd.simd_length(v) }
+private func simdCross(_ a: SIMD3<Float>, _ b: SIMD3<Float>) -> SIMD3<Float> { simd.simd_cross(a, b) }
+private func simdNormalize(_ v: SIMD3<Float>) -> SIMD3<Float> { simd.simd_normalize(v) }

--- a/Sources/OCCTMCPCore/Tools/SceneTools.swift
+++ b/Sources/OCCTMCPCore/Tools/SceneTools.swift
@@ -1,0 +1,349 @@
+// SceneTools — pure-manifest scene-mutation tools (Phase 1 in the Node
+// implementation). Each one reads the manifest, mutates an in-memory
+// copy, snapshots the prior state into SceneHistory, and writes the
+// manifest back. OCCTSwiftViewport's ScriptWatcher reloads on the file
+// write — that's the side effect that makes the live preview update.
+
+import Foundation
+import MCP
+import ScriptHarness
+
+/// Result envelope used by every scene tool.
+public struct ToolText {
+    public let text: String
+    public let isError: Bool
+    public init(_ text: String, isError: Bool = false) {
+        self.text = text
+        self.isError = isError
+    }
+    public func asCallToolResult() -> CallTool.Result {
+        return .init(
+            content: [.text(text: text, annotations: nil, _meta: nil)],
+            isError: isError
+        )
+    }
+}
+
+public enum SceneTools {
+    // ── remove_body ────────────────────────────────────────────────────────
+
+    public static func removeBody(
+        bodyId: String,
+        store: ManifestStore = ManifestStore(),
+        history: SceneHistory = .shared
+    ) async -> ToolText {
+        guard let manifest = try? store.read() else {
+            return .init("No scene loaded. Run execute_script first.")
+        }
+        await history.snapshot(store: store)
+
+        guard let target = manifest.body(withId: bodyId) else {
+            return .init("Body not found: \(bodyId)")
+        }
+        let outputDir = (store.path as NSString).deletingLastPathComponent
+        let bodyFile = "\(outputDir)/\(target.file)"
+
+        let updated = ScriptManifest(
+            version: manifest.version,
+            timestamp: Date(),
+            description: manifest.description,
+            bodies: manifest.bodies.filter { $0.id != bodyId },
+            graphs: manifest.graphs,
+            metadata: manifest.metadata
+        )
+        do {
+            try store.write(updated)
+        } catch {
+            return .init("Failed to write manifest: \(error.localizedDescription)", isError: true)
+        }
+        try? FileManager.default.removeItem(atPath: bodyFile)
+        return .init(
+            "Removed body \"\(bodyId)\" (file: \(target.file)). Remaining: \(updated.bodies.count)."
+        )
+    }
+
+    // ── clear_scene ────────────────────────────────────────────────────────
+
+    public static func clearScene(
+        keepHistory: Bool = false,
+        store: ManifestStore = ManifestStore(),
+        history: SceneHistory = .shared
+    ) async -> ToolText {
+        guard let manifest = try? store.read() else {
+            return .init("No scene loaded. Run execute_script first.")
+        }
+        await history.snapshot(store: store)
+
+        let outputDir = (store.path as NSString).deletingLastPathComponent
+        let removedCount = manifest.bodies.count
+        let filesToRemove = manifest.bodies.map { "\(outputDir)/\($0.file)" }
+
+        let updated = ScriptManifest(
+            version: manifest.version,
+            timestamp: Date(),
+            description: "(cleared)",
+            bodies: [],
+            graphs: manifest.graphs,
+            metadata: manifest.metadata
+        )
+        do {
+            try store.write(updated)
+        } catch {
+            return .init("Failed to write manifest: \(error.localizedDescription)", isError: true)
+        }
+        for path in filesToRemove {
+            try? FileManager.default.removeItem(atPath: path)
+        }
+        if !keepHistory {
+            await history.clear()
+        }
+        return .init(
+            "Cleared \(removedCount) bodies from scene." + (keepHistory ? "" : " History reset.")
+        )
+    }
+
+    // ── rename_body ────────────────────────────────────────────────────────
+
+    public static func renameBody(
+        bodyId: String,
+        newBodyId: String,
+        store: ManifestStore = ManifestStore(),
+        history: SceneHistory = .shared
+    ) async -> ToolText {
+        guard let manifest = try? store.read() else {
+            return .init("No scene loaded. Run execute_script first.")
+        }
+        await history.snapshot(store: store)
+
+        guard let target = manifest.body(withId: bodyId) else {
+            return .init("Body not found: \(bodyId)")
+        }
+        if manifest.bodies.contains(where: { $0.id == newBodyId }) {
+            return .init("Cannot rename: a body with id \"\(newBodyId)\" already exists.")
+        }
+
+        let updatedBodies = manifest.bodies.map { body -> BodyDescriptor in
+            guard body.id == bodyId else { return body }
+            return BodyDescriptor(
+                id: newBodyId,
+                file: body.file,
+                format: body.format,
+                name: body.name,
+                color: body.color,
+                roughness: body.roughness,
+                metallic: body.metallic
+            )
+        }
+        let updated = ScriptManifest(
+            version: manifest.version,
+            timestamp: Date(),
+            description: manifest.description,
+            bodies: updatedBodies,
+            graphs: manifest.graphs,
+            metadata: manifest.metadata
+        )
+        do {
+            try store.write(updated)
+        } catch {
+            return .init("Failed to write manifest: \(error.localizedDescription)", isError: true)
+        }
+        _ = target
+        return .init("Renamed \"\(bodyId)\" → \"\(newBodyId)\".")
+    }
+
+    // ── set_appearance ─────────────────────────────────────────────────────
+
+    public struct AppearanceUpdate {
+        public var color: [Float]?
+        public var opacity: Float?
+        public var roughness: Float?
+        public var metallic: Float?
+        public var name: String?
+        public init(
+            color: [Float]? = nil,
+            opacity: Float? = nil,
+            roughness: Float? = nil,
+            metallic: Float? = nil,
+            name: String? = nil
+        ) {
+            self.color = color
+            self.opacity = opacity
+            self.roughness = roughness
+            self.metallic = metallic
+            self.name = name
+        }
+        var anyFieldSet: Bool {
+            color != nil || opacity != nil || roughness != nil || metallic != nil || name != nil
+        }
+    }
+
+    public static func setAppearance(
+        bodyId: String,
+        update: AppearanceUpdate,
+        store: ManifestStore = ManifestStore(),
+        history: SceneHistory = .shared
+    ) async -> ToolText {
+        if !update.anyFieldSet {
+            return .init(
+                "No appearance fields provided. Pass at least one of: color, opacity, roughness, metallic, name."
+            )
+        }
+        if let c = update.color, c.count != 3 && c.count != 4 {
+            return .init("color must be [r,g,b] or [r,g,b,a]; got length \(c.count).")
+        }
+        guard let manifest = try? store.read() else {
+            return .init("No scene loaded. Run execute_script first.")
+        }
+        await history.snapshot(store: store)
+
+        guard let target = manifest.body(withId: bodyId) else {
+            return .init("Body not found: \(bodyId)")
+        }
+
+        var newColor = target.color
+        var applied: [String: String] = [:]
+        if let c = update.color {
+            let alpha: Float = (c.count == 4) ? c[3] : (target.color?.count == 4 ? target.color![3] : 1)
+            newColor = c.count == 3 ? [c[0], c[1], c[2], alpha] : c
+            applied["color"] = "\(newColor!)"
+        }
+        if let o = update.opacity {
+            var current = newColor ?? [0.7, 0.7, 0.7, 1]
+            if current.count == 3 { current.append(1) }
+            current[3] = o
+            newColor = current
+            applied["opacity"] = "\(o)"
+        }
+        let newRoughness = update.roughness ?? target.roughness
+        if let r = update.roughness { applied["roughness"] = "\(r)" }
+        let newMetallic = update.metallic ?? target.metallic
+        if let m = update.metallic { applied["metallic"] = "\(m)" }
+        let newName = update.name ?? target.name
+        if let n = update.name { applied["name"] = n }
+
+        let updatedBodies = manifest.bodies.map { body -> BodyDescriptor in
+            guard body.id == bodyId else { return body }
+            return BodyDescriptor(
+                id: body.id,
+                file: body.file,
+                format: body.format,
+                name: newName,
+                color: newColor,
+                roughness: newRoughness,
+                metallic: newMetallic
+            )
+        }
+        let updated = ScriptManifest(
+            version: manifest.version,
+            timestamp: Date(),
+            description: manifest.description,
+            bodies: updatedBodies,
+            graphs: manifest.graphs,
+            metadata: manifest.metadata
+        )
+        do {
+            try store.write(updated)
+        } catch {
+            return .init("Failed to write manifest: \(error.localizedDescription)", isError: true)
+        }
+        let pretty = applied
+            .sorted { $0.key < $1.key }
+            .map { "  \($0.key): \($0.value)" }
+            .joined(separator: "\n")
+        return .init("Updated appearance of \"\(bodyId)\":\n\(pretty)")
+    }
+
+    // ── compare_versions ───────────────────────────────────────────────────
+
+    public struct DiffReport: Encodable {
+        public let since: Int
+        public let available: Int
+        public let added: [String]
+        public let removed: [String]
+        public let appearanceChanged: [AppearanceChange]
+        public let fileChanged: [String]
+        public let unchanged: [String]
+    }
+    public struct AppearanceChange: Encodable {
+        public let id: String
+        public let fields: [String]
+    }
+
+    public static func compareVersions(
+        since: Int = 1,
+        store: ManifestStore = ManifestStore(),
+        history: SceneHistory = .shared
+    ) async -> ToolText {
+        guard let current = try? store.read() else {
+            return .init("No scene loaded. Run execute_script first.")
+        }
+        let availableCount = await history.count()
+        guard let prior = await history.snapshot(since: since) else {
+            return .init(
+                "Not enough history: requested \(since) runs back, only \(availableCount) snapshots available. Make at least \(since) state changes (execute_script or scene-mutation tools) before comparing."
+            )
+        }
+        let diff = diffManifests(prev: prior, curr: current, since: since, available: availableCount)
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        do {
+            let data = try encoder.encode(diff)
+            return .init(String(data: data, encoding: .utf8) ?? "{}")
+        } catch {
+            return .init("Failed to encode diff: \(error.localizedDescription)", isError: true)
+        }
+    }
+
+    static func diffManifests(
+        prev: ScriptManifest,
+        curr: ScriptManifest,
+        since: Int,
+        available: Int
+    ) -> DiffReport {
+        func key(_ b: BodyDescriptor) -> String {
+            return b.id ?? "__noid_\(b.file)"
+        }
+        let prevByKey = Dictionary(uniqueKeysWithValues: prev.bodies.map { (key($0), $0) })
+        let currByKey = Dictionary(uniqueKeysWithValues: curr.bodies.map { (key($0), $0) })
+
+        var added: [String] = []
+        var removed: [String] = []
+        var appearanceChanged: [AppearanceChange] = []
+        var fileChanged: [String] = []
+        var unchanged: [String] = []
+
+        for (k, currBody) in currByKey {
+            guard let prevBody = prevByKey[k] else {
+                added.append(k)
+                continue
+            }
+            var fields: [String] = []
+            if currBody.color != prevBody.color { fields.append("color") }
+            if currBody.name != prevBody.name { fields.append("name") }
+            if currBody.roughness != prevBody.roughness { fields.append("roughness") }
+            if currBody.metallic != prevBody.metallic { fields.append("metallic") }
+            if currBody.file != prevBody.file {
+                fileChanged.append(k)
+            }
+            if !fields.isEmpty {
+                appearanceChanged.append(AppearanceChange(id: k, fields: fields))
+            }
+            if fields.isEmpty && currBody.file == prevBody.file {
+                unchanged.append(k)
+            }
+        }
+        for k in prevByKey.keys where currByKey[k] == nil {
+            removed.append(k)
+        }
+
+        return DiffReport(
+            since: since,
+            available: available,
+            added: added.sorted(),
+            removed: removed.sorted(),
+            appearanceChanged: appearanceChanged.sorted { $0.id < $1.id },
+            fileChanged: fileChanged.sorted(),
+            unchanged: unchanged.sorted()
+        )
+    }
+}

--- a/Sources/OCCTMCPServer/main.swift
+++ b/Sources/OCCTMCPServer/main.swift
@@ -1,0 +1,16 @@
+// OCCTMCPServer — executable entry point. Builds the MCP server, binds it
+// to stdio, and parks until the client disconnects.
+
+import Foundation
+import MCP
+import OCCTMCPCore
+
+@main
+struct OCCTMCPServerMain {
+    static func main() async throws {
+        let server = await makeOCCTMCPServer()
+        let transport = StdioTransport()
+        try await server.start(transport: transport)
+        await server.waitUntilCompleted()
+    }
+}

--- a/SwiftTests/OCCTMCPCoreTests/PingTests.swift
+++ b/SwiftTests/OCCTMCPCoreTests/PingTests.swift
@@ -1,0 +1,29 @@
+import Testing
+import MCP
+@testable import OCCTMCPCore
+
+@Suite("OCCTMCP server scaffold")
+struct PingTests {
+    @Test("server lists the ping tool")
+    func listsPing() async throws {
+        let tools = catalogTools()
+        #expect(tools.contains(where: { $0.name == "ping" }))
+    }
+
+    @Test("ping handler returns pong")
+    func pingPongs() async throws {
+        let result = await dispatch(callName: "ping", arguments: [:])
+        #expect(result.isError == false)
+        guard case .text(let text, _, _) = result.content.first else {
+            Issue.record("expected a text content block")
+            return
+        }
+        #expect(text == "pong")
+    }
+
+    @Test("unknown tool name produces an error result")
+    func unknownToolErrors() async throws {
+        let result = await dispatch(callName: "no-such-tool", arguments: [:])
+        #expect(result.isError == true)
+    }
+}

--- a/SwiftTests/OCCTMCPCoreTests/SceneToolsTests.swift
+++ b/SwiftTests/OCCTMCPCoreTests/SceneToolsTests.swift
@@ -1,0 +1,176 @@
+// Unit tests for the scene-mutation tools — mirror tests/unit/
+// scene-mutation.test.mjs from the Node side.
+
+import Foundation
+import Testing
+import ScriptHarness
+@testable import OCCTMCPCore
+
+@Suite("Scene-mutation tools")
+struct SceneToolsTests {
+
+    /// Build a fresh tempdir, seed it with `alpha`+`beta` bodies and a
+    /// matching manifest, return a ManifestStore pointing at it. The
+    /// caller is responsible for SceneHistory.shared.clear().
+    func freshScene() throws -> ManifestStore {
+        let dir = NSTemporaryDirectory() + "occtmcp-swifttest-\(UUID().uuidString)"
+        try FileManager.default.createDirectory(
+            atPath: dir, withIntermediateDirectories: true)
+        let manifest = ScriptManifest(
+            version: 1,
+            timestamp: Date(),
+            description: "Test scene",
+            bodies: [
+                BodyDescriptor(id: "alpha", file: "alpha.brep", color: [1, 0, 0, 1]),
+                BodyDescriptor(id: "beta", file: "beta.brep", color: [0, 1, 0, 1]),
+            ]
+        )
+        let store = ManifestStore(path: "\(dir)/manifest.json")
+        try store.write(manifest)
+        try "DUMMY-A".write(toFile: "\(dir)/alpha.brep", atomically: true, encoding: .utf8)
+        try "DUMMY-B".write(toFile: "\(dir)/beta.brep", atomically: true, encoding: .utf8)
+        return store
+    }
+
+    func dirOf(_ store: ManifestStore) -> String {
+        return (store.path as NSString).deletingLastPathComponent
+    }
+
+    // ── remove_body ─────────────────────────────────────────────────────────
+
+    @Test("remove_body deletes manifest entry and BREP file")
+    func removesBody() async throws {
+        let store = try freshScene()
+        await SceneHistory.shared.clear()
+        defer { try? FileManager.default.removeItem(atPath: dirOf(store)) }
+
+        let result = await SceneTools.removeBody(bodyId: "alpha", store: store)
+        #expect(result.text.contains("Removed body \"alpha\""))
+
+        let updated = try store.read()
+        #expect(updated?.bodies.count == 1)
+        #expect(updated?.bodies.first?.id == "beta")
+        #expect(!FileManager.default.fileExists(atPath: "\(dirOf(store))/alpha.brep"))
+        #expect(FileManager.default.fileExists(atPath: "\(dirOf(store))/beta.brep"))
+    }
+
+    @Test("remove_body errors on unknown id")
+    func removesBodyMissing() async throws {
+        let store = try freshScene()
+        await SceneHistory.shared.clear()
+        defer { try? FileManager.default.removeItem(atPath: dirOf(store)) }
+
+        let result = await SceneTools.removeBody(bodyId: "nope", store: store)
+        #expect(result.text.contains("Body not found: nope"))
+    }
+
+    // ── clear_scene ─────────────────────────────────────────────────────────
+
+    @Test("clear_scene removes every body and its BREP")
+    func clearScene() async throws {
+        let store = try freshScene()
+        await SceneHistory.shared.clear()
+        defer { try? FileManager.default.removeItem(atPath: dirOf(store)) }
+
+        let result = await SceneTools.clearScene(keepHistory: false, store: store)
+        #expect(result.text.contains("Cleared 2 bodies"))
+
+        let updated = try store.read()
+        #expect(updated?.bodies.isEmpty == true)
+        #expect(!FileManager.default.fileExists(atPath: "\(dirOf(store))/alpha.brep"))
+        #expect(!FileManager.default.fileExists(atPath: "\(dirOf(store))/beta.brep"))
+    }
+
+    // ── rename_body ─────────────────────────────────────────────────────────
+
+    @Test("rename_body changes the id")
+    func renameBody() async throws {
+        let store = try freshScene()
+        await SceneHistory.shared.clear()
+        defer { try? FileManager.default.removeItem(atPath: dirOf(store)) }
+
+        let result = await SceneTools.renameBody(
+            bodyId: "alpha", newBodyId: "alpha2", store: store)
+        #expect(result.text.contains("\"alpha\" → \"alpha2\""))
+
+        let updated = try store.read()
+        #expect(updated?.bodies.first(where: { $0.file == "alpha.brep" })?.id == "alpha2")
+    }
+
+    @Test("rename_body rejects collisions")
+    func renameBodyCollision() async throws {
+        let store = try freshScene()
+        await SceneHistory.shared.clear()
+        defer { try? FileManager.default.removeItem(atPath: dirOf(store)) }
+
+        let result = await SceneTools.renameBody(
+            bodyId: "alpha", newBodyId: "beta", store: store)
+        #expect(result.text.contains("already exists"))
+    }
+
+    // ── set_appearance ──────────────────────────────────────────────────────
+
+    @Test("set_appearance updates color, opacity, and name")
+    func setAppearanceUpdates() async throws {
+        let store = try freshScene()
+        await SceneHistory.shared.clear()
+        defer { try? FileManager.default.removeItem(atPath: dirOf(store)) }
+
+        let result = await SceneTools.setAppearance(
+            bodyId: "alpha",
+            update: .init(color: [0.2, 0.4, 0.6], opacity: 0.5, name: "Alpha part"),
+            store: store
+        )
+        #expect(result.text.contains("Updated appearance of \"alpha\""))
+
+        let updated = try store.read()
+        let alpha = updated?.body(withId: "alpha")
+        #expect(alpha?.color == [0.2, 0.4, 0.6, 0.5])
+        #expect(alpha?.name == "Alpha part")
+    }
+
+    @Test("set_appearance rejects empty input")
+    func setAppearanceEmpty() async throws {
+        let store = try freshScene()
+        await SceneHistory.shared.clear()
+        defer { try? FileManager.default.removeItem(atPath: dirOf(store)) }
+
+        let result = await SceneTools.setAppearance(
+            bodyId: "alpha", update: .init(), store: store)
+        #expect(result.text.contains("No appearance fields provided"))
+    }
+
+    // ── compare_versions ────────────────────────────────────────────────────
+
+    @Test("compare_versions reports added bodies")
+    func compareVersionsAdds() async throws {
+        let store = try freshScene()
+        await SceneHistory.shared.clear()
+        defer { try? FileManager.default.removeItem(atPath: dirOf(store)) }
+
+        // Snapshot first, then mutate
+        await SceneHistory.shared.snapshot(store: store)
+        let cur = try store.read()!
+        var bodies = cur.bodies
+        bodies.append(BodyDescriptor(id: "gamma", file: "gamma.brep"))
+        let updated = ScriptManifest(
+            version: cur.version, timestamp: Date(), description: cur.description,
+            bodies: bodies, graphs: cur.graphs, metadata: cur.metadata
+        )
+        try store.write(updated)
+
+        let result = await SceneTools.compareVersions(since: 1, store: store)
+        #expect(result.text.contains("\"added\""))
+        #expect(result.text.contains("\"gamma\""))
+    }
+
+    @Test("compare_versions errors when history is too shallow")
+    func compareVersionsShallow() async throws {
+        let store = try freshScene()
+        await SceneHistory.shared.clear()
+        defer { try? FileManager.default.removeItem(atPath: dirOf(store)) }
+
+        let result = await SceneTools.compareVersions(since: 5, store: store)
+        #expect(result.text.contains("Not enough history"))
+    }
+}

--- a/SwiftTests/OCCTMCPCoreTests/SceneToolsTests.swift
+++ b/SwiftTests/OCCTMCPCoreTests/SceneToolsTests.swift
@@ -41,10 +41,10 @@ struct SceneToolsTests {
     @Test("remove_body deletes manifest entry and BREP file")
     func removesBody() async throws {
         let store = try freshScene()
-        await SceneHistory.shared.clear()
+        let history = SceneHistory()
         defer { try? FileManager.default.removeItem(atPath: dirOf(store)) }
 
-        let result = await SceneTools.removeBody(bodyId: "alpha", store: store)
+        let result = await SceneTools.removeBody(bodyId: "alpha", store: store, history: history)
         #expect(result.text.contains("Removed body \"alpha\""))
 
         let updated = try store.read()
@@ -57,10 +57,10 @@ struct SceneToolsTests {
     @Test("remove_body errors on unknown id")
     func removesBodyMissing() async throws {
         let store = try freshScene()
-        await SceneHistory.shared.clear()
+        let history = SceneHistory()
         defer { try? FileManager.default.removeItem(atPath: dirOf(store)) }
 
-        let result = await SceneTools.removeBody(bodyId: "nope", store: store)
+        let result = await SceneTools.removeBody(bodyId: "nope", store: store, history: history)
         #expect(result.text.contains("Body not found: nope"))
     }
 
@@ -69,10 +69,10 @@ struct SceneToolsTests {
     @Test("clear_scene removes every body and its BREP")
     func clearScene() async throws {
         let store = try freshScene()
-        await SceneHistory.shared.clear()
+        let history = SceneHistory()
         defer { try? FileManager.default.removeItem(atPath: dirOf(store)) }
 
-        let result = await SceneTools.clearScene(keepHistory: false, store: store)
+        let result = await SceneTools.clearScene(keepHistory: false, store: store, history: history)
         #expect(result.text.contains("Cleared 2 bodies"))
 
         let updated = try store.read()
@@ -86,11 +86,11 @@ struct SceneToolsTests {
     @Test("rename_body changes the id")
     func renameBody() async throws {
         let store = try freshScene()
-        await SceneHistory.shared.clear()
+        let history = SceneHistory()
         defer { try? FileManager.default.removeItem(atPath: dirOf(store)) }
 
         let result = await SceneTools.renameBody(
-            bodyId: "alpha", newBodyId: "alpha2", store: store)
+            bodyId: "alpha", newBodyId: "alpha2", store: store, history: history)
         #expect(result.text.contains("\"alpha\" → \"alpha2\""))
 
         let updated = try store.read()
@@ -100,11 +100,11 @@ struct SceneToolsTests {
     @Test("rename_body rejects collisions")
     func renameBodyCollision() async throws {
         let store = try freshScene()
-        await SceneHistory.shared.clear()
+        let history = SceneHistory()
         defer { try? FileManager.default.removeItem(atPath: dirOf(store)) }
 
         let result = await SceneTools.renameBody(
-            bodyId: "alpha", newBodyId: "beta", store: store)
+            bodyId: "alpha", newBodyId: "beta", store: store, history: history)
         #expect(result.text.contains("already exists"))
     }
 
@@ -113,13 +113,14 @@ struct SceneToolsTests {
     @Test("set_appearance updates color, opacity, and name")
     func setAppearanceUpdates() async throws {
         let store = try freshScene()
-        await SceneHistory.shared.clear()
+        let history = SceneHistory()
         defer { try? FileManager.default.removeItem(atPath: dirOf(store)) }
 
         let result = await SceneTools.setAppearance(
             bodyId: "alpha",
             update: .init(color: [0.2, 0.4, 0.6], opacity: 0.5, name: "Alpha part"),
-            store: store
+            store: store,
+            history: history
         )
         #expect(result.text.contains("Updated appearance of \"alpha\""))
 
@@ -132,11 +133,11 @@ struct SceneToolsTests {
     @Test("set_appearance rejects empty input")
     func setAppearanceEmpty() async throws {
         let store = try freshScene()
-        await SceneHistory.shared.clear()
+        let history = SceneHistory()
         defer { try? FileManager.default.removeItem(atPath: dirOf(store)) }
 
         let result = await SceneTools.setAppearance(
-            bodyId: "alpha", update: .init(), store: store)
+            bodyId: "alpha", update: .init(), store: store, history: history)
         #expect(result.text.contains("No appearance fields provided"))
     }
 
@@ -145,11 +146,11 @@ struct SceneToolsTests {
     @Test("compare_versions reports added bodies")
     func compareVersionsAdds() async throws {
         let store = try freshScene()
-        await SceneHistory.shared.clear()
+        let history = SceneHistory()
         defer { try? FileManager.default.removeItem(atPath: dirOf(store)) }
 
         // Snapshot first, then mutate
-        await SceneHistory.shared.snapshot(store: store)
+        await history.snapshot(store: store)
         let cur = try store.read()!
         var bodies = cur.bodies
         bodies.append(BodyDescriptor(id: "gamma", file: "gamma.brep"))
@@ -159,7 +160,7 @@ struct SceneToolsTests {
         )
         try store.write(updated)
 
-        let result = await SceneTools.compareVersions(since: 1, store: store)
+        let result = await SceneTools.compareVersions(since: 1, store: store, history: history)
         #expect(result.text.contains("\"added\""))
         #expect(result.text.contains("\"gamma\""))
     }
@@ -167,10 +168,10 @@ struct SceneToolsTests {
     @Test("compare_versions errors when history is too shallow")
     func compareVersionsShallow() async throws {
         let store = try freshScene()
-        await SceneHistory.shared.clear()
+        let history = SceneHistory()
         defer { try? FileManager.default.removeItem(atPath: dirOf(store)) }
 
-        let result = await SceneTools.compareVersions(since: 5, store: store)
+        let result = await SceneTools.compareVersions(since: 5, store: store, history: history)
         #expect(result.text.contains("Not enough history"))
     }
 }


### PR DESCRIPTION
## Summary

Full port of OCCTMCP to the official Swift MCP SDK ([modelcontextprotocol/swift-sdk](https://github.com/modelcontextprotocol/swift-sdk)), unblocking Swift Package Index publication. Coexists with the Node/TS implementation under `src/` until parity is reached; once done, the Node code can be retired.

This PR is being landed in **incremental commits** so the diff is reviewable and each tool can be verified in isolation. Will be marked ready-for-review once Phase 5.4 lands.

## Progress

### ✅ Phase 5.1 — Scaffold (commit `721272b`)
- `Package.swift` with library `OCCTMCPCore` + executable `occtmcp-server`
- Dependencies: swift-mcp-sdk 0.11+, OCCTSwift 0.165+, OCCTSwiftMesh 0.1+
- Sanity `ping` tool, 3 swift-testing cases, `.build/` gitignored

### ✅ Phase 5.2 — Scene mutators (commit `d1352d4`)
- Pulled in OCCTSwiftScripts dep (for `ScriptHarness.ScriptManifest`/`BodyDescriptor` and `DrawingComposer`)
- `Paths.swift` (env override > iCloud > local), `Manifest.swift` (Sendable read/write store), `SceneHistory.swift` (actor-wrapped ring buffer)
- 5 of 6 scene-mutation tools: `remove_body`, `clear_scene`, `rename_body`, `set_appearance`, `compare_versions`
- `export_scene` deferred to Phase 5.3 (will go in-process via `Exporter.writeXxx` instead of templated Swift script)
- 9 swift-testing cases against tempdir-redirected manifest

### ✅ Phase 5.3a — Pure-read introspection (commit `1a39786`)
- `compute_metrics` — `Shape.volumeInertia` / `.surfaceArea` / `.bounds`
- `query_topology` — `shape.faces()` / `.edges()` / `.vertices()` with surface/curve type classifiers
- `measure_distance` — `Shape.minDistance(to:)` / `.allDistanceSolutions(to:)`
- All direct OCCTSwift calls — replaces the fork+exec + JSONL marshaling pattern from the Node implementation

## Remaining

- **5.3b** — construction (transform_body, boolean_op, mirror_or_pattern, apply_feature)
- **5.3c** — engineering analysis (check_thickness, analyze_clearance, heal_shape, generate_mesh, simplify_mesh)
- **5.3d** — I/O + assembly (read_brep, import_file, inspect_assembly, set_assembly_metadata, export_scene)
- **5.3e** — visualization (render_preview via OCCTSwiftViewport's OffscreenRenderer, generate_drawing via DrawingComposer)
- **5.3f** — `validate_geometry`, `recognize_features` (in-process via ScriptHarness GraphIO + OCCTSwift AAG)
- **5.4** — `execute_script` (cached SPM workspace pattern from `occtkit Run`), Swift-side integration tests, tag v0.1.0, submit to Swift Package Index

Once parity lands: retire `src/` (or keep it under an archived subdirectory for one release cycle as a safety net).

## Test plan

- [x] `swift build` — clean (~3s warm, ~38s cold for the OCCTSwiftMesh transitive compile chain)
- [x] `swift test` — 12 swift-testing cases passing (3 ping + 9 scene mutators)
- [ ] Per-Phase 5.3 unit tests will land alongside each commit
- [ ] Phase 5.4 will add a stdio end-to-end harness (matches the Node `tests/integration/` shape)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
