### PR TITLE
Swift port v0.7 — radial leaders, heal_shape history, end-to-end remap test

### DIFF
--- a/Sources/OCCTMCPCore/AnnotationsRenderer.swift
+++ b/Sources/OCCTMCPCore/AnnotationsRenderer.swift
@@ -227,9 +227,12 @@ public enum AnnotationsRenderer {
             guard world.count >= 3 else { return nil }
             return angularDimension(armA: world[0], apex: world[1], armB: world[2], id: dim.id, color: color)
         case "radial":
-            // We only stored the centre; without a point on the edge we
-            // can't draw a leader. Fall back to a small marker sphere
-            // at the centre so the LLM at least sees something.
+            // v0.7: anchorPoints is [centre, rim] — draw a leader
+            // cylinder + rim arrow cap. Falls back to a marker sphere
+            // when the snapshot is legacy (centre only).
+            if world.count >= 2 {
+                return radialLeader(centre: world[0], rim: world[1], id: dim.id, color: color)
+            }
             return radialMarker(at: world[0], id: dim.id, color: color)
         default:
             return nil
@@ -304,6 +307,37 @@ public enum AnnotationsRenderer {
     private static func radialMarker(at center: SIMD3<Double>, id: String, color: SIMD4<Float>) -> ViewportBody? {
         guard let sphere = Shape.sphere(center: center, radius: 0.5) else { return nil }
         return makeViewportBody(sphere, id: id, color: color)
+    }
+
+    private static func radialLeader(
+        centre: SIMD3<Double>, rim: SIMD3<Double>, id: String, color: SIMD4<Float>
+    ) -> ViewportBody? {
+        let direction = rim - centre
+        let length = simd_length(direction)
+        guard length > 1e-6 else { return nil }
+        let dir = simd_normalize(direction)
+        let radius = max(length * 0.005, 0.05)
+        let capRadius = radius * 3
+        let capHeight = max(length * 0.06, 0.5)
+        var pieces: [Shape] = []
+        if let leader = Shape.cylinder(at: centre, direction: dir, radius: radius, height: length) {
+            pieces.append(leader)
+        }
+        if let rimCap = Shape.cylinder(
+            at: rim,
+            direction: dir,
+            radius: capRadius,
+            height: capHeight
+        ) {
+            pieces.append(rimCap)
+        }
+        // Small marker at the centre to make it visually distinct from
+        // a linear dimension (whose endpoints both get arrow caps).
+        if let centreMarker = Shape.sphere(center: centre, radius: capRadius) {
+            pieces.append(centreMarker)
+        }
+        guard !pieces.isEmpty, let compound = Shape.compound(pieces) else { return nil }
+        return makeViewportBody(compound, id: id, color: color)
     }
 
     // MARK: - Param helpers

--- a/Sources/OCCTMCPCore/HistoryRegistry.swift
+++ b/Sources/OCCTMCPCore/HistoryRegistry.swift
@@ -85,4 +85,48 @@ extension HistoryRegistry {
         }
         graphs[bodyId] = graph
     }
+
+    /// Conditional version of `recordIdentityHistory` — only records
+    /// if the pre/post topology counts match (face / edge / vertex).
+    /// Returns true when history was captured, false when the
+    /// post-mutation shape's topology differs and the heuristic should
+    /// take over downstream. Used by tools like `heal_shape` whose
+    /// operation usually preserves topology but might rewire edges
+    /// when fixing real defects.
+    @discardableResult
+    public func recordIdentityHistoryIfTopologyPreserved(
+        bodyId: String,
+        preMutationShape: Shape,
+        postMutationShape: Shape,
+        operationName: String
+    ) -> Bool {
+        guard let pre = TopologyGraph(shape: preMutationShape),
+              let post = TopologyGraph(shape: postMutationShape) else {
+            return false
+        }
+        guard pre.faceCount == post.faceCount,
+              pre.edgeCount == post.edgeCount,
+              pre.vertexCount == post.vertexCount else {
+            return false
+        }
+        for kind in [TopologyGraph.NodeKind.face, .edge, .vertex] {
+            let count: Int
+            switch kind {
+            case .face:    count = post.faceCount
+            case .edge:    count = post.edgeCount
+            case .vertex:  count = post.vertexCount
+            default:       count = 0
+            }
+            for i in 0..<count {
+                let ref = TopologyGraph.NodeRef(kind: kind, index: i)
+                post.recordHistory(
+                    operationName: operationName,
+                    original: ref,
+                    replacements: [ref]
+                )
+            }
+        }
+        graphs[bodyId] = post
+        return true
+    }
 }

--- a/Sources/OCCTMCPCore/SelectionRegistry.swift
+++ b/Sources/OCCTMCPCore/SelectionRegistry.swift
@@ -103,13 +103,21 @@ public struct AnchorSnapshot: Sendable, Codable {
     public var surfaceType: String?
     /// Edge curve type (line / circle / ...). nil for faces/vertices.
     public var curveType: String?
+    /// Geometric centre of a circular edge — the centre of curvature,
+    /// distinct from `center` (which holds the parameter-midpoint *rim*
+    /// point for edges). Lets `add_dimension(radial)` compute an exact
+    /// radius from geometry and lets `AnnotationsRenderer.dimension`
+    /// draw a leader from circleCenter → rim. nil for non-edges and
+    /// non-circular edges.
+    public var circleCenter: [Double]?
     public init(
         center: [Double],
         normal: [Double]? = nil,
         area: Double? = nil,
         length: Double? = nil,
         surfaceType: String? = nil,
-        curveType: String? = nil
+        curveType: String? = nil,
+        circleCenter: [Double]? = nil
     ) {
         self.center = center
         self.normal = normal
@@ -117,6 +125,7 @@ public struct AnchorSnapshot: Sendable, Codable {
         self.length = length
         self.surfaceType = surfaceType
         self.curveType = curveType
+        self.circleCenter = circleCenter
     }
 }
 

--- a/Sources/OCCTMCPCore/Tools/AnnotationsTools.swift
+++ b/Sources/OCCTMCPCore/Tools/AnnotationsTools.swift
@@ -106,17 +106,30 @@ public enum AnnotationsTools {
             guard let edgeId = anchors["circularEdge"] else {
                 return .init("radial dimension requires anchors.circularEdge.")
             }
-            guard let snap = await registry.snapshot(for: edgeId),
-                  let lengthArc = snap.length else {
-                return .init("Could not resolve circular edge — re-run select_topology to capture length.")
+            guard let snap = await registry.snapshot(for: edgeId) else {
+                return .init("Could not resolve circular edge.")
             }
-            // Approximate radius from arc length — works for full
-            // circles (length = 2πr). Fine for the typical use case
-            // (drilled holes, circular features).
-            let radius = lengthArc / (2 * .pi)
+            let rim = SIMD3(snap.center[0], snap.center[1], snap.center[2])
+            // v0.7: prefer the geometric centre captured by select_topology.
+            // Falls back to arc-length / 2π for legacy snapshots that
+            // don't have circleCenter populated.
+            let radius: Double
+            let centerArr: [Double]
+            if let c = snap.circleCenter, c.count == 3 {
+                let centre = SIMD3(c[0], c[1], c[2])
+                radius = simd_length(rim - centre)
+                centerArr = c
+            } else if let lengthArc = snap.length {
+                radius = lengthArc / (2 * .pi)
+                centerArr = snap.center   // best we can do without circleCenter
+            } else {
+                return .init("Could not resolve circular edge — re-run select_topology after upgrading to capture circleCenter.")
+            }
             let value = showDiameter ? radius * 2 : radius
-            let center = SIMD3(snap.center[0], snap.center[1], snap.center[2])
-            let points = [[center.x, center.y, center.z]]
+            // anchorPoints: [centre, rim]. Renderer draws a leader
+            // between them; centre alone (legacy v0.5 shape) was just
+            // a marker sphere with no rim attachment.
+            let points = [centerArr, [rim.x, rim.y, rim.z]]
             doc.dimensions.removeAll { $0.id == dimId }
             doc.dimensions.append(.init(
                 id: dimId, kind: "radial",

--- a/Sources/OCCTMCPCore/Tools/HealingTools.swift
+++ b/Sources/OCCTMCPCore/Tools/HealingTools.swift
@@ -75,11 +75,28 @@ public enum HealingTools {
         }
 
         await history.snapshot(store: store)
+
+        // v0.7: opt into history-based remap when heal preserved
+        // topology (which is the typical case — heal mostly tightens
+        // tolerances and merges duplicate vertices). When heal
+        // actually rewires geometry, the count check fails and
+        // remap_selection falls back to the centroid heuristic.
+        let recordedBodyId = isInPlace ? bodyId : (outputBodyId ?? bodyId)
+        let topologyPreserved = await HistoryRegistry.shared.recordIdentityHistoryIfTopologyPreserved(
+            bodyId: recordedBodyId,
+            preMutationShape: inputShape,
+            postMutationShape: healed,
+            operationName: "heal_shape"
+        )
+
         var warnings: [String] = []
         if before.faceCount == after.faceCount &&
             before.edgeCount == after.edgeCount &&
             before.isValid == after.isValid {
             warnings.append("Shape.healed() reported no structural change; before/after may be identical")
+        }
+        if !topologyPreserved {
+            warnings.append("Heal changed topology — remap_selection will fall back to the centroid heuristic for selections on this body.")
         }
 
         if !isInPlace, let newId = outputBodyId {

--- a/Sources/OCCTMCPCore/Tools/SelectionTools.swift
+++ b/Sources/OCCTMCPCore/Tools/SelectionTools.swift
@@ -125,11 +125,27 @@ public enum SelectionTools {
                 if let hi = filter.maxLength, length > hi { continue }
 
                 let center = edgeMidpoint(edge: edge)
+                // For circular edges, also capture the geometric centre
+                // (centre of curvature). `center` is the rim point at
+                // the parameter midpoint; circleCenter is the centre of
+                // the circle — radial dimensions need both.
+                let circleCenter: [Double]?
+                if edge.isCircle, let bounds = edge.parameterBounds {
+                    let mid = (bounds.first + bounds.last) * 0.5
+                    if let c = edge.centerOfCurvature(at: mid) {
+                        circleCenter = [c.x, c.y, c.z]
+                    } else {
+                        circleCenter = nil
+                    }
+                } else {
+                    circleCenter = nil
+                }
                 let anchor = TopologyAnchor.edge(bodyId: bodyId, index: i)
                 let snapshot = AnchorSnapshot(
                     center: center.map { [$0.x, $0.y, $0.z] } ?? [0, 0, 0],
                     length: length,
-                    curveType: curveType
+                    curveType: curveType,
+                    circleCenter: circleCenter
                 )
                 await registry.record(anchor: anchor, snapshot: snapshot)
                 entries.append(SelectionEntry(

--- a/SwiftTests/OCCTMCPCoreTests/IntegrationTests.swift
+++ b/SwiftTests/OCCTMCPCoreTests/IntegrationTests.swift
@@ -14,6 +14,7 @@
 
 import Foundation
 import Testing
+import OCCTSwift
 import ScriptHarness
 @testable import OCCTMCPCore
 
@@ -84,6 +85,116 @@ struct IntegrationTests {
             "check_thickness",
         ] {
             #expect(names.contains(expected), "missing tool: \(expected)")
+        }
+    }
+
+    @Test("history-based remap preserves selectionIds across transform_body")
+    func historyRemapPreservesAcrossTransform() async throws {
+        guard let binary = Self.binaryURL else {
+            Issue.record("Binary not built — run `swift build` first.")
+            return
+        }
+        let scene = NSTemporaryDirectory() + "occtmcp-it-history-\(UUID().uuidString)"
+        try FileManager.default.createDirectory(atPath: scene, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(atPath: scene) }
+
+        // Synthesize a real cylinder BREP so transform_body /
+        // select_topology can actually load it. r=10mm, h=25mm gives
+        // 3 faces (lateral + 2 caps), which is enough to verify
+        // selection survives a translate.
+        guard let cyl = Shape.cylinder(radius: 10, height: 25) else {
+            Issue.record("Failed to synthesize cylinder BREP fixture")
+            return
+        }
+        try Exporter.writeBREP(shape: cyl, to: URL(fileURLWithPath: "\(scene)/cyl.brep"))
+
+        let manifest = ScriptManifest(
+            description: "History remap test scene",
+            bodies: [
+                BodyDescriptor(
+                    id: "cyl",
+                    file: "cyl.brep",
+                    color: [0.8, 0.7, 0.3, 1]
+                ),
+            ]
+        )
+        let store = ManifestStore(path: "\(scene)/manifest.json")
+        try store.write(manifest)
+
+        let harness = try Harness(
+            binary: binary,
+            extraEnv: ["OCCTMCP_OUTPUT_DIR": scene]
+        )
+        defer { harness.terminate() }
+        try harness.handshake()
+
+        // 1. select_topology — pick a face on the cylinder
+        try harness.send(.init(
+            id: 30, method: "tools/call",
+            params: .object([
+                "name": .string("select_topology"),
+                "arguments": .object([
+                    "bodyId": .string("cyl"),
+                    "kind": .string("face"),
+                    "limit": .int(1),
+                ]),
+            ])
+        ))
+        let selectResp = try harness.recv(timeout: 10)
+        guard case .object(let result)? = selectResp["result"],
+              case .array(let content)? = result["content"],
+              case .object(let firstContent)? = content.first,
+              let text = firstContent["text"]?.stringValue,
+              let selectData = text.data(using: .utf8),
+              let parsed = try JSONSerialization.jsonObject(with: selectData) as? [String: Any],
+              let selections = parsed["selections"] as? [[String: Any]],
+              let firstSelection = selections.first,
+              let selectionId = firstSelection["selectionId"] as? String else {
+            Issue.record("select_topology response shape unexpected")
+            return
+        }
+
+        // 2. transform_body — move it
+        try harness.send(.init(
+            id: 31, method: "tools/call",
+            params: .object([
+                "name": .string("transform_body"),
+                "arguments": .object([
+                    "bodyId": .string("cyl"),
+                    "translate": .array([.double(20), .double(0), .double(0)]),
+                ]),
+            ])
+        ))
+        let transformResp = try harness.recv(timeout: 30)
+        #expect(transformResp["error"] == nil)
+
+        // 3. remap_selection — should find the face via history (fate
+        //    preserved), not via centroid heuristic
+        try harness.send(.init(
+            id: 32, method: "tools/call",
+            params: .object([
+                "name": .string("remap_selection"),
+                "arguments": .object([
+                    "selectionIds": .array([.string(selectionId)]),
+                ]),
+            ])
+        ))
+        let remapResp = try harness.recv(timeout: 5)
+        guard case .object(let remapResult)? = remapResp["result"],
+              case .array(let remapContent)? = remapResult["content"],
+              case .object(let remapBody)? = remapContent.first,
+              let remapText = remapBody["text"]?.stringValue,
+              let remapData = remapText.data(using: .utf8),
+              let remapParsed = try JSONSerialization.jsonObject(with: remapData) as? [String: Any],
+              let remapped = remapParsed["remapped"] as? [[String: Any]],
+              let firstEntry = remapped.first else {
+            Issue.record("remap_selection response shape unexpected")
+            return
+        }
+        #expect(firstEntry["fate"] as? String == "preserved",
+                "expected history-based remap to preserve, got: \(firstEntry["fate"] ?? "<nil>")")
+        if let conf = firstEntry["confidenceMm"] as? Double {
+            #expect(conf == 0, "history-based remap should report confidenceMm=0, got \(conf)")
         }
     }
 


### PR DESCRIPTION
## Summary

v0.7 closes three deferred items from v0.6 and adds the end-to-end stdio test that proves the history-based remap path actually works through the spawned binary. Same 45 tools — pure quality / coverage release.

## What lands

### Radial dimension leaders (was a marker sphere only)

- `AnchorSnapshot` gains `circleCenter: [Double]?`. `select_topology` populates it for circular edges via `Edge.centerOfCurvature(at: midpoint)`.
- `add_dimension(radial)` now computes radius exactly from `simd_length(rim - circleCenter)` (was `arcLength / 2π`). Falls back to the old formula for legacy snapshots.
- Anchor points become `[centre, rim]` and `AnnotationsRenderer.dimension(radial)` draws a leader cylinder + arrow cap + centre marker.

### `heal_shape` history opt-in

- `HistoryRegistry.recordIdentityHistoryIfTopologyPreserved` — only records when pre/post face/edge/vertex counts match.
- `heal_shape` calls it after the heal. Topology-preserving heals (the typical case) get history-based remap; topology-changing heals fall back to the heuristic with a warning surfaced in the response.

### End-to-end stdio integration test

- `historyRemapPreservesAcrossTransform` synthesises a real cylinder BREP at runtime, drives `select_topology` → `transform_body` → `remap_selection` through the spawned binary, asserts `fate: preserved` + `confidenceMm: 0`. Validates v0.6's history wiring + v0.7's `select_topology` upgrade end-to-end.

## Counts

- **45 tools** (unchanged)
- **20 swift-testing cases** (was 19 — added the history-path stdio test)

## Test plan

- [x] `swift build` — clean
- [x] `swift test` — 20/20 green
- [x] Specifically the new `historyRemapPreservesAcrossTransform` case passes — proves the full data path works through the spawned binary, not just unit-level

## Still deferred to v0.8+

- **History opt-in for `boolean_op` / `apply_feature` / `mirror_or_pattern`** — needs OCCTSwift to expose per-input `Modified()` / `Generated()` mappings (current shape is `BooleanResult.modifiedFaces` / `BooleanHistoryResult.has*` flags, neither rich enough for per-subshape remap). Track upstream.
- **Upstream points pipeline** — instanced rendering for `pointCloud` so it doesn't truncate at 256.
- **Dimension text overlay** — 2D pass in OffscreenRenderer.

## Hold-points before SPI submission

Unchanged:
1. **OCCT 8.0.0 GA** + **OCCTSwift 1.0**
2. **OCCTSwiftScripts v0.9 tag** — `Package.swift` still uses `branch("main")`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
