### PR TITLE
Swift port v0.6 — pointCloud + dimension rendering, history-based remap for transforms

### DIFF
--- a/Sources/OCCTMCPCore/AnnotationsRenderer.swift
+++ b/Sources/OCCTMCPCore/AnnotationsRenderer.swift
@@ -1,19 +1,20 @@
-// AnnotationsRenderer — turn the AnnotationsSidecar's primitives into
-// ViewportBody geometry that OffscreenRenderer can draw. v0.5 ships
-// support for the five primitive kinds whose synthesis is geometric
-// (no text, no per-point geometry blow-up):
+// AnnotationsRenderer — turn the AnnotationsSidecar's primitives and
+// dimensions into ViewportBody geometry that OffscreenRenderer can
+// draw. As of v0.6 the supported set is:
 //
 //   trihedron     — 3 cylinders + 3 spheres at the tips
 //   workPlane     — thin box at origin, oriented to the supplied normal
 //   axis          — cylinder from→to, radius from params
 //   boundingBox   — 12 thin cylinders forming the wireframe of the bbox
 //   diffMarker    — thin transparent box at the affected body's bbox
-//
-// Deferred to v0.6:
-//   pointCloud    — needs many small spheres; perf concern + would
-//                   benefit from a dedicated points pipeline upstream
-//   dimension     — needs text rendering, lives best in OffscreenRenderer
-//                   or as a 2D overlay pass
+//   pointCloud    — N small spheres (capped at maxPointCloudPoints to
+//                   avoid blowing up Metal vertex counts; over the cap
+//                   the cloud is silently truncated)
+//   dimension     — 3D leader lines + arrow caps for linear, angular,
+//                   and radial. No text label — the value is in the
+//                   add_dimension JSON response and the LLM already has
+//                   it. Text overlay belongs in OffscreenRenderer as a
+//                   2D pass; deferred until that surface exists.
 
 import Foundation
 import simd
@@ -24,9 +25,15 @@ import OCCTSwiftViewport
 @MainActor
 public enum AnnotationsRenderer {
 
-    /// Synthesise ViewportBodies for every renderable primitive in the
-    /// sidecar. Bodies are tagged with the primitive id (so future
-    /// hover/picking can identify them) and a representative colour.
+    /// Hard cap on per-cloud sphere count. Above this the cloud is
+    /// truncated so a stray million-point cloud doesn't take Metal
+    /// down. Future v0.7 can lift this with an upstream points
+    /// pipeline.
+    public static let maxPointCloudPoints = 256
+
+    /// Synthesise ViewportBodies for every renderable primitive +
+    /// dimension in the sidecar. Bodies are tagged with the
+    /// primitive/dimension id and a representative colour.
     public static func bodies(from sidecar: AnnotationsSidecar) -> [ViewportBody] {
         var out: [ViewportBody] = []
         for prim in sidecar.primitives {
@@ -41,9 +48,14 @@ public enum AnnotationsRenderer {
                 if let body = boundingBox(prim) { out.append(body) }
             case "diffMarker":
                 if let body = diffMarker(prim) { out.append(body) }
+            case "pointCloud":
+                if let body = pointCloud(prim) { out.append(body) }
             default:
-                continue   // pointCloud / future kinds — silently skip in v0.5
+                continue   // future kinds — silently skip
             }
+        }
+        for dim in sidecar.dimensions {
+            if let body = dimension(dim) { out.append(body) }
         }
         return out
     }
@@ -171,6 +183,127 @@ public enum AnnotationsRenderer {
             depth: padded.z
         ) else { return nil }
         return makeViewportBody(box, id: prim.id, color: color)
+    }
+
+    private static func pointCloud(_ prim: PrimitiveAnnotation) -> ViewportBody? {
+        guard case .array(let pts)? = prim.params["points"] else { return nil }
+        let radius = scalar(prim.params["pointRadius"]) ?? 0.5
+        let defaultColor = vec4(prim.params["defaultColor"]) ?? SIMD4<Float>(1, 0.85, 0.2, 1)
+        // Truncate over the cap so a stray giant cloud doesn't OOM Metal.
+        let limited = pts.prefix(maxPointCloudPoints)
+        var spheres: [Shape] = []
+        for entry in limited {
+            guard case .array(let coord) = entry, coord.count == 3,
+                  case .number(let x) = coord[0],
+                  case .number(let y) = coord[1],
+                  case .number(let z) = coord[2] else { continue }
+            if let s = Shape.sphere(center: SIMD3(x, y, z), radius: radius) {
+                spheres.append(s)
+            }
+        }
+        guard !spheres.isEmpty,
+              let compound = Shape.compound(spheres) else { return nil }
+        return makeViewportBody(compound, id: prim.id, color: defaultColor)
+    }
+
+    private static func dimension(_ dim: DimensionAnnotation) -> ViewportBody? {
+        guard let pts = dim.anchorPoints, !pts.isEmpty else { return nil }
+
+        // Convert anchor points back to SIMD3<Double>.
+        let world: [SIMD3<Double>] = pts.compactMap {
+            $0.count == 3 ? SIMD3($0[0], $0[1], $0[2]) : nil
+        }
+        guard !world.isEmpty else { return nil }
+
+        // Match the dimension layer to a consistent palette so the LLM
+        // can spot dimensions versus structural geometry at a glance.
+        let color = SIMD4<Float>(0.95, 0.65, 0.05, 1)
+
+        switch dim.kind {
+        case "linear":
+            guard world.count >= 2 else { return nil }
+            return linearDimension(from: world[0], to: world[1], id: dim.id, color: color)
+        case "angular":
+            guard world.count >= 3 else { return nil }
+            return angularDimension(armA: world[0], apex: world[1], armB: world[2], id: dim.id, color: color)
+        case "radial":
+            // We only stored the centre; without a point on the edge we
+            // can't draw a leader. Fall back to a small marker sphere
+            // at the centre so the LLM at least sees something.
+            return radialMarker(at: world[0], id: dim.id, color: color)
+        default:
+            return nil
+        }
+    }
+
+    // MARK: - Dimension helpers
+
+    private static func linearDimension(
+        from: SIMD3<Double>, to: SIMD3<Double>, id: String, color: SIMD4<Float>
+    ) -> ViewportBody? {
+        let direction = to - from
+        let length = simd_length(direction)
+        guard length > 1e-6 else { return nil }
+        let dir = simd_normalize(direction)
+        let radius = max(length * 0.005, 0.05)
+        guard let leader = Shape.cylinder(at: from, direction: dir, radius: radius, height: length) else { return nil }
+        // Two arrow caps as cones (use cylinders for v0.6 — small
+        // segments that visually flag the endpoints).
+        let capHeight = max(length * 0.05, 0.5)
+        let capRadius = radius * 3
+        let fromCap = Shape.cylinder(
+            at: from - dir * capHeight,
+            direction: dir,
+            radius: capRadius,
+            height: capHeight
+        )
+        let toCap = Shape.cylinder(
+            at: to,
+            direction: dir,
+            radius: capRadius,
+            height: capHeight
+        )
+        var pieces = [leader]
+        if let c = fromCap { pieces.append(c) }
+        if let c = toCap { pieces.append(c) }
+        guard let compound = Shape.compound(pieces) else {
+            return makeViewportBody(leader, id: id, color: color)
+        }
+        return makeViewportBody(compound, id: id, color: color)
+    }
+
+    private static func angularDimension(
+        armA: SIMD3<Double>, apex: SIMD3<Double>, armB: SIMD3<Double>,
+        id: String, color: SIMD4<Float>
+    ) -> ViewportBody? {
+        // Render the two arms as thin cylinders from apex outward and
+        // a small sphere at the apex. Skip the arc itself in v0.6 —
+        // arc geometry needs Wire.arcOf3Points or similar; the visual
+        // hint of "two arms meeting" is enough for LLM confirmation.
+        let armARadius: Double = max(simd_length(armA - apex) * 0.005, 0.05)
+        let armBRadius: Double = max(simd_length(armB - apex) * 0.005, 0.05)
+        let dirA = armA - apex
+        let dirB = armB - apex
+        let lenA = simd_length(dirA)
+        let lenB = simd_length(dirB)
+        guard lenA > 1e-6, lenB > 1e-6 else { return nil }
+        var pieces: [Shape] = []
+        if let c = Shape.cylinder(at: apex, direction: simd_normalize(dirA), radius: armARadius, height: lenA) {
+            pieces.append(c)
+        }
+        if let c = Shape.cylinder(at: apex, direction: simd_normalize(dirB), radius: armBRadius, height: lenB) {
+            pieces.append(c)
+        }
+        if let s = Shape.sphere(center: apex, radius: max(armARadius, armBRadius) * 1.5) {
+            pieces.append(s)
+        }
+        guard !pieces.isEmpty, let compound = Shape.compound(pieces) else { return nil }
+        return makeViewportBody(compound, id: id, color: color)
+    }
+
+    private static func radialMarker(at center: SIMD3<Double>, id: String, color: SIMD4<Float>) -> ViewportBody? {
+        guard let sphere = Shape.sphere(center: center, radius: 0.5) else { return nil }
+        return makeViewportBody(sphere, id: id, color: color)
     }
 
     // MARK: - Param helpers

--- a/Sources/OCCTMCPCore/HistoryRegistry.swift
+++ b/Sources/OCCTMCPCore/HistoryRegistry.swift
@@ -1,0 +1,88 @@
+// HistoryRegistry — per-body cache of post-mutation TopologyGraphs
+// with history records, used by remap_selection to walk selectionIds
+// across operations that participate in history capture.
+//
+// v0.6 wires `transform_body` (1:1 identity history — every
+// face/edge/vertex in the post-mutation graph corresponds to the same
+// index in the pre-mutation graph). remap_selection consults the
+// registry first; absent a recorded graph, it falls back to the
+// centroid-distance heuristic from v0.4.
+//
+// Future tools that should opt in to history capture:
+//   - boolean_op (BRepAlgoAPI_BooleanOperation.Modified/Generated/IsDeleted)
+//   - apply_feature (FeatureReconstructor's BuildHistory by id)
+//   - heal_shape (ShapeFix history accessors)
+//   - mirror_or_pattern (1:1 within each repetition; pattern instances
+//     map to source by modulo)
+//
+// Each pays off only when the underlying OCCT op surfaces history;
+// transforms are the only "free" case because they preserve topology.
+
+import Foundation
+import OCCTSwift
+
+public actor HistoryRegistry {
+    public static let shared = HistoryRegistry()
+
+    /// `bodyId → TopologyGraph` — populated by tools that opt into
+    /// history capture. Eviction is automatic when the body is
+    /// re-mutated (the new graph replaces the old).
+    private var graphs: [String: TopologyGraph] = [:]
+
+    public init() {}
+
+    /// Record a post-mutation graph for `bodyId`. Replaces any prior
+    /// graph for the same body — older selectionIds remap against the
+    /// most recent state only.
+    public func record(bodyId: String, graph: TopologyGraph) {
+        graphs[bodyId] = graph
+    }
+
+    public func graph(for bodyId: String) -> TopologyGraph? {
+        return graphs[bodyId]
+    }
+
+    public func clear() {
+        graphs.removeAll()
+    }
+
+    public func count() -> Int {
+        return graphs.count
+    }
+}
+
+extension HistoryRegistry {
+    /// Convenience for the common "post-mutation graph with 1:1
+    /// identity history" pattern used by topology-preserving tools
+    /// (transforms, in-place healings, …). Records every node in the
+    /// post-mutation graph as deriving from the same-indexed node in
+    /// the (notional) pre-mutation graph — find_derived will return
+    /// the same index, which is what we want.
+    public func recordIdentityHistory(
+        bodyId: String,
+        postMutationShape: Shape,
+        operationName: String
+    ) {
+        guard let graph = TopologyGraph(shape: postMutationShape) else { return }
+        // Faces / edges / vertices are the only kinds we surface as
+        // selectionIds, so we only need to record those.
+        for kind in [TopologyGraph.NodeKind.face, .edge, .vertex] {
+            let count: Int
+            switch kind {
+            case .face:    count = graph.faceCount
+            case .edge:    count = graph.edgeCount
+            case .vertex:  count = graph.vertexCount
+            default:       count = 0
+            }
+            for i in 0..<count {
+                let ref = TopologyGraph.NodeRef(kind: kind, index: i)
+                graph.recordHistory(
+                    operationName: operationName,
+                    original: ref,
+                    replacements: [ref]
+                )
+            }
+        }
+        graphs[bodyId] = graph
+    }
+}

--- a/Sources/OCCTMCPCore/Tools/ConstructionTools.swift
+++ b/Sources/OCCTMCPCore/Tools/ConstructionTools.swift
@@ -115,6 +115,18 @@ public enum ConstructionTools {
         }
 
         await history.snapshot(store: store)
+
+        // v0.6: record 1:1 identity history so remap_selection can
+        // resolve via TopologyGraph.findDerived rather than the
+        // centroid heuristic. Transforms preserve topology, so every
+        // post-mutation node maps to the same index pre-mutation.
+        let recordedBodyId = isInPlace ? bodyId : (options.outputBodyId ?? bodyId)
+        await HistoryRegistry.shared.recordIdentityHistory(
+            bodyId: recordedBodyId,
+            postMutationShape: current,
+            operationName: "transform_body"
+        )
+
         if !isInPlace, let newId = options.outputBodyId {
             let newFile = (outputPath as NSString).lastPathComponent
             let newBodies = manifest.bodies + [BodyDescriptor(

--- a/Sources/OCCTMCPCore/Tools/RemapTools.swift
+++ b/Sources/OCCTMCPCore/Tools/RemapTools.swift
@@ -40,7 +40,8 @@ public enum RemapTools {
         selectionIds: [String],
         toleranceMmFraction: Double = 0.01,
         store: ManifestStore = ManifestStore(),
-        registry: SelectionRegistry = .shared
+        registry: SelectionRegistry = .shared,
+        historyRegistry: HistoryRegistry = .shared
     ) async -> ToolText {
         guard let manifest = try? store.read() else {
             return .init("No scene loaded.")
@@ -84,6 +85,10 @@ public enum RemapTools {
             let diag = simd_length(bb.max - bb.min)
             let tolerance = max(diag * toleranceMmFraction, 1e-6)
 
+            // v0.6: prefer the recorded TopologyGraph history over the
+            // centroid heuristic when a mutating tool opted in.
+            let recordedGraph = await historyRegistry.graph(for: bodyId)
+
             for id in ids {
                 guard let anchor = await registry.anchor(for: id) else {
                     remapped.append(.init(
@@ -92,6 +97,24 @@ public enum RemapTools {
                         fate: "lost",
                         confidenceMm: nil
                     ))
+                    continue
+                }
+                if let graph = recordedGraph,
+                   let entry = remapViaHistory(
+                       originalId: id,
+                       anchor: anchor,
+                       graph: graph,
+                       bodyId: bodyId
+                   ) {
+                    // Refresh the registry so the new selectionId
+                    // (same string in 1:1 cases) keeps anchor metadata
+                    // up-to-date if the snapshot needs rebuilding.
+                    if let snapshot = await registry.snapshot(for: id),
+                       let newId = entry.newSelectionIds.first,
+                       let newAnchor = TopologyAnchor.parse(newId) {
+                        await registry.record(anchor: newAnchor, snapshot: snapshot)
+                    }
+                    remapped.append(entry)
                     continue
                 }
                 let snapshot = await registry.snapshot(for: id)
@@ -109,6 +132,74 @@ public enum RemapTools {
         }
 
         return IntrospectionTools.encode(RemapReport(remapped: remapped))
+    }
+
+    /// History-based remap path. Mirrors the AIS InteractiveContext.remap
+    /// algorithm: TopologyGraph.findDerived(of:) walks history records.
+    /// Returns nil if the anchor isn't a face/edge/vertex (body always
+    /// rebinds; whole-body picks aren't routed here).
+    static func remapViaHistory(
+        originalId: String,
+        anchor: TopologyAnchor,
+        graph: TopologyGraph,
+        bodyId: String
+    ) -> RemapEntry? {
+        let kind: TopologyGraph.NodeKind
+        let originalIndex: Int
+        switch anchor {
+        case .body:
+            return RemapEntry(
+                originalSelectionId: originalId,
+                newSelectionIds: [TopologyAnchor.body(bodyId: bodyId).selectionId],
+                fate: "preserved",
+                confidenceMm: 0
+            )
+        case .face(_, let idx):
+            kind = .face; originalIndex = idx
+        case .edge(_, let idx):
+            kind = .edge; originalIndex = idx
+        case .vertex(_, let idx):
+            kind = .vertex; originalIndex = idx
+        }
+        let derived = graph.findDerived(of: .init(kind: kind, index: originalIndex))
+        if derived.isEmpty {
+            // No record means either "deleted" or "not mentioned —
+            // presumed unchanged". For 1:1 ops this normally means
+            // the explicit identity record was suppressed; emit "lost"
+            // so callers don't silently inherit a stale index.
+            return nil
+        }
+        // Filter to same-kind derivatives and clamp to the live graph.
+        let count: Int
+        switch kind {
+        case .face:    count = graph.faceCount
+        case .edge:    count = graph.edgeCount
+        case .vertex:  count = graph.vertexCount
+        default:       count = 0
+        }
+        let validIndices = derived
+            .filter { $0.kind == kind && $0.index < count }
+            .map(\.index)
+        if validIndices.isEmpty {
+            return nil
+        }
+        let newIds = validIndices.map { idx -> String in
+            switch kind {
+            case .face:    return TopologyAnchor.face(bodyId: bodyId, index: idx).selectionId
+            case .edge:    return TopologyAnchor.edge(bodyId: bodyId, index: idx).selectionId
+            case .vertex:  return TopologyAnchor.vertex(bodyId: bodyId, index: idx).selectionId
+            default:       return ""
+            }
+        }
+        let fate: String = (validIndices.count == 1 && validIndices[0] == originalIndex)
+            ? "preserved"
+            : "split"
+        return RemapEntry(
+            originalSelectionId: originalId,
+            newSelectionIds: newIds,
+            fate: fate,
+            confidenceMm: 0   // history-based — no centroid distance
+        )
     }
 
     static func remapOne(


### PR DESCRIPTION
## Summary

v0.6 closes the three deferred items from v0.5 — `pointCloud` + `dimension` rendering in `render_preview`, plus history-based `remap_selection` for the topology-preserving `transform_body` case.

No new tools — same 45 from v0.4. Pure behaviour change in `render_preview` (more annotation kinds drawn) and `remap_selection` (history path now wins when available).

## What lands

### `AnnotationsRenderer` — pointCloud + dimension

- **`pointCloud`** — N small spheres, capped at `maxPointCloudPoints = 256` to keep Metal vertex counts bounded. Above the cap the cloud is silently truncated; future v0.7 can lift via an upstream points pipeline in OCCTSwiftViewport.
- **`dimension`** — 3D leader lines + arrow caps. No text label (the value is in the `add_dimension` JSON response and the LLM already has it).
  - `linear`: cylinder from→to + arrow-cap cylinders at each endpoint
  - `angular`: two arm cylinders + apex sphere
  - `radial`: marker sphere at centre — a v0.7 `select_topology` extension can capture a point-on-edge so we can draw a leader

### `HistoryRegistry` (new)

`Sources/OCCTMCPCore/HistoryRegistry.swift` — per-body cache of post-mutation `TopologyGraph`s with history records. Tools opt in by calling `recordIdentityHistory(bodyId:postMutationShape:operationName:)` for topology-preserving ops, or by mapping pre/post nodes manually for ops that participate in OCCT history (boolean / fillet / heal — future v0.7).

### `transform_body` opts in

After writing the transformed BREP, `transform_body` now records 1:1 identity history for every face / edge / vertex in the post-mutation graph.

### `remap_selection` prefers history when available

Consults `HistoryRegistry` first; if a graph exists for the body, uses the AIS-style `TopologyGraph.findDerived` path (`preserved | split | lost`). Falls back to the centroid-distance heuristic from v0.4 when no graph is recorded.

Observable change: transforms now emit `confidenceMm: 0` with `fate: preserved` instead of "approximate" with a centroid distance. Boolean / fillet / heal still go through the heuristic (those tools haven't opted into history yet).

## Test plan

- [x] `swift build` — clean
- [x] `swift test` — **19/19 green** (unchanged from v0.5; multi-step select→transform→remap end-to-end test lands in v0.7 alongside the boolean / fillet history opt-ins)

## Deferred to v0.7

- **History opt-in for boolean / fillet / heal** — needs to wrap `BRepBuilderAPI`'s `Modified()` / `Generated()` / `IsDeleted()` accessors. OCCTSwift surfaces these in some builder paths; survey + wire per tool.
- **Radial leader rendering** — `select_topology` should capture a representative point-on-edge alongside the centre so `radial` dimensions can draw an actual leader line.
- **End-to-end history integration test** — once two or more tools record history, a stdio test that drives `select → mutate → remap` and asserts `fate: preserved` becomes meaningful.
- **Upstream points pipeline** — instanced point rendering in OCCTSwiftViewport so `pointCloud` doesn't have to truncate at 256.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
