### PR TITLE
Port execute_script + graph_ml (Phase 5.4)

### DIFF
--- a/Sources/OCCTMCPCore/Server.swift
+++ b/Sources/OCCTMCPCore/Server.swift
@@ -158,6 +158,19 @@ func catalogTools() -> [Tool] {
             ])
         ),
         Tool(
+            name: "graph_ml",
+            description: "Export a BREP's topology graph as ML-friendly JSON. Pass an absolute BREP path and optionally a description. Wraps ScriptHarness BREPGraphJSONExporter.",
+            inputSchema: .object([
+                "type": .string("object"),
+                "properties": .object([
+                    "brep_path": .object(["type": .string("string")]),
+                    "description": .object(["type": .string("string")]),
+                ]),
+                "required": .array([.string("brep_path")]),
+                "additionalProperties": .bool(false),
+            ])
+        ),
+        Tool(
             name: "feature_recognize",
             description: "Detect pockets and holes via AAG heuristics. Pass an absolute BREP path; recognize_features is the scene-aware variant.",
             inputSchema: .object([
@@ -690,6 +703,15 @@ func dispatch(callName: String, arguments: [String: Value]) async -> CallTool.Re
             return ToolText("feature_recognize requires `brep_path`.", isError: true).asCallToolResult()
         }
         return await AnalysisTools.featureRecognize(brepPath: path).asCallToolResult()
+
+    case "graph_ml":
+        guard let path = arguments["brep_path"]?.stringValue else {
+            return ToolText("graph_ml requires `brep_path`.", isError: true).asCallToolResult()
+        }
+        return await AnalysisTools.graphML(
+            brepPath: path,
+            description: arguments["description"]?.stringValue
+        ).asCallToolResult()
 
     case "remove_body":
         guard let bodyId = arguments["bodyId"]?.stringValue else {

--- a/Sources/OCCTMCPCore/Server.swift
+++ b/Sources/OCCTMCPCore/Server.swift
@@ -231,6 +231,25 @@ func catalogTools() -> [Tool] {
             ])
         ),
         Tool(
+            name: "execute_script",
+            description: "Compile and run an arbitrary Swift CAD script via a cached SPM workspace. The script must import OCCTSwift and ScriptHarness, accumulate geometry on a ScriptContext, and call ctx.emit(). Cold start ~60s on first call (full SPM build of OCCTSwift); subsequent calls ~1-2s incremental.",
+            inputSchema: .object([
+                "type": .string("object"),
+                "properties": .object([
+                    "code": .object([
+                        "type": .string("string"),
+                        "description": .string("Complete Swift source for main.swift."),
+                    ]),
+                    "description": .object([
+                        "type": .string("string"),
+                        "description": .string("Short description of what this script creates."),
+                    ]),
+                ]),
+                "required": .array([.string("code")]),
+                "additionalProperties": .bool(false),
+            ])
+        ),
+        Tool(
             name: "ping",
             description: "Sanity-check tool — returns 'pong' so callers can verify the OCCTMCP Swift server is alive.",
             inputSchema: .object([
@@ -561,6 +580,15 @@ func dispatch(callName: String, arguments: [String: Value]) async -> CallTool.Re
     switch callName {
     case "ping":
         return ToolText("pong").asCallToolResult()
+
+    case "execute_script":
+        guard let code = arguments["code"]?.stringValue else {
+            return ToolText("execute_script requires `code`.", isError: true).asCallToolResult()
+        }
+        return await ExecuteScriptTool.execute(
+            code: code,
+            description: arguments["description"]?.stringValue
+        ).asCallToolResult()
 
     case "apply_feature":
         guard let bodyId = arguments["bodyId"]?.stringValue,

--- a/Sources/OCCTMCPCore/Tools/AnalysisTools.swift
+++ b/Sources/OCCTMCPCore/Tools/AnalysisTools.swift
@@ -288,6 +288,27 @@ public enum AnalysisTools {
         }
     }
 
+    public static func graphML(
+        brepPath: String,
+        description: String? = nil
+    ) async -> ToolText {
+        guard FileManager.default.fileExists(atPath: brepPath) else {
+            return .init("BREP file not found: \(brepPath)")
+        }
+        do {
+            let shape = try Shape.loadBREP(fromPath: brepPath)
+            let graph = try GraphIO.buildGraph(from: shape)
+            let tempURL = URL(fileURLWithPath: NSTemporaryDirectory())
+                .appendingPathComponent("occtmcp-graphml-\(UUID().uuidString).json")
+            try BREPGraphJSONExporter.export(graph, to: tempURL, description: description)
+            defer { try? FileManager.default.removeItem(at: tempURL) }
+            let data = try Data(contentsOf: tempURL)
+            return .init(String(data: data, encoding: .utf8) ?? "{}")
+        } catch {
+            return .init("graph_ml failed: \(error.localizedDescription)", isError: true)
+        }
+    }
+
     public static func featureRecognize(brepPath: String) async -> ToolText {
         guard FileManager.default.fileExists(atPath: brepPath) else {
             return .init("BREP file not found: \(brepPath)")

--- a/Sources/OCCTMCPCore/Tools/ExecuteScriptTool.swift
+++ b/Sources/OCCTMCPCore/Tools/ExecuteScriptTool.swift
@@ -1,0 +1,197 @@
+// ExecuteScriptTool — runs an arbitrary Swift CAD script via a cached
+// SPM workspace. Mirrors `occtkit run` (Sources/occtkit/Commands/Run.swift)
+// from OCCTSwiftScripts but lives in-process here so the MCP server
+// doesn't need to fork a separate occtkit binary.
+//
+// Cache layout: ~/.occtmcp-cache/workspace/{Package.swift,Sources/Script/main.swift}.
+// First call is slow (SPM builds OCCTSwift transitive). Subsequent calls
+// are incremental builds (~1-2s on a hot system).
+//
+// Side effect: ScriptContext.emit() in the user script writes a fresh
+// manifest.json into the resolved output directory. SceneHistory snapshots
+// the prior state so compare_versions sees the change.
+
+import Foundation
+
+public enum ExecuteScriptTool {
+
+    public static let cacheDir: URL = FileManager.default.homeDirectoryForCurrentUser
+        .appendingPathComponent(".occtmcp-cache/workspace")
+
+    public static let buildTimeoutSeconds: TimeInterval = 300
+
+    /// Pin floor for OCCTSwiftScripts (provides ScriptHarness). Bump as
+    /// new ScriptManifest fields land.
+    static let scriptsPin = "0.8.1"
+
+    public static func execute(
+        code: String,
+        description: String? = nil,
+        history: ScriptHistoryStore = .shared,
+        store: ManifestStore = ManifestStore(),
+        sceneHistory: SceneHistory = .shared
+    ) async -> ToolText {
+        await sceneHistory.snapshot(store: store)
+        await history.set(code)
+
+        do {
+            try ensureWorkspace()
+            try writeUserScript(code: code)
+        } catch {
+            return .init("Workspace setup failed: \(error.localizedDescription)", isError: true)
+        }
+
+        let runResult: RunResult
+        do {
+            runResult = try await runWorkspace()
+        } catch {
+            return .init("Build / run failed: \(error.localizedDescription)", isError: true)
+        }
+
+        let filtered = filterBuildOutput(
+            [runResult.stdout, runResult.stderr].filter { !$0.isEmpty }.joined(separator: "\n")
+        )
+        var manifestSection = ""
+        if let manifest = try? store.read() {
+            let encoder = JSONEncoder()
+            encoder.dateEncodingStrategy = .iso8601
+            encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+            if let data = try? encoder.encode(manifest),
+               let str = String(data: data, encoding: .utf8) {
+                manifestSection = "\n\nManifest:\n\(str)"
+            }
+        }
+        if runResult.exitCode == 0 {
+            let prefix = "Script executed successfully."
+                + (description.map { " (\($0))" } ?? "")
+            return .init("\(prefix)\n\nOutput:\n\(filtered.isEmpty ? "(no output)" : filtered)\(manifestSection)")
+        }
+        return .init("Script failed.\n\n\(filtered)", isError: true)
+    }
+
+    // MARK: - Workspace management
+
+    static func ensureWorkspace() throws {
+        let fm = FileManager.default
+        try fm.createDirectory(
+            at: cacheDir.appendingPathComponent("Sources/Script"),
+            withIntermediateDirectories: true
+        )
+        let packageURL = cacheDir.appendingPathComponent("Package.swift")
+        let packageContent = """
+        // swift-tools-version: 6.0
+        import PackageDescription
+
+        let package = Package(
+            name: "OCCTMCPUserScript",
+            platforms: [.macOS(.v15)],
+            dependencies: [
+                .package(url: "https://github.com/gsdali/OCCTSwiftScripts.git", from: "\(scriptsPin)"),
+            ],
+            targets: [
+                .executableTarget(
+                    name: "Script",
+                    dependencies: [
+                        .product(name: "ScriptHarness", package: "OCCTSwiftScripts"),
+                    ],
+                    path: "Sources/Script",
+                    swiftSettings: [.swiftLanguageMode(.v6)]
+                ),
+            ]
+        )
+        """
+        // Only rewrite when the contents change so SPM's mtime-based
+        // up-to-date checks aren't invalidated on every call.
+        let existing = try? String(contentsOf: packageURL, encoding: .utf8)
+        if existing != packageContent {
+            try packageContent.write(to: packageURL, atomically: true, encoding: .utf8)
+        }
+    }
+
+    static func writeUserScript(code: String) throws {
+        let mainURL = cacheDir.appendingPathComponent("Sources/Script/main.swift")
+        try code.write(to: mainURL, atomically: true, encoding: .utf8)
+    }
+
+    // MARK: - Build & run
+
+    struct RunResult {
+        let stdout: String
+        let stderr: String
+        let exitCode: Int32
+    }
+
+    static func runWorkspace() async throws -> RunResult {
+        // First build (catch compile errors cleanly), then run with
+        // --skip-build so script stdout isn't drowned in build noise.
+        let build = try runProcess(
+            executable: "/usr/bin/swift",
+            args: ["build", "-c", "release", "--package-path", cacheDir.path]
+        )
+        if build.exitCode != 0 {
+            return build
+        }
+        return try runProcess(
+            executable: "/usr/bin/swift",
+            args: ["run", "-c", "release", "--skip-build",
+                   "--package-path", cacheDir.path, "Script"]
+        )
+    }
+
+    static func runProcess(executable: String, args: [String]) throws -> RunResult {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: executable)
+        process.arguments = args
+        process.currentDirectoryURL = cacheDir
+
+        let stdoutPipe = Pipe()
+        let stderrPipe = Pipe()
+        process.standardOutput = stdoutPipe
+        process.standardError = stderrPipe
+        try process.run()
+        process.waitUntilExit()
+
+        let stdout = String(
+            data: stdoutPipe.fileHandleForReading.readDataToEndOfFile(),
+            encoding: .utf8
+        ) ?? ""
+        let stderr = String(
+            data: stderrPipe.fileHandleForReading.readDataToEndOfFile(),
+            encoding: .utf8
+        ) ?? ""
+        return RunResult(stdout: stdout, stderr: stderr, exitCode: process.terminationStatus)
+    }
+
+    // MARK: - Output filtering (mirrors src/tools.ts filterBuildOutput)
+
+    static func filterBuildOutput(_ raw: String) -> String {
+        let kept = raw
+            .split(separator: "\n", omittingEmptySubsequences: false)
+            .map(String.init)
+            .filter { line in
+                !line.contains("nullability type specifier")
+                    && !line.contains("insert '_Nullable'")
+                    && !line.contains("insert '_Nonnull'")
+                    && !line.contains("insert '_Null_unspecified'")
+                    && !line.contains("<module-includes>:")
+                    && !line.contains("in file included from <module-includes>")
+                    && !line.contains("#import \"OCCTBridge.h\"")
+                    && !isContextLine(line)
+            }
+        return kept.joined(separator: "\n")
+            .replacingOccurrences(
+                of: "\n{3,}", with: "\n\n",
+                options: .regularExpression
+            )
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private static func isContextLine(_ line: String) -> Bool {
+        // Pure line-number context like "  42 |"
+        if line.range(of: #"^\s*\d+\s*\|\s*$"#, options: .regularExpression) != nil { return true }
+        // Caret/note lines
+        if line.range(of: #"^\s*\|.*(?:warning|note):"#, options: .regularExpression) != nil { return true }
+        if line.range(of: #"^\s*\|\s*[`|]-"#, options: .regularExpression) != nil { return true }
+        return false
+    }
+}

--- a/SwiftTests/OCCTMCPCoreTests/ExecuteScriptTests.swift
+++ b/SwiftTests/OCCTMCPCoreTests/ExecuteScriptTests.swift
@@ -1,0 +1,66 @@
+// Unit tests for ExecuteScriptTool's pure logic — output filtering and
+// workspace scaffolding. The SPM-build-and-run path is exercised by
+// the (slow, opt-in) integration suite once Phase 5.4's stdio harness
+// lands.
+
+import Foundation
+import Testing
+@testable import OCCTMCPCore
+
+@Suite("execute_script logic")
+struct ExecuteScriptTests {
+
+    @Test("filterBuildOutput drops OCCT bridge nullability noise")
+    func filtersBridgeNoise() {
+        let input = """
+        Build complete!
+        warning: nullability type specifier 'NSStringEncoding *' missing nullability annotation; insert '_Nullable' if the pointer may be null
+        ScriptContext: emitting 1 body
+        in file included from <module-includes>:42
+        normal log line
+        """
+        let out = ExecuteScriptTool.filterBuildOutput(input)
+        #expect(!out.contains("nullability type specifier"))
+        #expect(!out.contains("<module-includes>"))
+        #expect(out.contains("ScriptContext"))
+        #expect(out.contains("normal log line"))
+    }
+
+    @Test("filterBuildOutput collapses runs of blank lines")
+    func collapsesBlankRuns() {
+        let input = "first\n\n\n\n\nsecond"
+        let out = ExecuteScriptTool.filterBuildOutput(input)
+        #expect(out == "first\n\nsecond")
+    }
+
+    @Test("ensureWorkspace creates Package.swift and Sources/Script directory")
+    func ensuresWorkspace() throws {
+        // Use a tempdir as the cache root by overriding cacheDir via reflection
+        // is awkward; instead, just call against the real cache and clean up
+        // any prior state to keep the test deterministic.
+        // (The real cache is a shared resource; serial running is fine because
+        // swift-testing serialises tests within a single suite by default.)
+        let fm = FileManager.default
+        let pkg = ExecuteScriptTool.cacheDir.appendingPathComponent("Package.swift")
+        let src = ExecuteScriptTool.cacheDir.appendingPathComponent("Sources/Script")
+
+        try? fm.removeItem(at: ExecuteScriptTool.cacheDir)
+        try ExecuteScriptTool.ensureWorkspace()
+        #expect(fm.fileExists(atPath: pkg.path))
+        #expect(fm.fileExists(atPath: src.path))
+
+        let contents = try String(contentsOf: pkg, encoding: .utf8)
+        #expect(contents.contains("OCCTMCPUserScript"))
+        #expect(contents.contains("ScriptHarness"))
+    }
+
+    @Test("writeUserScript writes main.swift verbatim")
+    func writesUserScript() throws {
+        try ExecuteScriptTool.ensureWorkspace()
+        let code = "// hello, world\nprint(\"hi\")\n"
+        try ExecuteScriptTool.writeUserScript(code: code)
+        let mainURL = ExecuteScriptTool.cacheDir.appendingPathComponent("Sources/Script/main.swift")
+        let written = try String(contentsOf: mainURL, encoding: .utf8)
+        #expect(written == code)
+    }
+}


### PR DESCRIPTION
## Summary

Phase 5.4 of the Swift port. Adds `execute_script` (the headline tool) plus `graph_ml`, bringing the live tool count to **34 of 36**.

After this lands the Swift binary covers every routine LLM CAD flow — typed primitives for "what's the volume?" / "boolean-subtract these" / "render a preview" / "export to STEP", plus the escape hatch (`execute_script`) for novel geometry. The remaining 2 tools (`set_assembly_metadata`, `render_preview`, `check_thickness` — actually 3) are deferred behind external work (XCAF write surface, OCCTSwiftViewport `OffscreenRenderer`, custom ray-cast port).

## What lands

### `execute_script` (`Sources/OCCTMCPCore/Tools/ExecuteScriptTool.swift`)

Mirrors `occtkit run` but lives in-process so the Swift MCP binary doesn't need to fork a separate `occtkit` subprocess.

- **Cache:** `~/.occtmcp-cache/workspace/` with a `Package.swift` pinning OCCTSwiftScripts and exposing `ScriptHarness` as the only target dep. First call is slow (full SwiftPM build of the OCCTSwift transitive closure); subsequent calls amortise to the incremental ~1–2 s.
- **`ensureWorkspace()`** is idempotent and only rewrites `Package.swift` when the contents would change, so SPM's mtime-based up-to-date checks survive.
- **`runWorkspace()`** does `swift build` then `swift run --skip-build` — that way the user script's stdout isn't drowned in build noise on success but real compile errors still surface.
- **`filterBuildOutput`** is the Swift port of `src/tools.ts`'s filter — strips OCCT bridge nullability warnings and pure context-only diag lines so the LLM sees just script output + real errors.
- Snapshot is taken before each script so `compare_versions` sees the change; `ScriptHistoryStore` is fed the source so `get_script` can return it.

### `graph_ml`

Thin wrapper around `ScriptHarness.BREPGraphJSONExporter`. Writes the JSON to a tempfile, reads it back, returns it verbatim — matching the Node side's pass-through behaviour. The Node `uv_samples` / `edge_samples` params are deferred until OCCTSwiftScripts exposes parameterised export.

### Tests

4 new `swift-testing` cases covering `filterBuildOutput`, `ensureWorkspace`, and `writeUserScript`. Total: **16 cases across 3 suites**, all green in <50 ms wall time.

The actual SPM-build-and-run path for `execute_script` is exercised by the cold-start of any real call. A stdio-end-to-end integration harness lands in Phase 5.5 alongside the SPI tag and `set_assembly_metadata` / `render_preview` / `check_thickness` ports.

## Tool counts

- **34 tools registered** (was 32 in PR #11)
- All 4 graph_* / feature_recognize raw-path tools, 5 scene mutators, 3 introspection, 2 construction, 1 mirror_or_pattern, 2 mesh, 1 heal, 3 IO, 4 analysis, 3 core reads, get_api_reference, ping, execute_script — that's 34.

## Test plan

- [x] `swift build` — clean
- [x] `swift test` — 16/16 green
- [ ] Stdio integration harness — Phase 5.5
- [ ] Tag v0.1.0 + submit to Swift Package Index — Phase 5.5

🤖 Generated with [Claude Code](https://claude.com/claude-code)
