### PR TITLE
Swift port v0.8 — introspection tools + auto_dimension

### DIFF
--- a/Sources/OCCTMCPCore/SelectionRegistry.swift
+++ b/Sources/OCCTMCPCore/SelectionRegistry.swift
@@ -166,4 +166,25 @@ public actor SelectionRegistry {
     public func count() -> Int {
         return anchors.count
     }
+
+    /// Snapshot of the registry — used by `list_selections` to surface
+    /// active picks back to the LLM. Sorted by selectionId for stable
+    /// output across runs.
+    public func listEntries() -> [Entry] {
+        return anchors.keys.sorted().map { id in
+            Entry(
+                selectionId: id,
+                bodyId: anchors[id]?.bodyId ?? "",
+                kind: anchors[id]?.kind ?? "unknown",
+                snapshot: snapshots[id]
+            )
+        }
+    }
+
+    public struct Entry: Sendable, Codable {
+        public let selectionId: String
+        public let bodyId: String
+        public let kind: String
+        public let snapshot: AnchorSnapshot?
+    }
 }

--- a/Sources/OCCTMCPCore/Server.swift
+++ b/Sources/OCCTMCPCore/Server.swift
@@ -493,6 +493,49 @@ func catalogTools() -> [Tool] {
             ])
         ),
         Tool(
+            name: "list_selections",
+            description: "Return every active selectionId in the SelectionRegistry plus its anchor metadata. Cheap introspection — useful when the LLM has lost track of which picks it has made earlier in the session.",
+            inputSchema: .object([
+                "type": .string("object"),
+                "properties": .object([:]),
+                "additionalProperties": .bool(false),
+            ])
+        ),
+        Tool(
+            name: "clear_selections",
+            description: "Drop every selectionId from the SelectionRegistry. Returns the count cleared.",
+            inputSchema: .object([
+                "type": .string("object"),
+                "properties": .object([:]),
+                "additionalProperties": .bool(false),
+            ])
+        ),
+        Tool(
+            name: "list_annotations",
+            description: "Read the <output_dir>/annotations.json sidecar and return its dimensions + scene primitives.",
+            inputSchema: .object([
+                "type": .string("object"),
+                "properties": .object([:]),
+                "additionalProperties": .bool(false),
+            ])
+        ),
+        Tool(
+            name: "auto_dimension",
+            description: "Run AAG hole detection, then add a radial dimension to each hole's circular rim edge. One call instead of N (recognize_features → select_topology → add_dimension per hole). Returns a list of dimensionIds + selectionIds the LLM can refer to later.",
+            inputSchema: .object([
+                "type": .string("object"),
+                "properties": .object([
+                    "bodyId": .object(["type": .string("string")]),
+                    "showDiameter": .object([
+                        "type": .string("boolean"),
+                        "description": .string("If true, dimension shows diameter instead of radius. Default false."),
+                    ]),
+                ]),
+                "required": .array([.string("bodyId")]),
+                "additionalProperties": .bool(false),
+            ])
+        ),
+        Tool(
             name: "select_topology",
             description: "Pick faces / edges / vertices on a scene body matching criteria. Returns server-tracked selectionIds (sel:<bodyId>#<kind>[<idx>]) plus an anchor snapshot — the LLM can refer back via remap_selection / add_dimension.",
             inputSchema: .object([
@@ -961,6 +1004,24 @@ func dispatch(callName: String, arguments: [String: Value]) async -> CallTool.Re
         let tol = arguments["toleranceMmFraction"]?.doubleValue ?? 0.01
         return await RemapTools.remapSelection(
             selectionIds: ids, toleranceMmFraction: tol
+        ).asCallToolResult()
+
+    case "list_selections":
+        return await RegistryIntrospectionTools.listSelections().asCallToolResult()
+
+    case "clear_selections":
+        return await RegistryIntrospectionTools.clearSelections().asCallToolResult()
+
+    case "list_annotations":
+        return await RegistryIntrospectionTools.listAnnotations().asCallToolResult()
+
+    case "auto_dimension":
+        guard let bodyId = arguments["bodyId"]?.stringValue else {
+            return ToolText("auto_dimension requires `bodyId`.", isError: true).asCallToolResult()
+        }
+        return await AutoDimensionTool.autoDimension(
+            bodyId: bodyId,
+            showDiameter: arguments["showDiameter"]?.boolValue ?? false
         ).asCallToolResult()
 
     case "select_topology":

--- a/Sources/OCCTMCPCore/Tools/AutoDimensionTool.swift
+++ b/Sources/OCCTMCPCore/Tools/AutoDimensionTool.swift
@@ -1,0 +1,148 @@
+// AutoDimensionTool — composes recognize_features + select_topology +
+// add_dimension. Walks the AAG-detected holes on a body, picks each
+// hole's circular rim edge, captures a selection on it, and adds a
+// radial dimension. One call instead of N round-trips.
+//
+// v0.8 covers radial dims on holes. Linear dims on slots / pockets
+// (anchor pairs) and angular dims on chamfered features are open
+// directions — they each need a default-anchor heuristic that's worth
+// its own conversation.
+
+import Foundation
+import simd
+import OCCTSwift
+import ScriptHarness
+
+public enum AutoDimensionTool {
+
+    public struct AutoDimensionEntry: Encodable {
+        public let kind: String              // "hole_radius" | "hole_diameter"
+        public let dimensionId: String
+        public let selectionId: String
+        public let value: Double
+        public let edgeIndex: Int
+    }
+
+    public struct AutoDimensionResult: Encodable {
+        public let bodyId: String
+        public let added: [AutoDimensionEntry]
+        public let skipped: [SkipReason]
+
+        public struct SkipReason: Encodable {
+            public let faceIndex: Int
+            public let reason: String
+        }
+    }
+
+    public static func autoDimension(
+        bodyId: String,
+        showDiameter: Bool = false,
+        store: ManifestStore = ManifestStore(),
+        registry: SelectionRegistry = .shared
+    ) async -> ToolText {
+        let loaded: (manifest: ScriptManifest, body: BodyDescriptor, shape: Shape, path: String)
+        do {
+            loaded = try IntrospectionTools.loadShape(bodyId: bodyId, store: store)
+        } catch {
+            return .init("\(error)")
+        }
+        let shape = loaded.shape
+        let aag = AAG(shape: shape)
+        let allEdges = shape.edges()
+
+        var added: [AutoDimensionEntry] = []
+        var skipped: [AutoDimensionResult.SkipReason] = []
+
+        for hole in aag.detectHoles() {
+            let faceIndex = hole.faceIndex
+            let faceEdges = shape.edgesInFace(at: faceIndex)
+            guard !faceEdges.isEmpty else {
+                skipped.append(.init(faceIndex: faceIndex, reason: "face has no edges"))
+                continue
+            }
+            // Find the first circular edge — that's the rim.
+            guard let rimEdge = faceEdges.first(where: { $0.isCircle }) else {
+                skipped.append(.init(faceIndex: faceIndex, reason: "no circular rim edge on hole face"))
+                continue
+            }
+            // Find the rim edge's global index (matches the
+            // `edge[N]` selectionId scheme).
+            guard let edgeIndex = indexOf(rimEdge, in: allEdges) else {
+                skipped.append(.init(faceIndex: faceIndex, reason: "rim edge not found in shape's edge list"))
+                continue
+            }
+
+            // Capture the selection so add_dimension can resolve it.
+            let bounds = rimEdge.parameterBounds
+            let mid: Double = bounds.map { ($0.first + $0.last) * 0.5 } ?? 0
+            let rimPoint = rimEdge.point(at: mid) ?? SIMD3<Double>(0, 0, 0)
+            let circleCenter = rimEdge.centerOfCurvature(at: mid)
+            let snapshot = AnchorSnapshot(
+                center: [rimPoint.x, rimPoint.y, rimPoint.z],
+                length: rimEdge.length,
+                curveType: "circle",
+                circleCenter: circleCenter.map { [$0.x, $0.y, $0.z] }
+            )
+            let anchor = TopologyAnchor.edge(bodyId: bodyId, index: edgeIndex)
+            await registry.record(anchor: anchor, snapshot: snapshot)
+
+            // Run add_dimension with the selectionId we just minted.
+            let dimResp = await AnnotationsTools.addDimension(
+                kind: .radial,
+                anchors: ["circularEdge": anchor.selectionId],
+                showDiameter: showDiameter,
+                id: "auto_hole_\(faceIndex)",
+                store: store,
+                registry: registry
+            )
+            // dimResp.text is JSON for the DimensionResult — pull
+            // dimensionId + value out by re-parsing. Cheap and avoids
+            // duplicating the logic.
+            guard let data = dimResp.text.data(using: .utf8),
+                  let parsed = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+                  let dimId = parsed["dimensionId"] as? String,
+                  let value = parsed["value"] as? Double else {
+                skipped.append(.init(faceIndex: faceIndex, reason: "add_dimension failed: \(dimResp.text)"))
+                continue
+            }
+            added.append(.init(
+                kind: showDiameter ? "hole_diameter" : "hole_radius",
+                dimensionId: dimId,
+                selectionId: anchor.selectionId,
+                value: value,
+                edgeIndex: edgeIndex
+            ))
+        }
+
+        return IntrospectionTools.encode(AutoDimensionResult(
+            bodyId: bodyId,
+            added: added,
+            skipped: skipped
+        ))
+    }
+
+    /// Map a Face-edge handle back to its index in the shape's full
+    /// edge list. OCCT doesn't expose a direct lookup, so we match by
+    /// midpoint + length — both stable for a given Edge instance.
+    /// O(E) per lookup; acceptable for the typical hole-count.
+    static func indexOf(_ target: Edge, in allEdges: [Edge]) -> Int? {
+        guard let bounds = target.parameterBounds else { return nil }
+        let mid = (bounds.first + bounds.last) * 0.5
+        guard let targetMidpoint = target.point(at: mid) else { return nil }
+        let targetLength = target.length
+
+        for (i, candidate) in allEdges.enumerated() {
+            guard let cb = candidate.parameterBounds,
+                  let cMid = candidate.point(at: (cb.first + cb.last) * 0.5) else {
+                continue
+            }
+            let dist = simd_length(cMid - targetMidpoint)
+            let lenDiff = abs(candidate.length - targetLength)
+            // Tight matching — same edge should be sub-mm in both axes.
+            if dist < 1e-6 && lenDiff < 1e-6 {
+                return i
+            }
+        }
+        return nil
+    }
+}

--- a/Sources/OCCTMCPCore/Tools/IntrospectionRegistryTools.swift
+++ b/Sources/OCCTMCPCore/Tools/IntrospectionRegistryTools.swift
@@ -1,0 +1,58 @@
+// IntrospectionRegistryTools — list_selections, clear_selections,
+// list_annotations. Cheap state-introspection tools so the LLM can see
+// what's been accumulated in the SelectionRegistry / AnnotationsStore
+// without re-running select_topology / re-reading the sidecar by hand.
+
+import Foundation
+
+public enum RegistryIntrospectionTools {
+
+    // MARK: - list_selections
+
+    public struct ListSelectionsResult: Encodable {
+        public let count: Int
+        public let selections: [SelectionRegistry.Entry]
+    }
+
+    public static func listSelections(
+        registry: SelectionRegistry = .shared
+    ) async -> ToolText {
+        let entries = await registry.listEntries()
+        return IntrospectionTools.encode(ListSelectionsResult(
+            count: entries.count,
+            selections: entries
+        ))
+    }
+
+    // MARK: - clear_selections
+
+    public struct ClearSelectionsResult: Encodable {
+        public let cleared: Int
+    }
+
+    public static func clearSelections(
+        registry: SelectionRegistry = .shared
+    ) async -> ToolText {
+        let count = await registry.count()
+        await registry.clear()
+        return IntrospectionTools.encode(ClearSelectionsResult(cleared: count))
+    }
+
+    // MARK: - list_annotations
+
+    public struct ListAnnotationsResult: Encodable {
+        public let dimensions: [DimensionAnnotation]
+        public let primitives: [PrimitiveAnnotation]
+    }
+
+    public static func listAnnotations(
+        store: ManifestStore = ManifestStore()
+    ) async -> ToolText {
+        let outputDir = (store.path as NSString).deletingLastPathComponent
+        let sidecar = AnnotationsStore(outputDir: outputDir).read()
+        return IntrospectionTools.encode(ListAnnotationsResult(
+            dimensions: sidecar.dimensions,
+            primitives: sidecar.primitives
+        ))
+    }
+}


### PR DESCRIPTION
## Summary

v0.8 adds four small tools — three introspection + one composition — that build on v0.4-v0.7's foundation. 49 tools total (up from 45). No upstream changes required; the larger v0.8 candidates are honestly upstream-blocked and tracked in the release notes.

## What lands

### Introspection — `list_selections` / `clear_selections` / `list_annotations`

The LLM accumulates state across a session: selectionIds in `SelectionRegistry`, dimensions / primitives in `<output_dir>/annotations.json`. Without introspection it can lose track. These three tools surface that state.

- `list_selections` — every active selectionId + anchor metadata
- `clear_selections` — drop the lot, returns the count
- `list_annotations` — read the sidecar back as JSON

### `auto_dimension` (`Sources/OCCTMCPCore/Tools/AutoDimensionTool.swift`)

Composition tool: AAG hole detection → for each hole, find the circular rim edge, capture a selectionId for it, add a radial dimension. One call instead of N round-trips. Returns `dimensionId` + `selectionId` per hole, plus a `skipped` list with reasons (face has no edges, no circular rim, edge not in shape's edge list).

Pockets / chamfers / linear-feature dimensioning are open directions — each needs its own anchor heuristic and is worth its own conversation.

## What's NOT in v0.8 (and why)

- **`mirror_or_pattern` history opt-in** — re-evaluating the contract: pattern adds a new body without mutating the source, so it doesn't fit `remap_selection`'s "across a mutation" semantics. The right tool is `find_correspondences(sourceSelectionIds, targetBodyId, transformHints?)` — its own conversation, queued for v0.9 or later.
- **`boolean_op` / `apply_feature` history opt-in** — needs OCCTSwift to expose per-input `Modified()` / `Generated()` mappings (current `BooleanResult.modifiedFaces` is a flat array; `BooleanHistoryResult.has*` is booleans). Track upstream.
- **`pointCloud` > 256 points** — needs OCCTSwiftViewport's instanced point pipeline.
- **Dimension text overlay** — needs OffscreenRenderer 2D pass.

## Counts

- **49 tools** (was 45 — added `list_selections`, `clear_selections`, `list_annotations`, `auto_dimension`)
- **20 swift-testing cases** (unchanged — per-tool unit tests for the v0.8 surface land alongside the next end-to-end integration test)

## Test plan

- [x] `swift build` — clean
- [x] `swift test` — 20/20 green
- [ ] End-to-end stdio test for `auto_dimension` — needs a multi-hole BREP fixture; current cylinder fixture has no holes. Hold for a v0.9 fixture-management pass.

## Hold-points before SPI submission

Unchanged from v0.3 onward:
1. **OCCT 8.0.0 GA** + **OCCTSwift 1.0**
2. **OCCTSwiftScripts v0.9 tag** — `Package.swift` still uses `branch("main")`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
