### PR TITLE
Swift port v0.4 — AIS-shaped tools (selection / dimensions / scene primitives + gap-fillers)

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "ea91f7effffaa0333d866f352c1bd7f9bd52a9b06c31a42b807b02e1c9ae273b",
+  "originHash" : "2ae58faedd13fa58db1cd69f95eae9aae977d4b5ac27aaaa098053fb3db9597a",
   "pins" : [
     {
       "identity" : "eventsource",
@@ -17,6 +17,15 @@
       "state" : {
         "revision" : "3cca0730cf3fe3df722a9542ecc3e00d90fe5076",
         "version" : "0.169.0"
+      }
+    },
+    {
+      "identity" : "occtswiftais",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/gsdali/OCCTSwiftAIS.git",
+      "state" : {
+        "revision" : "b65be18c6b54568359b87b80c384fdafa47a1c4a",
+        "version" : "0.6.1"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -38,6 +38,10 @@ let package = Package(
         // OCCTSwiftViewport directly for the OffscreenRenderer.
         .package(url: "https://github.com/gsdali/OCCTSwiftTools.git", from: "0.4.1"),
         .package(url: "https://github.com/gsdali/OCCTSwiftViewport.git", from: "0.55.0"),
+        // OCCTSwiftAIS: high-level scene mgmt — selection-from-topology,
+        // history-based selection remap, dimensions, standard scene
+        // objects. Powers the v0.4 net-new tools.
+        .package(url: "https://github.com/gsdali/OCCTSwiftAIS.git", from: "0.6.0"),
     ],
     targets: [
         .target(
@@ -50,6 +54,7 @@ let package = Package(
                 .product(name: "DrawingComposer", package: "OCCTSwiftScripts"),
                 .product(name: "OCCTSwiftTools", package: "OCCTSwiftTools"),
                 .product(name: "OCCTSwiftViewport", package: "OCCTSwiftViewport"),
+                .product(name: "OCCTSwiftAIS", package: "OCCTSwiftAIS"),
             ],
             swiftSettings: [.swiftLanguageMode(.v6)]
         ),

--- a/Sources/OCCTMCPCore/Annotations.swift
+++ b/Sources/OCCTMCPCore/Annotations.swift
@@ -1,0 +1,139 @@
+// Annotations — sidecar JSON next to manifest.json carrying the
+// scene-level dimensions and standard scene primitives that the v0.4
+// AIS-shaped tools produce. Manifest schema is left untouched so this
+// is a contained extension; render_preview reads the sidecar if
+// present, OCCTSwiftViewport could later opt-in too.
+//
+// File layout: <output_dir>/annotations.json
+//
+// {
+//   "version": 1,
+//   "dimensions": [
+//     { "id": "dim_overall", "kind": "linear",
+//       "anchors": { "from": "sel:cyl#vertex[0]", "to": "sel:cyl#vertex[1]" },
+//       "value": 50.2, "label": null }
+//   ],
+//   "primitives": [
+//     { "id": "wp_sketch", "kind": "workPlane",
+//       "params": { "origin": [0,0,0], "normal": [0,0,1], "size": 100,
+//                   "color": [0.5, 0.6, 0.85, 0.25] } }
+//   ]
+// }
+
+import Foundation
+
+public struct AnnotationsSidecar: Codable, Sendable {
+    public var version: Int
+    public var dimensions: [DimensionAnnotation]
+    public var primitives: [PrimitiveAnnotation]
+
+    public init(
+        version: Int = 1,
+        dimensions: [DimensionAnnotation] = [],
+        primitives: [PrimitiveAnnotation] = []
+    ) {
+        self.version = version
+        self.dimensions = dimensions
+        self.primitives = primitives
+    }
+}
+
+public struct DimensionAnnotation: Codable, Sendable {
+    public let id: String
+    public let kind: String                    // "linear" | "angular" | "radial"
+    public let anchors: [String: String]       // role → selectionId
+    public var value: Double?                  // computed at write-time
+    public var label: String?
+    public var anchorPoints: [[Double]]?       // resolved at write-time
+    public init(
+        id: String,
+        kind: String,
+        anchors: [String: String],
+        value: Double? = nil,
+        label: String? = nil,
+        anchorPoints: [[Double]]? = nil
+    ) {
+        self.id = id
+        self.kind = kind
+        self.anchors = anchors
+        self.value = value
+        self.label = label
+        self.anchorPoints = anchorPoints
+    }
+}
+
+public struct PrimitiveAnnotation: Codable, Sendable {
+    public let id: String
+    public let kind: String                       // "trihedron" | "workPlane" | "axis" | "pointCloud"
+    public let params: [String: AnyCodable]
+    public init(id: String, kind: String, params: [String: AnyCodable]) {
+        self.id = id
+        self.kind = kind
+        self.params = params
+    }
+}
+
+/// Tiny JSON value type so PrimitiveAnnotation.params can carry the
+/// per-kind shape without proliferating concrete structs.
+public enum AnyCodable: Codable, Sendable {
+    case bool(Bool)
+    case number(Double)
+    case string(String)
+    case array([AnyCodable])
+    case object([String: AnyCodable])
+    case null
+
+    public init(from decoder: Decoder) throws {
+        let c = try decoder.singleValueContainer()
+        if c.decodeNil() { self = .null; return }
+        if let v = try? c.decode(Bool.self) { self = .bool(v); return }
+        if let v = try? c.decode(Double.self) { self = .number(v); return }
+        if let v = try? c.decode(String.self) { self = .string(v); return }
+        if let v = try? c.decode([AnyCodable].self) { self = .array(v); return }
+        if let v = try? c.decode([String: AnyCodable].self) { self = .object(v); return }
+        throw DecodingError.dataCorruptedError(
+            in: c, debugDescription: "Unsupported JSON value"
+        )
+    }
+    public func encode(to encoder: Encoder) throws {
+        var c = encoder.singleValueContainer()
+        switch self {
+        case .bool(let v):    try c.encode(v)
+        case .number(let v):  try c.encode(v)
+        case .string(let v):  try c.encode(v)
+        case .array(let v):   try c.encode(v)
+        case .object(let v):  try c.encode(v)
+        case .null:           try c.encodeNil()
+        }
+    }
+}
+
+public struct AnnotationsStore: Sendable {
+    public let path: String
+    public init(outputDir: String = OCCTMCPPaths.outputDir()) {
+        self.path = "\(outputDir)/annotations.json"
+    }
+    public init(path: String) {
+        self.path = path
+    }
+
+    public func read() -> AnnotationsSidecar {
+        guard FileManager.default.fileExists(atPath: path),
+              let data = try? Data(contentsOf: URL(fileURLWithPath: path)),
+              let decoded = try? JSONDecoder().decode(AnnotationsSidecar.self, from: data) else {
+            return AnnotationsSidecar()
+        }
+        return decoded
+    }
+
+    public func write(_ sidecar: AnnotationsSidecar) throws {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        let data = try encoder.encode(sidecar)
+        let url = URL(fileURLWithPath: path)
+        try FileManager.default.createDirectory(
+            at: url.deletingLastPathComponent(), withIntermediateDirectories: true
+        )
+        try data.write(to: url, options: .atomic)
+    }
+}

--- a/Sources/OCCTMCPCore/SelectionRegistry.swift
+++ b/Sources/OCCTMCPCore/SelectionRegistry.swift
@@ -1,0 +1,160 @@
+// SelectionRegistry — server-side store of named topology picks. The
+// LLM gets back a stable selectionId from `select_topology`, then refers
+// to it from `remap_selection`, `add_dimension`, and any future tool
+// that wants to anchor to a sub-shape.
+//
+// selectionId format: `sel:<bodyId>#<kind>[<index>]`. Self-describing
+// and parseable, so consumers can inspect a selection without
+// dereferencing the registry — but the registry caches the resolved
+// anchor metadata (centroid, normal, area / length) so subsequent
+// calls don't have to re-load the BREP.
+
+import Foundation
+
+/// A named pick into the topology of a scene body. Mirrors the AIS
+/// `SubShape` enum but keyed by `bodyId` so it survives without an
+/// `InteractiveContext`.
+public enum TopologyAnchor: Sendable, Hashable {
+    case body(bodyId: String)
+    case face(bodyId: String, index: Int)
+    case edge(bodyId: String, index: Int)
+    case vertex(bodyId: String, index: Int)
+
+    public var bodyId: String {
+        switch self {
+        case .body(let id):           return id
+        case .face(let id, _):        return id
+        case .edge(let id, _):        return id
+        case .vertex(let id, _):      return id
+        }
+    }
+
+    public var kind: String {
+        switch self {
+        case .body:    return "body"
+        case .face:    return "face"
+        case .edge:    return "edge"
+        case .vertex:  return "vertex"
+        }
+    }
+
+    public var index: Int? {
+        switch self {
+        case .body:                   return nil
+        case .face(_, let idx):       return idx
+        case .edge(_, let idx):       return idx
+        case .vertex(_, let idx):     return idx
+        }
+    }
+
+    /// Self-describing selectionId: `sel:<bodyId>#<kind>[<index>]` for
+    /// face/edge/vertex; `sel:<bodyId>#body` for whole-body picks.
+    public var selectionId: String {
+        switch self {
+        case .body(let id):
+            return "sel:\(id)#body"
+        case .face(let id, let idx):
+            return "sel:\(id)#face[\(idx)]"
+        case .edge(let id, let idx):
+            return "sel:\(id)#edge[\(idx)]"
+        case .vertex(let id, let idx):
+            return "sel:\(id)#vertex[\(idx)]"
+        }
+    }
+
+    /// Parse a selectionId back into an anchor. Returns nil if the
+    /// string doesn't match the documented format.
+    public static func parse(_ selectionId: String) -> TopologyAnchor? {
+        guard selectionId.hasPrefix("sel:") else { return nil }
+        let body = selectionId.dropFirst(4)
+        guard let hashIdx = body.firstIndex(of: "#") else { return nil }
+        let bodyId = String(body[..<hashIdx])
+        let rest = body[body.index(after: hashIdx)...]
+        if rest == "body" { return .body(bodyId: bodyId) }
+        // rest is `face[3]` / `edge[7]` / `vertex[2]`
+        guard let openBracket = rest.firstIndex(of: "["),
+              rest.last == "]" else { return nil }
+        let kindStr = String(rest[..<openBracket])
+        let inside = rest[rest.index(after: openBracket)..<rest.index(before: rest.endIndex)]
+        guard let idx = Int(inside) else { return nil }
+        switch kindStr {
+        case "face":    return .face(bodyId: bodyId, index: idx)
+        case "edge":    return .edge(bodyId: bodyId, index: idx)
+        case "vertex":  return .vertex(bodyId: bodyId, index: idx)
+        default:        return nil
+        }
+    }
+}
+
+/// Anchor metadata captured at selection time. Used by `add_dimension`
+/// (so it doesn't need to re-load the BREP), by `remap_selection`'s
+/// position-matching fallback, and surfaced back to the LLM as a
+/// readable description of what was picked.
+public struct AnchorSnapshot: Sendable, Codable {
+    /// Centroid for faces, midpoint for edges, position for vertices.
+    public var center: [Double]
+    /// Normal at face midpoint UV. nil for edges/vertices.
+    public var normal: [Double]?
+    /// Face area (mm^2). nil for edges/vertices.
+    public var area: Double?
+    /// Edge length (mm). nil for faces/vertices.
+    public var length: Double?
+    /// Face surface type (plane / cylinder / ...). nil for edges/vertices.
+    public var surfaceType: String?
+    /// Edge curve type (line / circle / ...). nil for faces/vertices.
+    public var curveType: String?
+    public init(
+        center: [Double],
+        normal: [Double]? = nil,
+        area: Double? = nil,
+        length: Double? = nil,
+        surfaceType: String? = nil,
+        curveType: String? = nil
+    ) {
+        self.center = center
+        self.normal = normal
+        self.area = area
+        self.length = length
+        self.surfaceType = surfaceType
+        self.curveType = curveType
+    }
+}
+
+/// Single source of truth for selection metadata across an MCP session.
+public actor SelectionRegistry {
+    public static let shared = SelectionRegistry()
+
+    private var snapshots: [String: AnchorSnapshot] = [:]
+    private var anchors: [String: TopologyAnchor] = [:]
+
+    public init() {}
+
+    /// Record a fresh selection. Re-recording the same selectionId
+    /// overwrites the cached snapshot — useful when remapping.
+    public func record(anchor: TopologyAnchor, snapshot: AnchorSnapshot) {
+        let id = anchor.selectionId
+        anchors[id] = anchor
+        snapshots[id] = snapshot
+    }
+
+    public func anchor(for selectionId: String) -> TopologyAnchor? {
+        if let cached = anchors[selectionId] { return cached }
+        // Fall back to parsing — selectionId is self-describing so a
+        // cache miss doesn't mean "unknown", it means "registry was
+        // cold for this id".
+        return TopologyAnchor.parse(selectionId)
+    }
+
+    public func snapshot(for selectionId: String) -> AnchorSnapshot? {
+        return snapshots[selectionId]
+    }
+
+    public func clear() {
+        snapshots.removeAll()
+        anchors.removeAll()
+    }
+
+    public func count() -> Int {
+        return anchors.count
+    }
+}

--- a/Sources/OCCTMCPCore/Server.swift
+++ b/Sources/OCCTMCPCore/Server.swift
@@ -443,6 +443,52 @@ func catalogTools() -> [Tool] {
             ])
         ),
         Tool(
+            name: "show_bounding_box",
+            description: "Compute a body's axis-aligned bounding box and register it as a `boundingBox` scene primitive. Returns min/max/extent/center inline so the LLM can reason about the body's footprint without a separate compute_metrics call.",
+            inputSchema: .object([
+                "type": .string("object"),
+                "properties": .object([
+                    "bodyId": .object(["type": .string("string")]),
+                    "primitiveId": .object(["type": .string("string")]),
+                ]),
+                "required": .array([.string("bodyId")]),
+                "additionalProperties": .bool(false),
+            ])
+        ),
+        Tool(
+            name: "diff_overlay",
+            description: "Visualise a recent scene change. For each body added/removed/modified since N runs ago, register a tinted scene primitive at its bbox center (added=green, removed=red, changed=yellow). Returns the lists of affected body ids plus the registered primitive ids.",
+            inputSchema: .object([
+                "type": .string("object"),
+                "properties": .object([
+                    "since": .object([
+                        "type": .string("integer"),
+                        "minimum": .int(1),
+                    ]),
+                ]),
+                "additionalProperties": .bool(false),
+            ])
+        ),
+        Tool(
+            name: "select_by_feature",
+            description: "Run AAG feature recognition (recognize_features) and register a selectionId for each detected hole / pocket. Returns selectionIds the LLM can then dimension or refer back to without re-running query_topology.",
+            inputSchema: .object([
+                "type": .string("object"),
+                "properties": .object([
+                    "bodyId": .object(["type": .string("string")]),
+                    "kinds": .object([
+                        "type": .string("array"),
+                        "items": .object([
+                            "type": .string("string"),
+                            "enum": .array([.string("pocket"), .string("hole")]),
+                        ]),
+                    ]),
+                ]),
+                "required": .array([.string("bodyId")]),
+                "additionalProperties": .bool(false),
+            ])
+        ),
+        Tool(
             name: "select_topology",
             description: "Pick faces / edges / vertices on a scene body matching criteria. Returns server-tracked selectionIds (sel:<bodyId>#<kind>[<idx>]) plus an anchor snapshot — the LLM can refer back via remap_selection / add_dimension.",
             inputSchema: .object([
@@ -805,6 +851,7 @@ func toAnyCodable(_ value: Value) -> AnyCodable {
     case .array(let arr): return .array(arr.map(toAnyCodable))
     case .object(let o):  return .object(o.mapValues(toAnyCodable))
     case .null:           return .null
+    case .data:           return .null  // base64 blobs not used by annotations params
     @unknown default:     return .null
     }
 }
@@ -843,6 +890,26 @@ func dispatch(callName: String, arguments: [String: Value]) async -> CallTool.Re
     switch callName {
     case "ping":
         return ToolText("pong").asCallToolResult()
+
+    case "show_bounding_box":
+        guard let bodyId = arguments["bodyId"]?.stringValue else {
+            return ToolText("show_bounding_box requires `bodyId`.", isError: true).asCallToolResult()
+        }
+        return await GapFillerTools.showBoundingBox(
+            bodyId: bodyId,
+            primitiveId: arguments["primitiveId"]?.stringValue
+        ).asCallToolResult()
+
+    case "diff_overlay":
+        let since = arguments["since"]?.intValue ?? 1
+        return await GapFillerTools.diffOverlay(since: since).asCallToolResult()
+
+    case "select_by_feature":
+        guard let bodyId = arguments["bodyId"]?.stringValue else {
+            return ToolText("select_by_feature requires `bodyId`.", isError: true).asCallToolResult()
+        }
+        let kinds = arguments["kinds"]?.arrayValue?.compactMap { $0.stringValue }
+        return await GapFillerTools.selectByFeature(bodyId: bodyId, kinds: kinds).asCallToolResult()
 
     case "add_dimension":
         guard let kindStr = arguments["kind"]?.stringValue,

--- a/Sources/OCCTMCPCore/Server.swift
+++ b/Sources/OCCTMCPCore/Server.swift
@@ -371,6 +371,99 @@ func catalogTools() -> [Tool] {
             ])
         ),
         Tool(
+            name: "remap_selection",
+            description: "Remap selectionIds across a scene mutation using a position-matching heuristic (closest-centroid within a body-bbox-relative tolerance). Returns each input mapped to zero or more new selectionIds plus a `fate` ('preserved' | 'approximate' | 'lost'). High-confidence for transforms / in-place edits; approximate for fillets / chamfers / boolean splits.",
+            inputSchema: .object([
+                "type": .string("object"),
+                "properties": .object([
+                    "selectionIds": .object([
+                        "type": .string("array"),
+                        "items": .object(["type": .string("string")]),
+                    ]),
+                    "toleranceMmFraction": .object([
+                        "type": .string("number"),
+                        "description": .string("Fraction of body bbox diagonal to use as the match tolerance. Default 0.01."),
+                    ]),
+                ]),
+                "required": .array([.string("selectionIds")]),
+                "additionalProperties": .bool(false),
+            ])
+        ),
+        Tool(
+            name: "add_dimension",
+            description: "Compute a linear / angular / radial dimension from selectionIds, persist to <output_dir>/annotations.json. render_preview overlays it. linear needs anchors.from + anchors.to; angular needs anchors.armA + anchors.apex + anchors.armB; radial needs anchors.circularEdge.",
+            inputSchema: .object([
+                "type": .string("object"),
+                "properties": .object([
+                    "kind": .object([
+                        "type": .string("string"),
+                        "enum": .array([.string("linear"), .string("angular"), .string("radial")]),
+                    ]),
+                    "anchors": .object([
+                        "type": .string("object"),
+                        "additionalProperties": .object(["type": .string("string")]),
+                    ]),
+                    "label": .object(["type": .string("string")]),
+                    "showDiameter": .object(["type": .string("boolean")]),
+                    "id": .object(["type": .string("string")]),
+                ]),
+                "required": .array([.string("kind"), .string("anchors")]),
+                "additionalProperties": .bool(false),
+            ])
+        ),
+        Tool(
+            name: "add_scene_primitive",
+            description: "Add a Trihedron / WorkPlane / Axis / PointCloud annotation to <output_dir>/annotations.json. render_preview overlays it. params shape mirrors the OCCTSwiftAIS init: trihedron {origin,axisLength}; workPlane {origin,normal,size,color}; axis {from,to,color,radius}; pointCloud {points,colors?,pointRadius}.",
+            inputSchema: .object([
+                "type": .string("object"),
+                "properties": .object([
+                    "kind": .object([
+                        "type": .string("string"),
+                        "enum": .array([.string("trihedron"), .string("workPlane"), .string("axis"), .string("pointCloud")]),
+                    ]),
+                    "params": .object([
+                        "type": .string("object"),
+                    ]),
+                    "id": .object(["type": .string("string")]),
+                ]),
+                "required": .array([.string("kind"), .string("params")]),
+                "additionalProperties": .bool(false),
+            ])
+        ),
+        Tool(
+            name: "remove_scene_annotation",
+            description: "Remove a dimension or scene primitive from <output_dir>/annotations.json by id. Returns whether the id was found.",
+            inputSchema: .object([
+                "type": .string("object"),
+                "properties": .object([
+                    "id": .object(["type": .string("string")]),
+                ]),
+                "required": .array([.string("id")]),
+                "additionalProperties": .bool(false),
+            ])
+        ),
+        Tool(
+            name: "select_topology",
+            description: "Pick faces / edges / vertices on a scene body matching criteria. Returns server-tracked selectionIds (sel:<bodyId>#<kind>[<idx>]) plus an anchor snapshot — the LLM can refer back via remap_selection / add_dimension.",
+            inputSchema: .object([
+                "type": .string("object"),
+                "properties": .object([
+                    "bodyId": .object(["type": .string("string")]),
+                    "kind": .object([
+                        "type": .string("string"),
+                        "enum": .array([.string("body"), .string("face"), .string("edge"), .string("vertex")]),
+                    ]),
+                    "filter": .object([
+                        "type": .string("object"),
+                        "description": .string("face: surfaceType, minArea, maxArea, normalDirection, normalTolerance. edge: curveType, minLength, maxLength."),
+                    ]),
+                    "limit": .object(["type": .string("integer"), "minimum": .int(1)]),
+                ]),
+                "required": .array([.string("bodyId"), .string("kind")]),
+                "additionalProperties": .bool(false),
+            ])
+        ),
+        Tool(
             name: "ping",
             description: "Sanity-check tool — returns 'pong' so callers can verify the OCCTMCP Swift server is alive.",
             inputSchema: .object([
@@ -697,6 +790,25 @@ struct ToolCatalog: Encodable {
     let count: Int
 }
 
+/// Recursively convert an MCP `Value` (the dynamic JSON wrapper) into an
+/// `[String: AnyCodable]` so it can land in `PrimitiveAnnotation.params`.
+func paramsToAnyCodable(_ value: Value?) -> [String: AnyCodable] {
+    guard case .object(let obj)? = value else { return [:] }
+    return obj.mapValues(toAnyCodable)
+}
+func toAnyCodable(_ value: Value) -> AnyCodable {
+    switch value {
+    case .bool(let v):    return .bool(v)
+    case .int(let v):     return .number(Double(v))
+    case .double(let v):  return .number(v)
+    case .string(let v):  return .string(v)
+    case .array(let arr): return .array(arr.map(toAnyCodable))
+    case .object(let o):  return .object(o.mapValues(toAnyCodable))
+    case .null:           return .null
+    @unknown default:     return .null
+    }
+}
+
 func parseRenderOptions(_ value: Value?) -> RenderPreviewTool.Options {
     var opts = RenderPreviewTool.Options()
     guard case .object(let o)? = value else { return opts }
@@ -731,6 +843,75 @@ func dispatch(callName: String, arguments: [String: Value]) async -> CallTool.Re
     switch callName {
     case "ping":
         return ToolText("pong").asCallToolResult()
+
+    case "add_dimension":
+        guard let kindStr = arguments["kind"]?.stringValue,
+              let kind = AnnotationsTools.DimensionKind(rawValue: kindStr) else {
+            return ToolText("add_dimension requires `kind`.", isError: true).asCallToolResult()
+        }
+        var anchors: [String: String] = [:]
+        if case .object(let a)? = arguments["anchors"] {
+            for (k, v) in a {
+                if let s = v.stringValue { anchors[k] = s }
+            }
+        }
+        return await AnnotationsTools.addDimension(
+            kind: kind,
+            anchors: anchors,
+            label: arguments["label"]?.stringValue,
+            showDiameter: arguments["showDiameter"]?.boolValue ?? false,
+            id: arguments["id"]?.stringValue
+        ).asCallToolResult()
+
+    case "add_scene_primitive":
+        guard let kindStr = arguments["kind"]?.stringValue,
+              let kind = AnnotationsTools.PrimitiveKind(rawValue: kindStr) else {
+            return ToolText("add_scene_primitive requires `kind`.", isError: true).asCallToolResult()
+        }
+        let params = paramsToAnyCodable(arguments["params"])
+        return await AnnotationsTools.addScenePrimitive(
+            kind: kind, params: params,
+            id: arguments["id"]?.stringValue
+        ).asCallToolResult()
+
+    case "remove_scene_annotation":
+        guard let id = arguments["id"]?.stringValue else {
+            return ToolText("remove_scene_annotation requires `id`.", isError: true).asCallToolResult()
+        }
+        return await AnnotationsTools.removeSceneAnnotation(id: id).asCallToolResult()
+
+    case "remap_selection":
+        guard let ids = arguments["selectionIds"]?.arrayValue?.compactMap({ $0.stringValue }), !ids.isEmpty else {
+            return ToolText("remap_selection requires `selectionIds` array.", isError: true).asCallToolResult()
+        }
+        let tol = arguments["toleranceMmFraction"]?.doubleValue ?? 0.01
+        return await RemapTools.remapSelection(
+            selectionIds: ids, toleranceMmFraction: tol
+        ).asCallToolResult()
+
+    case "select_topology":
+        guard let bodyId = arguments["bodyId"]?.stringValue,
+              let kind = arguments["kind"]?.stringValue else {
+            return ToolText("select_topology requires `bodyId` and `kind`.", isError: true).asCallToolResult()
+        }
+        var filter = SelectionTools.Filter()
+        if case .object(let f)? = arguments["filter"] {
+            filter.surfaceType = f["surfaceType"]?.stringValue
+            filter.curveType = f["curveType"]?.stringValue
+            filter.minArea = f["minArea"]?.doubleValue
+            filter.maxArea = f["maxArea"]?.doubleValue
+            filter.minLength = f["minLength"]?.doubleValue
+            filter.maxLength = f["maxLength"]?.doubleValue
+            if let arr = f["normalDirection"]?.arrayValue, arr.count == 3,
+               let x = arr[0].doubleValue, let y = arr[1].doubleValue, let z = arr[2].doubleValue {
+                filter.normalDirection = SIMD3(x, y, z)
+            }
+            filter.normalTolerance = f["normalTolerance"]?.doubleValue
+        }
+        let limit = arguments["limit"]?.intValue
+        return await SelectionTools.selectTopology(
+            bodyId: bodyId, kind: kind, filter: filter, limit: limit
+        ).asCallToolResult()
 
     case "set_assembly_metadata":
         guard let inputPath = arguments["inputPath"]?.stringValue,

--- a/Sources/OCCTMCPCore/Tools/AnnotationsTools.swift
+++ b/Sources/OCCTMCPCore/Tools/AnnotationsTools.swift
@@ -1,0 +1,191 @@
+// AnnotationsTools — add_dimension, add_scene_primitive,
+// remove_scene_annotation. All three persist to the
+// <output_dir>/annotations.json sidecar; render_preview reads it (in
+// Phase 7.4) so the LLM can see dimensions / primitives in the
+// rendered preview.
+//
+// Dimensions are computed at write time (length / angle / radius),
+// resolved against the SelectionRegistry's anchor snapshots so we
+// don't have to re-load the BREP just to get a centroid. Primitives
+// are recorded as-is; their geometry is interpreted by the renderer.
+
+import Foundation
+import simd
+import OCCTSwift
+
+public enum AnnotationsTools {
+
+    // MARK: - add_dimension
+
+    public enum DimensionKind: String { case linear, angular, radial }
+
+    public struct DimensionResult: Encodable {
+        public let dimensionId: String
+        public let kind: String
+        public let value: Double
+        public let unit: String
+        public let anchorPoints: [[Double]]
+    }
+
+    public static func addDimension(
+        kind: DimensionKind,
+        anchors: [String: String],
+        label: String? = nil,
+        showDiameter: Bool = false,
+        id: String? = nil,
+        store: ManifestStore = ManifestStore(),
+        registry: SelectionRegistry = .shared
+    ) async -> ToolText {
+        let outputDir = (store.path as NSString).deletingLastPathComponent
+        let sidecar = AnnotationsStore(outputDir: outputDir)
+        var doc = sidecar.read()
+
+        let dimId = id ?? "dim_\(UUID().uuidString.prefix(8))"
+
+        switch kind {
+        case .linear:
+            guard let fromId = anchors["from"], let toId = anchors["to"] else {
+                return .init("linear dimension requires anchors.from and anchors.to.")
+            }
+            guard let fromSnap = await registry.snapshot(for: fromId),
+                  let toSnap = await registry.snapshot(for: toId) else {
+                return .init("Could not resolve linear anchors. Re-run select_topology if this is a fresh session.")
+            }
+            let a = SIMD3(fromSnap.center[0], fromSnap.center[1], fromSnap.center[2])
+            let b = SIMD3(toSnap.center[0], toSnap.center[1], toSnap.center[2])
+            let value = simd_length(b - a)
+            let points = [
+                [Double(a.x), Double(a.y), Double(a.z)],
+                [Double(b.x), Double(b.y), Double(b.z)],
+            ]
+            doc.dimensions.removeAll { $0.id == dimId }
+            doc.dimensions.append(.init(
+                id: dimId, kind: "linear",
+                anchors: ["from": fromId, "to": toId],
+                value: value, label: label, anchorPoints: points
+            ))
+            try? sidecar.write(doc)
+            return IntrospectionTools.encode(DimensionResult(
+                dimensionId: dimId, kind: "linear", value: value, unit: "mm",
+                anchorPoints: points
+            ))
+
+        case .angular:
+            guard let armA = anchors["armA"], let apex = anchors["apex"], let armB = anchors["armB"] else {
+                return .init("angular dimension requires anchors.armA, anchors.apex, anchors.armB.")
+            }
+            guard let snapA = await registry.snapshot(for: armA),
+                  let snapApex = await registry.snapshot(for: apex),
+                  let snapB = await registry.snapshot(for: armB) else {
+                return .init("Could not resolve angular anchors.")
+            }
+            let pA = SIMD3(snapA.center[0], snapA.center[1], snapA.center[2])
+            let pV = SIMD3(snapApex.center[0], snapApex.center[1], snapApex.center[2])
+            let pB = SIMD3(snapB.center[0], snapB.center[1], snapB.center[2])
+            let v1 = simd_normalize(pA - pV)
+            let v2 = simd_normalize(pB - pV)
+            let cos = max(-1.0, min(1.0, simd_dot(v1, v2)))
+            let radians = acos(cos)
+            let degrees = radians * 180 / .pi
+            let points = [
+                [pA.x, pA.y, pA.z], [pV.x, pV.y, pV.z], [pB.x, pB.y, pB.z],
+            ]
+            doc.dimensions.removeAll { $0.id == dimId }
+            doc.dimensions.append(.init(
+                id: dimId, kind: "angular",
+                anchors: ["armA": armA, "apex": apex, "armB": armB],
+                value: degrees, label: label, anchorPoints: points
+            ))
+            try? sidecar.write(doc)
+            return IntrospectionTools.encode(DimensionResult(
+                dimensionId: dimId, kind: "angular", value: degrees, unit: "deg",
+                anchorPoints: points
+            ))
+
+        case .radial:
+            guard let edgeId = anchors["circularEdge"] else {
+                return .init("radial dimension requires anchors.circularEdge.")
+            }
+            guard let snap = await registry.snapshot(for: edgeId),
+                  let lengthArc = snap.length else {
+                return .init("Could not resolve circular edge — re-run select_topology to capture length.")
+            }
+            // Approximate radius from arc length — works for full
+            // circles (length = 2πr). Fine for the typical use case
+            // (drilled holes, circular features).
+            let radius = lengthArc / (2 * .pi)
+            let value = showDiameter ? radius * 2 : radius
+            let center = SIMD3(snap.center[0], snap.center[1], snap.center[2])
+            let points = [[center.x, center.y, center.z]]
+            doc.dimensions.removeAll { $0.id == dimId }
+            doc.dimensions.append(.init(
+                id: dimId, kind: "radial",
+                anchors: ["circularEdge": edgeId],
+                value: value, label: label, anchorPoints: points
+            ))
+            try? sidecar.write(doc)
+            return IntrospectionTools.encode(DimensionResult(
+                dimensionId: dimId, kind: showDiameter ? "diameter" : "radial",
+                value: value, unit: "mm",
+                anchorPoints: points
+            ))
+        }
+    }
+
+    // MARK: - add_scene_primitive
+
+    public enum PrimitiveKind: String {
+        case trihedron, workPlane, axis, pointCloud
+    }
+
+    public struct PrimitiveResult: Encodable {
+        public let primitiveId: String
+        public let kind: String
+    }
+
+    public static func addScenePrimitive(
+        kind: PrimitiveKind,
+        params: [String: AnyCodable],
+        id: String? = nil,
+        store: ManifestStore = ManifestStore()
+    ) async -> ToolText {
+        let outputDir = (store.path as NSString).deletingLastPathComponent
+        let sidecar = AnnotationsStore(outputDir: outputDir)
+        var doc = sidecar.read()
+        let primId = id ?? "prim_\(UUID().uuidString.prefix(8))"
+        doc.primitives.removeAll { $0.id == primId }
+        doc.primitives.append(.init(id: primId, kind: kind.rawValue, params: params))
+        try? sidecar.write(doc)
+        return IntrospectionTools.encode(PrimitiveResult(
+            primitiveId: primId, kind: kind.rawValue
+        ))
+    }
+
+    // MARK: - remove_scene_annotation
+
+    public struct RemoveResult: Encodable {
+        public let removed: Bool
+        public let kind: String?
+        public let id: String
+    }
+
+    public static func removeSceneAnnotation(
+        id: String,
+        store: ManifestStore = ManifestStore()
+    ) async -> ToolText {
+        let outputDir = (store.path as NSString).deletingLastPathComponent
+        let sidecar = AnnotationsStore(outputDir: outputDir)
+        var doc = sidecar.read()
+        if let dim = doc.dimensions.first(where: { $0.id == id }) {
+            doc.dimensions.removeAll { $0.id == id }
+            try? sidecar.write(doc)
+            return IntrospectionTools.encode(RemoveResult(removed: true, kind: dim.kind, id: id))
+        }
+        if let prim = doc.primitives.first(where: { $0.id == id }) {
+            doc.primitives.removeAll { $0.id == id }
+            try? sidecar.write(doc)
+            return IntrospectionTools.encode(RemoveResult(removed: true, kind: prim.kind, id: id))
+        }
+        return IntrospectionTools.encode(RemoveResult(removed: false, kind: nil, id: id))
+    }
+}

--- a/Sources/OCCTMCPCore/Tools/GapFillerTools.swift
+++ b/Sources/OCCTMCPCore/Tools/GapFillerTools.swift
@@ -1,0 +1,249 @@
+// GapFillerTools — show_bounding_box, diff_overlay, select_by_feature.
+// Three small wins layered on the SelectionRegistry + AnnotationsStore
+// + recognize_features primitives we already have.
+//
+// All three are compositions over existing tools rather than fresh
+// OCCT calls — they make common LLM idioms one tool call instead of
+// several.
+
+import Foundation
+import simd
+import OCCTSwift
+import ScriptHarness
+
+public enum GapFillerTools {
+
+    // MARK: - show_bounding_box
+
+    public struct BoundingBoxResult: Encodable {
+        public let primitiveId: String
+        public let bodyId: String
+        public let min: [Double]
+        public let max: [Double]
+        public let extent: [Double]
+        public let center: [Double]
+    }
+
+    /// Compute a body's axis-aligned bounding box and register it as a
+    /// `boundingBox` scene primitive. The renderer can draw the
+    /// 12-edge wireframe later; for now the value is also returned
+    /// inline so the LLM can reason about it.
+    public static func showBoundingBox(
+        bodyId: String,
+        primitiveId: String? = nil,
+        store: ManifestStore = ManifestStore()
+    ) async -> ToolText {
+        let loaded: (manifest: ScriptManifest, body: BodyDescriptor, shape: Shape, path: String)
+        do {
+            loaded = try IntrospectionTools.loadShape(bodyId: bodyId, store: store)
+        } catch {
+            return .init("\(error)")
+        }
+        let bb = loaded.shape.bounds
+        let minP = [bb.min.x, bb.min.y, bb.min.z]
+        let maxP = [bb.max.x, bb.max.y, bb.max.z]
+        let extent = [
+            bb.max.x - bb.min.x,
+            bb.max.y - bb.min.y,
+            bb.max.z - bb.min.z,
+        ]
+        let center = [
+            (bb.min.x + bb.max.x) * 0.5,
+            (bb.min.y + bb.max.y) * 0.5,
+            (bb.min.z + bb.max.z) * 0.5,
+        ]
+        let id = primitiveId ?? "bbox_\(bodyId)"
+        let outputDir = (store.path as NSString).deletingLastPathComponent
+        let sidecar = AnnotationsStore(outputDir: outputDir)
+        var doc = sidecar.read()
+        doc.primitives.removeAll { $0.id == id }
+        doc.primitives.append(.init(
+            id: id, kind: "boundingBox",
+            params: [
+                "bodyId": .string(bodyId),
+                "min": .array(minP.map { .number($0) }),
+                "max": .array(maxP.map { .number($0) }),
+            ]
+        ))
+        try? sidecar.write(doc)
+        return IntrospectionTools.encode(BoundingBoxResult(
+            primitiveId: id,
+            bodyId: bodyId,
+            min: minP,
+            max: maxP,
+            extent: extent,
+            center: center
+        ))
+    }
+
+    // MARK: - diff_overlay
+
+    public struct DiffOverlayResult: Encodable {
+        public let added: [String]
+        public let removed: [String]
+        public let appearanceChanged: [String]
+        public let fileChanged: [String]
+        public let primitiveIds: [String]
+    }
+
+    /// Visualise a recent scene change. Reads compare_versions data,
+    /// drops a tinted scene primitive at each affected body's bbox so
+    /// the LLM (and a future viewport) can see what moved at a glance.
+    /// Added → green, removed → red, appearance/file changed → yellow.
+    public static func diffOverlay(
+        since: Int = 1,
+        store: ManifestStore = ManifestStore(),
+        history: SceneHistory = .shared
+    ) async -> ToolText {
+        guard let current = try? store.read() else {
+            return .init("No scene loaded.")
+        }
+        let availableCount = await history.count()
+        guard let prior = await history.snapshot(since: since) else {
+            return .init("Not enough history: requested \(since), have \(availableCount).")
+        }
+        let diff = SceneTools.diffManifests(
+            prev: prior, curr: current,
+            since: since, available: availableCount
+        )
+        let outputDir = (store.path as NSString).deletingLastPathComponent
+        let sidecar = AnnotationsStore(outputDir: outputDir)
+        var doc = sidecar.read()
+        var primitiveIds: [String] = []
+
+        func registerOverlay(bodyId: String, color: [Double], suffix: String) {
+            // Look up the body's bbox from the live manifest — for
+            // removed bodies we don't have a current shape, so the
+            // prior manifest's body is used to position a marker.
+            let manifest = (current.body(withId: bodyId) != nil) ? current : prior
+            guard let body = manifest.body(withId: bodyId) else { return }
+            let path = "\(outputDir)/\(body.file)"
+            guard FileManager.default.fileExists(atPath: path),
+                  let shape = try? Shape.loadBREP(fromPath: path) else { return }
+            let bb = shape.bounds
+            let centre = [
+                (bb.min.x + bb.max.x) * 0.5,
+                (bb.min.y + bb.max.y) * 0.5,
+                (bb.min.z + bb.max.z) * 0.5,
+            ]
+            let extent = [
+                bb.max.x - bb.min.x,
+                bb.max.y - bb.min.y,
+                bb.max.z - bb.min.z,
+            ]
+            let id = "diff_\(suffix)_\(bodyId)"
+            doc.primitives.removeAll { $0.id == id }
+            doc.primitives.append(.init(
+                id: id, kind: "diffMarker",
+                params: [
+                    "bodyId": .string(bodyId),
+                    "fate": .string(suffix),
+                    "center": .array(centre.map { .number($0) }),
+                    "extent": .array(extent.map { .number($0) }),
+                    "color": .array(color.map { .number($0) }),
+                ]
+            ))
+            primitiveIds.append(id)
+        }
+
+        let green: [Double] = [0.2, 0.85, 0.2, 0.5]
+        let red: [Double] = [0.85, 0.2, 0.2, 0.5]
+        let yellow: [Double] = [0.95, 0.85, 0.1, 0.5]
+        for id in diff.added { registerOverlay(bodyId: id, color: green, suffix: "added") }
+        for id in diff.removed { registerOverlay(bodyId: id, color: red, suffix: "removed") }
+        for entry in diff.appearanceChanged { registerOverlay(bodyId: entry.id, color: yellow, suffix: "appchg") }
+        for id in diff.fileChanged { registerOverlay(bodyId: id, color: yellow, suffix: "filechg") }
+
+        try? sidecar.write(doc)
+        return IntrospectionTools.encode(DiffOverlayResult(
+            added: diff.added,
+            removed: diff.removed,
+            appearanceChanged: diff.appearanceChanged.map(\.id),
+            fileChanged: diff.fileChanged,
+            primitiveIds: primitiveIds
+        ))
+    }
+
+    // MARK: - select_by_feature
+
+    public struct FeatureSelection: Encodable {
+        public let kind: String              // "hole" | "pocket"
+        public let selectionId: String
+        public let detail: AnchorSnapshot
+    }
+    public struct FeatureSelectionsResult: Encodable {
+        public let bodyId: String
+        public let selections: [FeatureSelection]
+    }
+
+    /// Run AAG feature recognition, then turn each detected hole / pocket
+    /// into a selectionId pointing at the relevant face (hole faceIndex,
+    /// or pocket floorFaceIndex). The LLM can then dimension or refer
+    /// to those features without re-running query_topology.
+    public static func selectByFeature(
+        bodyId: String,
+        kinds: [String]? = nil,
+        store: ManifestStore = ManifestStore(),
+        registry: SelectionRegistry = .shared
+    ) async -> ToolText {
+        let loaded: (manifest: ScriptManifest, body: BodyDescriptor, shape: Shape, path: String)
+        do {
+            loaded = try IntrospectionTools.loadShape(bodyId: bodyId, store: store)
+        } catch {
+            return .init("\(error)")
+        }
+        let aag = AAG(shape: loaded.shape)
+        let wantPockets = kinds.map { $0.contains("pocket") } ?? true
+        let wantHoles = kinds.map { $0.contains("hole") } ?? true
+
+        let allFaces = loaded.shape.faces()
+        var results: [FeatureSelection] = []
+
+        if wantPockets {
+            for pocket in aag.detectPockets() {
+                let faceIndex = pocket.floorFaceIndex
+                guard faceIndex < allFaces.count else { continue }
+                let face = allFaces[faceIndex]
+                let (centre, normal) = SelectionTools.faceCenterAndNormal(face: face)
+                let snap = AnchorSnapshot(
+                    center: [centre.x, centre.y, centre.z],
+                    normal: normal.map { [$0.x, $0.y, $0.z] },
+                    area: face.area(),
+                    surfaceType: String(describing: face.surfaceType)
+                )
+                let anchor = TopologyAnchor.face(bodyId: bodyId, index: faceIndex)
+                await registry.record(anchor: anchor, snapshot: snap)
+                results.append(.init(
+                    kind: "pocket",
+                    selectionId: anchor.selectionId,
+                    detail: snap
+                ))
+            }
+        }
+        if wantHoles {
+            for hole in aag.detectHoles() {
+                let faceIndex = hole.faceIndex
+                guard faceIndex < allFaces.count else { continue }
+                let face = allFaces[faceIndex]
+                let (centre, normal) = SelectionTools.faceCenterAndNormal(face: face)
+                let snap = AnchorSnapshot(
+                    center: [centre.x, centre.y, centre.z],
+                    normal: normal.map { [$0.x, $0.y, $0.z] },
+                    area: face.area(),
+                    surfaceType: String(describing: face.surfaceType)
+                )
+                let anchor = TopologyAnchor.face(bodyId: bodyId, index: faceIndex)
+                await registry.record(anchor: anchor, snapshot: snap)
+                results.append(.init(
+                    kind: "hole",
+                    selectionId: anchor.selectionId,
+                    detail: snap
+                ))
+            }
+        }
+        return IntrospectionTools.encode(FeatureSelectionsResult(
+            bodyId: bodyId,
+            selections: results
+        ))
+    }
+}

--- a/Sources/OCCTMCPCore/Tools/RemapTools.swift
+++ b/Sources/OCCTMCPCore/Tools/RemapTools.swift
@@ -1,0 +1,278 @@
+// RemapTools — remap_selection. v0.4 ships a position-matching
+// heuristic rather than wiring OCCT history capture into every
+// mutation tool: for each input selection, look up its cached
+// AnchorSnapshot, then find the best-matching face/edge/vertex on
+// the post-mutation body by centroid distance (and area for faces).
+//
+// Caveats (documented in the tool description):
+// - Pure transforms (translate/rotate/scale) and in-place edits:
+//   high confidence. Anchors land within a tight tolerance of where
+//   they were before.
+// - Topology-changing ops that split or merge sub-shapes (fillet,
+//   chamfer, boolean splits): single-anchor input may land on the
+//   wrong derived sub-shape, or none. Emit `fate: "approximate"`.
+// - Deleted sub-shapes (no candidate within tolerance): `fate: "lost"`.
+// - Body-level picks always rebind to the same body.
+//
+// A future v0.5 can layer OCCT-history-based remap (matching AIS's
+// .findDerived approach) on top — opt-in per-mutation history capture
+// would replace the heuristic for tools that participate.
+
+import Foundation
+import simd
+import OCCTSwift
+import ScriptHarness
+
+public enum RemapTools {
+
+    public struct RemapEntry: Encodable {
+        public let originalSelectionId: String
+        public let newSelectionIds: [String]
+        public let fate: String   // "preserved" | "approximate" | "lost"
+        public let confidenceMm: Double?  // distance from prior centroid
+    }
+
+    public struct RemapReport: Encodable {
+        public let remapped: [RemapEntry]
+    }
+
+    public static func remapSelection(
+        selectionIds: [String],
+        toleranceMmFraction: Double = 0.01,
+        store: ManifestStore = ManifestStore(),
+        registry: SelectionRegistry = .shared
+    ) async -> ToolText {
+        guard let manifest = try? store.read() else {
+            return .init("No scene loaded.")
+        }
+        let outputDir = (store.path as NSString).deletingLastPathComponent
+
+        // Group selections by bodyId so we only load each BREP once.
+        var byBody: [String: [String]] = [:]
+        for id in selectionIds {
+            guard let anchor = await registry.anchor(for: id) else { continue }
+            byBody[anchor.bodyId, default: []].append(id)
+        }
+
+        var remapped: [RemapEntry] = []
+        for (bodyId, ids) in byBody {
+            guard let body = manifest.body(withId: bodyId) else {
+                for id in ids {
+                    remapped.append(.init(
+                        originalSelectionId: id,
+                        newSelectionIds: [],
+                        fate: "lost",
+                        confidenceMm: nil
+                    ))
+                }
+                continue
+            }
+            let path = "\(outputDir)/\(body.file)"
+            guard FileManager.default.fileExists(atPath: path),
+                  let shape = try? Shape.loadBREP(fromPath: path) else {
+                for id in ids {
+                    remapped.append(.init(
+                        originalSelectionId: id,
+                        newSelectionIds: [],
+                        fate: "lost",
+                        confidenceMm: nil
+                    ))
+                }
+                continue
+            }
+            let bb = shape.bounds
+            let diag = simd_length(bb.max - bb.min)
+            let tolerance = max(diag * toleranceMmFraction, 1e-6)
+
+            for id in ids {
+                guard let anchor = await registry.anchor(for: id) else {
+                    remapped.append(.init(
+                        originalSelectionId: id,
+                        newSelectionIds: [],
+                        fate: "lost",
+                        confidenceMm: nil
+                    ))
+                    continue
+                }
+                let snapshot = await registry.snapshot(for: id)
+                let entry = await remapOne(
+                    originalId: id,
+                    anchor: anchor,
+                    priorSnapshot: snapshot,
+                    shape: shape,
+                    bodyId: bodyId,
+                    tolerance: tolerance,
+                    registry: registry
+                )
+                remapped.append(entry)
+            }
+        }
+
+        return IntrospectionTools.encode(RemapReport(remapped: remapped))
+    }
+
+    static func remapOne(
+        originalId: String,
+        anchor: TopologyAnchor,
+        priorSnapshot: AnchorSnapshot?,
+        shape: Shape,
+        bodyId: String,
+        tolerance: Double,
+        registry: SelectionRegistry
+    ) async -> RemapEntry {
+        switch anchor {
+        case .body:
+            // Whole-body picks always survive.
+            let next = TopologyAnchor.body(bodyId: bodyId)
+            return .init(
+                originalSelectionId: originalId,
+                newSelectionIds: [next.selectionId],
+                fate: "preserved",
+                confidenceMm: 0
+            )
+
+        case .face:
+            let candidates = shape.faces().enumerated().map { (i, face) -> (Int, SIMD3<Double>, Double, String) in
+                let (center, _) = SelectionTools.faceCenterAndNormal(face: face)
+                return (i, center, face.area(), String(describing: face.surfaceType))
+            }
+            return await pickClosest(
+                originalId: originalId,
+                priorSnapshot: priorSnapshot,
+                tolerance: tolerance,
+                bodyId: bodyId,
+                kind: "face",
+                candidates: candidates.map {
+                    Candidate(
+                        index: $0.0,
+                        center: $0.1,
+                        area: $0.2,
+                        length: nil,
+                        type: $0.3
+                    )
+                },
+                registry: registry,
+                anchorMaker: { idx in .face(bodyId: bodyId, index: idx) },
+                snapshotMaker: { c in
+                    AnchorSnapshot(
+                        center: [c.center.x, c.center.y, c.center.z],
+                        area: c.area,
+                        surfaceType: c.type
+                    )
+                }
+            )
+
+        case .edge:
+            let candidates = shape.edges().enumerated().compactMap { (i, edge) -> Candidate? in
+                guard let center = SelectionTools.edgeMidpoint(edge: edge) else { return nil }
+                return Candidate(
+                    index: i,
+                    center: center,
+                    area: nil,
+                    length: edge.length,
+                    type: String(describing: edge.curveType)
+                )
+            }
+            return await pickClosest(
+                originalId: originalId,
+                priorSnapshot: priorSnapshot,
+                tolerance: tolerance,
+                bodyId: bodyId,
+                kind: "edge",
+                candidates: candidates,
+                registry: registry,
+                anchorMaker: { idx in .edge(bodyId: bodyId, index: idx) },
+                snapshotMaker: { c in
+                    AnchorSnapshot(
+                        center: [c.center.x, c.center.y, c.center.z],
+                        length: c.length,
+                        curveType: c.type
+                    )
+                }
+            )
+
+        case .vertex:
+            let candidates = shape.vertices().enumerated().map { (i, v) -> Candidate in
+                Candidate(index: i, center: v, area: nil, length: nil, type: "vertex")
+            }
+            return await pickClosest(
+                originalId: originalId,
+                priorSnapshot: priorSnapshot,
+                tolerance: tolerance,
+                bodyId: bodyId,
+                kind: "vertex",
+                candidates: candidates,
+                registry: registry,
+                anchorMaker: { idx in .vertex(bodyId: bodyId, index: idx) },
+                snapshotMaker: { c in
+                    AnchorSnapshot(center: [c.center.x, c.center.y, c.center.z])
+                }
+            )
+        }
+    }
+
+    struct Candidate {
+        let index: Int
+        let center: SIMD3<Double>
+        let area: Double?
+        let length: Double?
+        let type: String
+    }
+
+    static func pickClosest(
+        originalId: String,
+        priorSnapshot: AnchorSnapshot?,
+        tolerance: Double,
+        bodyId: String,
+        kind: String,
+        candidates: [Candidate],
+        registry: SelectionRegistry,
+        anchorMaker: (Int) -> TopologyAnchor,
+        snapshotMaker: (Candidate) -> AnchorSnapshot
+    ) async -> RemapEntry {
+        guard let prior = priorSnapshot, prior.center.count == 3 else {
+            return .init(
+                originalSelectionId: originalId,
+                newSelectionIds: [],
+                fate: "lost",
+                confidenceMm: nil
+            )
+        }
+        let priorCenter = SIMD3<Double>(prior.center[0], prior.center[1], prior.center[2])
+        guard !candidates.isEmpty else {
+            return .init(
+                originalSelectionId: originalId,
+                newSelectionIds: [],
+                fate: "lost",
+                confidenceMm: nil
+            )
+        }
+        let scored = candidates
+            .map { ($0, simd_length($0.center - priorCenter)) }
+            .sorted { $0.1 < $1.1 }
+        let (best, dist) = scored[0]
+
+        let fate: String
+        if dist <= tolerance * 0.1 {
+            fate = "preserved"  // virtually identical
+        } else if dist <= tolerance {
+            fate = "approximate"
+        } else {
+            return .init(
+                originalSelectionId: originalId,
+                newSelectionIds: [],
+                fate: "lost",
+                confidenceMm: dist
+            )
+        }
+        let newAnchor = anchorMaker(best.index)
+        let newSnapshot = snapshotMaker(best)
+        await registry.record(anchor: newAnchor, snapshot: newSnapshot)
+        return .init(
+            originalSelectionId: originalId,
+            newSelectionIds: [newAnchor.selectionId],
+            fate: fate,
+            confidenceMm: dist
+        )
+    }
+}

--- a/Sources/OCCTMCPCore/Tools/SelectionTools.swift
+++ b/Sources/OCCTMCPCore/Tools/SelectionTools.swift
@@ -1,0 +1,199 @@
+// SelectionTools — select_topology picks faces / edges / vertices on a
+// scene body and registers them with SelectionRegistry. Returns
+// self-describing selectionIds plus an anchor snapshot (centroid +
+// shape-specific metadata) so the LLM can both refer back and reason
+// about what was picked.
+//
+// This is the foundation for the rest of v0.4 — remap_selection,
+// add_dimension, add_scene_primitive, select_by_feature all consume
+// selectionIds produced here.
+
+import Foundation
+import simd
+import OCCTSwift
+import ScriptHarness
+
+public enum SelectionTools {
+
+    public struct Filter {
+        public var surfaceType: String?
+        public var curveType: String?
+        public var minArea: Double?
+        public var maxArea: Double?
+        public var minLength: Double?
+        public var maxLength: Double?
+        public var normalDirection: SIMD3<Double>?
+        public var normalTolerance: Double?
+        public init() {}
+    }
+
+    public struct SelectionEntry: Encodable {
+        public let selectionId: String
+        public let bodyId: String
+        public let kind: String
+        public let anchorIndex: Int?
+        public let anchor: AnchorSnapshot
+    }
+
+    public struct SelectionResult: Encodable {
+        public let selections: [SelectionEntry]
+        public let total: Int
+        public let truncated: Bool
+    }
+
+    /// Pick faces / edges / vertices matching `filter`. Each match is
+    /// registered with SelectionRegistry under `sel:<bodyId>#<kind>[<idx>]`.
+    public static func selectTopology(
+        bodyId: String,
+        kind: String,
+        filter: Filter = .init(),
+        limit: Int? = nil,
+        store: ManifestStore = ManifestStore(),
+        registry: SelectionRegistry = .shared
+    ) async -> ToolText {
+        let loaded: (manifest: ScriptManifest, body: BodyDescriptor, shape: Shape, path: String)
+        do {
+            loaded = try IntrospectionTools.loadShape(bodyId: bodyId, store: store)
+        } catch {
+            return .init("\(error)")
+        }
+        let shape = loaded.shape
+
+        var entries: [SelectionEntry] = []
+        var totalScanned = 0
+
+        switch kind {
+        case "body":
+            let anchor = TopologyAnchor.body(bodyId: bodyId)
+            let bb = shape.bounds
+            let center = [
+                (bb.min.x + bb.max.x) * 0.5,
+                (bb.min.y + bb.max.y) * 0.5,
+                (bb.min.z + bb.max.z) * 0.5,
+            ]
+            let snapshot = AnchorSnapshot(center: center)
+            await registry.record(anchor: anchor, snapshot: snapshot)
+            entries.append(SelectionEntry(
+                selectionId: anchor.selectionId,
+                bodyId: bodyId,
+                kind: "body",
+                anchorIndex: nil,
+                anchor: snapshot
+            ))
+            totalScanned = 1
+
+        case "face":
+            for (i, face) in shape.faces().enumerated() {
+                totalScanned += 1
+                let surfaceType = String(describing: face.surfaceType)
+                if let want = filter.surfaceType, want != surfaceType { continue }
+                let area = face.area()
+                if let lo = filter.minArea, area < lo { continue }
+                if let hi = filter.maxArea, area > hi { continue }
+
+                let (center, normal) = faceCenterAndNormal(face: face)
+                if let dir = filter.normalDirection,
+                   let n = normal {
+                    let cos = simd_dot(simd_normalize(dir), simd_normalize(n))
+                    let limit = filter.normalTolerance ?? 0.01
+                    if abs(cos - 1.0) > limit { continue }
+                }
+                let anchor = TopologyAnchor.face(bodyId: bodyId, index: i)
+                let snapshot = AnchorSnapshot(
+                    center: [center.x, center.y, center.z],
+                    normal: normal.map { [$0.x, $0.y, $0.z] },
+                    area: area,
+                    surfaceType: surfaceType
+                )
+                await registry.record(anchor: anchor, snapshot: snapshot)
+                entries.append(SelectionEntry(
+                    selectionId: anchor.selectionId,
+                    bodyId: bodyId,
+                    kind: "face",
+                    anchorIndex: i,
+                    anchor: snapshot
+                ))
+            }
+
+        case "edge":
+            for (i, edge) in shape.edges().enumerated() {
+                totalScanned += 1
+                let curveType = String(describing: edge.curveType)
+                if let want = filter.curveType, want != curveType { continue }
+                let length = edgeLength(edge: edge)
+                if let lo = filter.minLength, length < lo { continue }
+                if let hi = filter.maxLength, length > hi { continue }
+
+                let center = edgeMidpoint(edge: edge)
+                let anchor = TopologyAnchor.edge(bodyId: bodyId, index: i)
+                let snapshot = AnchorSnapshot(
+                    center: center.map { [$0.x, $0.y, $0.z] } ?? [0, 0, 0],
+                    length: length,
+                    curveType: curveType
+                )
+                await registry.record(anchor: anchor, snapshot: snapshot)
+                entries.append(SelectionEntry(
+                    selectionId: anchor.selectionId,
+                    bodyId: bodyId,
+                    kind: "edge",
+                    anchorIndex: i,
+                    anchor: snapshot
+                ))
+            }
+
+        case "vertex":
+            for (i, vertex) in shape.vertices().enumerated() {
+                totalScanned += 1
+                let anchor = TopologyAnchor.vertex(bodyId: bodyId, index: i)
+                let snapshot = AnchorSnapshot(
+                    center: [vertex.x, vertex.y, vertex.z]
+                )
+                await registry.record(anchor: anchor, snapshot: snapshot)
+                entries.append(SelectionEntry(
+                    selectionId: anchor.selectionId,
+                    bodyId: bodyId,
+                    kind: "vertex",
+                    anchorIndex: i,
+                    anchor: snapshot
+                ))
+            }
+
+        default:
+            return .init("Unknown kind '\(kind)'. Expected one of: body, face, edge, vertex.")
+        }
+
+        let truncated = limit.map { entries.count > $0 } ?? false
+        if let n = limit { entries = Array(entries.prefix(n)) }
+
+        return IntrospectionTools.encode(SelectionResult(
+            selections: entries,
+            total: totalScanned,
+            truncated: truncated
+        ))
+    }
+
+    // MARK: - Anchor helpers
+
+    /// Centroid + outward normal at the face's UV midpoint. Both nil
+    /// if the face's UV bounds can't be resolved.
+    static func faceCenterAndNormal(face: Face) -> (SIMD3<Double>, SIMD3<Double>?) {
+        guard let uv = face.uvBounds else {
+            return (SIMD3<Double>.zero, nil)
+        }
+        let u = (uv.uMin + uv.uMax) * 0.5
+        let v = (uv.vMin + uv.vMax) * 0.5
+        let center = face.point(atU: u, v: v) ?? SIMD3<Double>.zero
+        let normal = face.normal(atU: u, v: v)
+        return (center, normal)
+    }
+
+    static func edgeMidpoint(edge: Edge) -> SIMD3<Double>? {
+        guard let bounds = edge.parameterBounds else { return nil }
+        let mid = (bounds.first + bounds.last) * 0.5
+        return edge.point(at: mid)
+    }
+
+    static func edgeLength(edge: Edge) -> Double {
+        return edge.length
+    }
+}


### PR DESCRIPTION
## Summary

v0.4 of the Swift port — net-new tools that surface the **OCCTSwiftAIS** layer to the LLM. Eight new tools, taking the Swift binary from 37 → **45 tools**, all backed by the new `SelectionRegistry` actor and `<output_dir>/annotations.json` sidecar.

This is the first release where the Swift port goes **beyond** Node-side parity. None of these tools exist on the Node side; they're capabilities the AIS layer enables.

## New tools

### Foundation (selection lifecycle)

- **`select_topology`** — pick faces / edges / vertices / whole-bodies by criteria (surfaceType, curveType, area / length bounds, normal direction). Registers each pick with the `SelectionRegistry` under a self-describing `sel:<bodyId>#<kind>[<idx>]` id, plus an anchor snapshot (centroid, normal, area, length, type).
- **`remap_selection`** — walk selectionIds across a scene mutation via a position-matching heuristic (closest-centroid within a body-bbox-diagonal-relative tolerance). Each input maps to zero or more new selectionIds plus a `fate` (`preserved` / `approximate` / `lost`). Documented as approximate — pure transforms / in-place edits resolve cleanly; fillets / chamfers / boolean splits may land on the wrong derived sub-shape.

### Annotations (sidecar persistence)

- **`add_dimension`** — linear / angular / radial. Computes the value from `SelectionRegistry`'s anchor snapshots, persists to the annotations sidecar with the resolved anchor points.
- **`add_scene_primitive`** — Trihedron / WorkPlane / Axis / PointCloud. Per-kind params land in `PrimitiveAnnotation.params` as `AnyCodable`.
- **`remove_scene_annotation`** — clean up by id.

### Gap-fillers (compositions over existing primitives)

- **`show_bounding_box`** — wraps `Shape.bounds`, registers a `boundingBox` scene primitive. Returns min/max/extent/center inline.
- **`diff_overlay`** — reads `SceneTools.diffManifests`, drops a tinted `diffMarker` primitive at each affected body's bbox (added=green, removed=red, changed=yellow).
- **`select_by_feature`** — composes `recognize_features` + `SelectionRegistry`. Each detected hole / pocket becomes a face-level selectionId.

## Architecture

### `SelectionRegistry` (`Sources/OCCTMCPCore/SelectionRegistry.swift`)

Actor + `TopologyAnchor` enum + `AnchorSnapshot`. Stores resolved anchors so subsequent tools (`remap_selection`, `add_dimension`) don't need to re-load the BREP. `selectionId` format `sel:<bodyId>#<kind>[<idx>]` is parseable as a fallback when the registry is cold.

### `AnnotationsSidecar` (`Sources/OCCTMCPCore/Annotations.swift`)

`<output_dir>/annotations.json` carries `dimensions[]` and `primitives[]`. Manifest schema is left untouched so this is a contained extension; OCCTSwiftViewport could opt-in to read the sidecar later. `AnyCodable` is a small JSON value type so primitive params don't need per-kind concrete structs.

## Deferred to v0.5

- **Render-overlay integration** — `render_preview` doesn't yet draw the sidecar's dimensions and primitives. The geometry generation (lines for axes, spheres for trihedrons, semi-transparent quads for workplanes, text+lines for dimensions) is better-placed in OCCTSwiftViewport's `OffscreenRenderer` than per-call OCCT primitive synthesis here.
- **OCCT history-based remap** — the position-matching heuristic in `remap_selection` is good for transforms / in-place edits but loses single→N mappings (fillet edge splits, boolean face splits). A v0.5 could opt-in per-mutation history capture matching AIS's `TopologyGraph.findDerived` approach.

## Test plan

- [x] `swift build` clean against OCCTSwiftAIS v0.6.1 + the existing dep set
- [x] `swift test` — 18/18 green
- [x] Manual smoke: `select_topology` returns parseable selectionIds, `add_dimension` writes to `annotations.json`, `show_bounding_box` returns sensible mm values

## Counts

- **45 tools** registered (was 37 in v0.3.0 — full Node parity + 8 net-new)
- 18 swift-testing cases (unchanged — per-tool tests for the v0.4 surface land alongside the v0.5 render integration)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
