### PR TITLE
v1.0.0 — refresh docs, add SPI manifest

### DIFF
--- a/.spi.yml
+++ b/.spi.yml
@@ -1,0 +1,5 @@
+version: 1
+builder:
+  configs:
+    - documentation_targets: [OCCTMCPCore]
+      platform: macos

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,114 +4,148 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## What This Is
 
-MCP server that gives LLMs the ability to create and iterate on CAD models using OpenCASCADE via OCCTSwift. The server exposes a growing set of tools over stdio transport using the `@modelcontextprotocol/sdk` — a few core tools (`execute_script`, scene reads, API reference) plus thin wrappers around occtkit verbs (graph ops, feature recognition, drawing export, reconstruct) and pure-TS scene-mutation tools (remove/rename/clear/appearance/compare/export).
+MCP server that gives LLMs the ability to author, inspect, and iterate on 3D CAD models with OpenCASCADE via the OCCTSwift family. Two implementations live side-by-side:
+
+- **Swift** (`Sources/`, `Package.swift`) — the **primary**, in-process server. Uses the official Swift MCP SDK, calls OCCTSwift / OCCTSwiftMesh / OCCTSwiftTools / OCCTSwiftAIS / DrawingComposer directly. 49 typed tools. macOS 15+.
+- **Node / TypeScript** (`src/`, `dist/`) — the original implementation. Shells out to the `occtkit` CLI via `OCCTSwiftScripts`. 36 tools (the pre-v0.4 surface; selection / remap / annotations are Swift-only).
+
+Both speak stdio MCP and read/write the same `manifest.json` + `annotations.json` files in the output directory. Pick whichever fits the host: the Swift binary eliminates JSONL marshalling and per-call subprocess spawn; the Node server runs anywhere a Node 18+ runtime exists, but needs `occtkit` on `$PATH`.
+
+The Swift port reached **v1.0.0** on 2026-05-09 and is published on the [Swift Package Index](https://swiftpackageindex.com/gsdali/OCCTMCP).
 
 ## Build & Run
+
+### Swift (primary)
+
+```bash
+swift build -c release         # debug build is `swift build`
+swift run occtmcp-server       # stdio transport
+swift test                     # 22 swift-testing cases under SwiftTests/OCCTMCPCoreTests
+```
+
+`swift test` runs unit + integration tests against a tempdir. Integration tests spawn the built `occtmcp-server` binary and drive it over stdio (so a `swift build` must precede them; the harness itself does this).
+
+### Node
 
 ```bash
 npm run build    # tsc → dist/
 npm start        # node dist/index.js (stdio transport)
 npm run dev      # tsc --watch
-```
-
-```bash
 npm test                  # node:test unit tests for scene-mutation logic (no occtkit)
 npm run test:integration  # node:test end-to-end chain through occtkit (slow; ~30–120s)
 ```
 
-Tests under `tests/unit/` exercise the pure-TS scene-mutation code against a tempdir (set `OCCTMCP_OUTPUT_DIR` to redirect manifest reads/writes). `tests/integration/` runs every Phase 2 + Phase 3 verb-wrapping tool through a real occtkit subprocess against a tempdir seeded from a starter BREP. No linter configured.
+`OCCTMCP_OUTPUT_DIR` redirects manifest reads/writes to a tempdir on both paths — the test suites use this.
 
-## Architecture
+## Swift Architecture
 
-The server is a single-process Node.js app (ESM, strict TypeScript):
+`Sources/OCCTMCPCore/` (library) + `Sources/OCCTMCPServer/` (executable that connects stdio).
 
-- `src/index.ts` — Exports `createServer()` factory (which registers every tool with zod schemas) and connects stdio transport when run directly. Tests import `createServer()` to introspect the tool registry without binding stdio. The `get_api_reference` tool's `mcp_tools` category dumps the live registry as JSON Schema for LLM auto-discovery
-- `src/tools.ts` — Core tool implementations (`execute_script`, `get_scene`, `get_script`, `export_model`, `get_api_reference`): writes Swift code to a tempfile, sends it to a long-lived `occtkit run --serve` child by default, falls back to one-shot `occtkit run <path>` if serve mode is unavailable. `executeScript` calls `snapshotScene()` before running so `compare_versions` has history
-- `src/scene-tools.ts` — Pure-TS scene-mutation tools (`remove_body`, `clear_scene`, `rename_body`, `set_appearance`, `compare_versions`, `export_scene`). Read/modify/write `manifest.json` directly; OCCTSwiftViewport's ScriptWatcher reloads on the write. `export_scene` is the exception: it generates a one-shot Swift script that loads the bodies' BREPs and calls `Exporter.writeXxx`, run via `occtkit run`. Maintains an in-memory ring buffer of the last 10 manifest snapshots for `compare_versions`
-- `src/api-tools.ts` — Thin wrappers around existing occtkit verbs (`validate_geometry` → `graph-validate`, `recognize_features` → `feature-recognize`, `apply_feature` → `reconstruct`, `generate_drawing` → `drawing-export`). Each resolves a `bodyId` against the scene manifest, passes the BREP path to the verb, returns the verb's JSON output
-- `src/verb-tools.ts` — Wrappers around the post-#6 batch of occtkit verbs: `compute_metrics`, `query_topology`, `measure_distance`, `check_thickness`, `analyze_clearance`, `generate_mesh` (pure reads); `transform_body`, `boolean_op`, `mirror_or_pattern`, `heal_shape` (scene mutators — snapshot before mutating, support in-place vs new-body output); `read_brep`, `import_file` (run the verb in a staging tmpdir then merge into the live manifest, since `load-brep` / `import` would otherwise clobber the live manifest with their own); `render_preview` (PNG out). Most verbs accept JSON-on-stdin or `<request.json>` form — wrappers always go via `runVerbJSON` (writes a tempfile, passes the path)
-- `src/occtkit.ts` — Resolves how to invoke `occtkit`: prefers PATH, falls back to `swift run -c release occtkit` inside the sibling OCCTSwiftScripts repo, throws a clear setup error if neither is available. Result is memoised
-- `src/occtkit-serve.ts` — Singleton long-lived `occtkit run --serve` child. JSONL request/response over stdin/stdout (one envelope per request, post-`gsdali/OCCTSwiftScripts#5`). Per-request timeout kills the child and respawns on next call. If a returned envelope lacks the `ok` field (pre-fix occtkit), serve mode is permanently disabled for the session and callers fall back to one-shot
-- `src/paths.ts` — Output dir / manifest path resolution. Resolution order: `OCCTMCP_OUTPUT_DIR` env var (used by the test suite) > iCloud Drive > local fallback (`~/.occtswift-scripts/output`). Per-call tempfile name generation lives here too
-- `src/api-reference.ts` — **Generated** OCCTSwift API reference strings keyed by category. Do not edit by hand — it is rewritten by `scripts/generate-api-reference.mjs` (runs as `npm run prebuild`). The generator parses `~/Projects/OCCTSwift/Sources/OCCTSwift/*.swift` directly, extracts `public func` declarations, and groups them via the editorial `CATEGORIES` array at the top of the script. New OCCTSwift methods that don't match any category are surfaced in the generator's stderr "UNMATCHED" report — extend `CATEGORIES` (add a `markRx` or `nameRx` rule) when something important is missing.
+- `Server.swift` — `createServer()` factory: registers all 49 tools with their JSON Schemas, returns an `MCP.Server` ready to bind to a transport. Tests import `createServer()` to introspect the registry without binding stdio. The `get_api_reference` tool's `mcp_tools` category dumps the live registry as JSON Schema for LLM auto-discovery.
+- `Tools/` — one file per tool family:
+  - `CoreTools.swift` — `get_scene`, `get_script`, `export_model`, `get_api_reference`
+  - `ExecuteScriptTool.swift` — `execute_script` (writes Swift to tempfile, `occtkit run` via the resolved binary, parses manifest)
+  - `SceneTools.swift` — `remove_body`, `clear_scene`, `rename_body`, `set_appearance`, `compare_versions`, `export_scene` (pure manifest manipulation; `export_scene` runs a templated script via occtkit)
+  - `IntrospectionTools.swift` — `validate_geometry`, `compute_metrics`, `query_topology`, `measure_distance` (in-process via OCCTSwift)
+  - `FeatureTools.swift` — `recognize_features`, `apply_feature`
+  - `ConstructionTools.swift` — `transform_body`, `boolean_op`, `mirror_or_pattern` (record history into `HistoryRegistry`)
+  - `EngineeringTools.swift` — `check_thickness`, `analyze_clearance`
+  - `HealingTools.swift` — `heal_shape` (records identity history if topology preserved)
+  - `IOTools.swift` — `read_brep`, `import_file`, `inspect_assembly`, `set_assembly_metadata`
+  - `MeshTools.swift` — `generate_mesh`, `simplify_mesh`
+  - `RenderPreviewTool.swift` — `render_preview` (depends on Tools+Viewport per the layered architecture; reads annotations sidecar and overlays measurements / primitives via `AnnotationsRenderer`)
+  - `DrawingTools.swift` — `generate_drawing`
+  - `AnalysisTools.swift` — graph-level: `graph_validate`, `graph_compact`, `graph_dedup`, `graph_ml`, `feature_recognize`
+  - `SelectionTools.swift` — `select_topology`
+  - `RemapTools.swift` — `remap_selection` (consults `HistoryRegistry`, falls back to centroid heuristic)
+  - `AnnotationsTools.swift` — `add_dimension`, `add_scene_primitive`, `remove_scene_annotation`
+  - `GapFillerTools.swift` — `show_bounding_box`, `diff_overlay`, `select_by_feature`
+  - `IntrospectionRegistryTools.swift` — `list_selections`, `clear_selections`, `list_annotations`
+  - `AutoDimensionTool.swift` — `auto_dimension`
+- `Manifest.swift` — `ScriptManifest` + `BodyDescriptor` Codable, plus `ManifestStore` (atomic JSON read/write)
+- `Annotations.swift` — `AnnotationsSidecar` (`<output_dir>/annotations.json`): `dimensions[]` + `primitives[]`, `AnyCodable` for per-kind primitive params
+- `AnnotationsRenderer.swift` — synthesises `ViewportBody` overlays from the sidecar (trihedron / workPlane / axis / pointCloud / boundingBox / diffMarker / 3D dimension leaders), and `ViewportMeasurement` entries (linear / angular / radial) for OffscreenRenderer's 2D label overlay. `pointCloud` routes through `OCCTSwiftTools.PointConverter.pointsToBody` (no per-point cap).
+- `SelectionRegistry.swift` — actor-backed store of `selectionId → AnchorSnapshot`. `selectionId` format `sel:<bodyId>#<kind>[<idx>]` is self-describing and parseable.
+- `HistoryRegistry.swift` — actor-backed `bodyId → TopologyGraph`. `recordIdentityHistory` (transforms — 1:1), `recordIdentityHistoryIfTopologyPreserved` (heals — guarded), `recordBooleanHistory` (boolean_op — translates `ShapeHistoryRef.record(of:)` outputs into `recordHistory` entries by centroid match within the modified∪generated set; records under result body and both inputs so a selectionId on either side remaps cleanly). `apply_feature` / `mirror_or_pattern` don't opt in yet — they fall back to `RemapTools`' centroid heuristic.
+- `Paths.swift` — output dir resolution: `OCCTMCP_OUTPUT_DIR` env > iCloud Drive (`~/Library/Mobile Documents/com~apple~CloudDocs/OCCTSwiftScripts/output/`) > local fallback (`~/.occtswift-scripts/output/`)
+- `SceneHistory.swift` — in-memory ring buffer (last 10 manifest snapshots) backing `compare_versions`
 
-### Data Flow
+`OCCTMCPServer/main.swift` connects `createServer()` to stdio.
 
-`execute_script` is the core tool. It:
-1. Writes the LLM's Swift code to a per-call tempfile under `os.tmpdir()` and stashes the source for `get_script`
-2. **Serve path (default):** sends `{"args": ["<tempfile>"]}` over stdin to the singleton `occtkit run --serve` child managed by `src/occtkit-serve.ts`, awaits one JSONL envelope `{ ok, exit, stdout, stderr, error? }`. Cold start of the child is 60+s on first call; subsequent calls amortise to ~1–2s incremental.
-3. **One-shot fallback:** if serve mode threw (timeout, child crash, pre-fix occtkit detected), runs `occtkit run <tempfile>` as a fresh subprocess. Triggers automatically; `OCCTMCP_OCCTKIT_NO_SERVE=1` forces this path always.
-4. Filters noisy OCCT bridge nullability warnings from build output (`filterBuildOutput`); the same filter runs on both paths so compiler diagnostics still reach the LLM under the `Script failed.` prefix
-5. Reads `manifest.json` from the output directory and returns it with build output
-6. Removes the tempfile in a `finally` block
+### Layered architecture (post-Tools / AIS split)
 
-Writing `manifest.json` is the side effect that matters: `OCCTSwiftViewport`'s `ScriptWatcher` watches that file, so emitting it is what triggers the live 3D reload.
+OCCTSwift / OCCTSwiftViewport are kernel layers. `OCCTSwiftTools` is the bridge (Shape ↔ ViewportBody, plus Curve / Surface / Wire / **Point** converters). `OCCTSwiftAIS` is the interactive-services layer (selection, manipulators, dimensions). `render_preview` depends on **Tools + Viewport**, not Viewport alone — that's why we hold OCCTSwiftViewport at 0.55.x even though v1.0.0 is tagged: Tools / AIS / Scripts v1.0 still pin Viewport `from: 0.55.0` (`<1.0.0`). It bumps when those bump.
 
-The 2 min timeout is per-request in both paths. On serve-mode timeout the child is `SIGTERM`'d so any pending requests reject and the next `execute_script` respawns it.
+### History wiring (selectionId remap across mutations)
 
-### Output Directory Resolution
+`remap_selection` resolves a `selectionId` against the post-mutation state of a body via:
 
-`paths.ts:outputDir()` prefers iCloud Drive (`~/Library/Mobile Documents/com~apple~CloudDocs/OCCTSwiftScripts/output/`) if the iCloud container exists, otherwise falls back to `~/.occtswift-scripts/output/`. The manifest and all BREP/STEP files live here.
+1. `HistoryRegistry.graph(for: bodyId)` — if recorded, walk `TopologyGraph.findDerived(originalRef:)`. fate ∈ {preserved, split, lost}, confidenceMm = 0.
+2. Centroid heuristic — load pre and post BREPs, find nearest face/edge/vertex within an epsilon. fate is preserved if within ε, lost otherwise. confidenceMm reports the centroid distance.
+
+Per-tool opt-in status:
+
+| Tool             | History path                              | Notes |
+|------------------|-------------------------------------------|-------|
+| `transform_body` | identity history (topology preserved)     | every node maps 1:1 |
+| `heal_shape`     | identity history if pre/post counts match | falls back to heuristic if shape repair changed topology |
+| `boolean_op`     | per-input history via `recordBooleanHistory` | OCCTSwift `*WithFullHistory` variants; recorded under output + both inputs |
+| `apply_feature`  | heuristic only                            | needs OCCTSwift#165 Tier 2 (fillet/chamfer/shell) + Tier 3 (FeatureReconstructor) — not yet shipped |
+| `mirror_or_pattern` | heuristic only                         | doesn't fit the contract — needs a `find_correspondences` tool |
+
+### Data flow for `execute_script`
+
+1. Writes the LLM's Swift code to a per-call tempfile under `os.tmpdir()` and stashes the source for `get_script`.
+2. Calls `occtkit run <tempfile>` via the resolved binary (PATH > sibling-repo `swift run -c release occtkit`). Cold start of the underlying SwiftPM workspace is 60+s on first call; subsequent calls amortise via OCCTSwiftScripts' serve mode where available.
+3. Filters noisy OCCT bridge nullability warnings from build output; compiler diagnostics still reach the LLM under the `Script failed.` prefix.
+4. Reads `manifest.json` from the output directory and returns it with build output. `executeScript` calls `snapshotScene()` before running so `compare_versions` has history.
+5. Removes the tempfile in a `finally` block.
+
+Writing `manifest.json` is the side effect that matters: `OCCTSwiftViewport`'s `ScriptWatcher` watches that file, so emitting it triggers the live 3D reload.
+
+The 2 min timeout is per-request.
+
+## Node Architecture
+
+The Node server is a single-process Node.js app (ESM, strict TypeScript):
+
+- `src/index.ts` — `createServer()` factory + stdio binding
+- `src/tools.ts` — Core: `execute_script`, `get_scene`, `get_script`, `export_model`, `get_api_reference`. Delegates to a long-lived `occtkit run --serve` child by default, falls back to one-shot `occtkit run <path>` if serve mode is unavailable
+- `src/scene-tools.ts` — Pure-TS scene-mutation tools (`remove_body`, `clear_scene`, `rename_body`, `set_appearance`, `compare_versions`, `export_scene`). `export_scene` is the exception: generates a one-shot Swift script run via `occtkit run`. Maintains an in-memory ring buffer of the last 10 manifest snapshots for `compare_versions`
+- `src/api-tools.ts` — Wrappers around occtkit verbs (`validate_geometry` → `graph-validate`, `recognize_features` → `feature-recognize`, `apply_feature` → `reconstruct`, `generate_drawing` → `drawing-export`)
+- `src/verb-tools.ts` — Wrappers around the rest of the occtkit verbs (compute_metrics / query_topology / measure_distance / check_thickness / analyze_clearance / generate_mesh / transform_body / boolean_op / mirror_or_pattern / heal_shape / read_brep / import_file / render_preview)
+- `src/occtkit.ts` — Resolves how to invoke `occtkit`: prefers PATH, falls back to `swift run -c release occtkit` inside the sibling OCCTSwiftScripts repo
+- `src/occtkit-serve.ts` — Singleton long-lived `occtkit run --serve` child. JSONL request/response over stdin/stdout. Per-request timeout kills the child and respawns on next call
+- `src/paths.ts` — Same resolution rules as the Swift `Paths.swift`
+- `src/api-reference.ts` — **Generated** OCCTSwift API reference, rewritten by `scripts/generate-api-reference.mjs` (runs as `npm run prebuild`). Parses `~/Projects/OCCTSwift/Sources/OCCTSwift/*.swift` and groups public funcs via the editorial `CATEGORIES` array. New OCCTSwift methods that don't match any category are surfaced in the generator's stderr "UNMATCHED" report — extend `CATEGORIES` (add a `markRx` or `nameRx` rule) when something important is missing.
+
+The Node server does not expose the v0.4+ tool surface (selection / remap / annotations / history). Those are Swift-only.
 
 ## External Dependencies
 
-- **OCCTSwiftScripts** ≥ post-`fd2a1cf` (the `--serve` framing fix from `gsdali/OCCTSwiftScripts#5`) — provides the `occtkit` CLI used by every `execute_script` call. Two install options, either works:
-  - `make install` from the OCCTSwiftScripts repo puts `occtkit` on `$PATH` (preferred — fastest invocation, no sibling-repo path dependency).
-  - Clone OCCTSwiftScripts to `~/Projects/OCCTSwiftScripts` so `swift run -c release occtkit` works as the fallback (slower per-call than the binary, but no install step).
-  - Older OCCTSwiftScripts (without #5's framing) still works in one-shot fallback mode, just without the serve-mode amortisation. The serve client auto-detects the missing `ok` field on the first envelope and disables serve for the session.
-- **OCCTSwift** — Swift wrapper around OpenCASCADE; transitive dep of OCCTSwiftScripts. Required at `~/Projects/OCCTSwift/` only when regenerating `src/api-reference.ts` via `scripts/generate-api-reference.mjs` (runs as `npm run prebuild`).
-- **OCCTSwiftViewport** — Metal viewport that watches the output directory via `ScriptWatcher` and auto-reloads. Optional but expected if you want the live preview.
+### Swift implementation
+
+- **OCCTSwift** ≥ 1.0.2 — kernel wrapper around OpenCASCADE, ships `*WithFullHistory` boolean variants
+- **OCCTSwiftMesh** ≥ 1.0.0 — mesh-domain algorithms (QEM decimation today; smoothing / repair / remeshing in roadmap)
+- **OCCTSwiftScripts** ≥ 1.0.0 — provides `occtkit` (only used by `execute_script` and `export_scene`); also ships `ScriptHarness` + `DrawingComposer` consumed in-process
+- **OCCTSwiftTools** ≥ 1.0.1 — Shape↔ViewportBody bridge, ships `PointConverter`
+- **OCCTSwiftViewport** ≥ 0.55.2 — Metal viewport + offscreen renderer. Held under 1.0 because Tools/AIS/Scripts v1.0 still pin Viewport `<1.0.0`
+- **OCCTSwiftAIS** ≥ 1.0.0 — selection, manipulators, dimensions
+- **modelcontextprotocol/swift-sdk** ≥ 0.11.0 — MCP transport + types
+
+### Node implementation
+
+- **OCCTSwiftScripts** — provides `occtkit` on `$PATH` (`make install` from the OCCTSwiftScripts repo) or via sibling clone at `~/Projects/OCCTSwiftScripts` so `swift run -c release occtkit` works as the fallback
+- **OCCTSwift** — required at `~/Projects/OCCTSwift/` only when regenerating `src/api-reference.ts` via `scripts/generate-api-reference.mjs` (runs as `npm run prebuild`)
+- **OCCTSwiftViewport** — Metal viewport that watches the output directory via `ScriptWatcher` and auto-reloads. Optional but expected if you want the live preview
 
 ## MCP Tools
 
-| Tool | Purpose |
-|------|---------|
-| `execute_script` | Write Swift code to a tempfile, run via `occtkit run`, return output + manifest |
-| `get_scene` | Read current manifest.json + list output files |
-| `get_script` | Return the most recent script executed in this MCP session (kept in memory; not a filesystem read) |
-| `export_model` | List exported BREP/STEP/STL/OBJ file paths |
-| `get_api_reference` | Return OCCTSwift API reference by category (or "all") |
-| `graph_validate` | Validate a BREP's topology graph — wraps `occtkit graph-validate` |
-| `graph_compact` | Drop unreferenced nodes, write rebuilt BREP — wraps `occtkit graph-compact` |
-| `graph_dedup` | Deduplicate shared surface/curve geometry — wraps `occtkit graph-dedup` |
-| `graph_ml` | ML-friendly graph + UV/edge sample export — wraps `occtkit graph-ml` |
-| `feature_recognize` | AAG-based pocket + hole detection — wraps `occtkit feature-recognize` |
-| `remove_body` | Delete a body from the manifest + its BREP file (pure TS) |
-| `clear_scene` | Wipe all bodies from the manifest + delete their BREPs (pure TS) |
-| `rename_body` | Change a body's id in the manifest (pure TS) |
-| `set_appearance` | Update color / opacity / roughness / metallic / name on a body (pure TS) |
-| `compare_versions` | Diff current scene vs a snapshot N runs back; uses an in-memory ring buffer |
-| `export_scene` | Export current scene to step / iges / brep / stl / obj / gltf / glb (templated `occtkit run` script) |
-| `validate_geometry` | Per-body topology validation — resolves bodyId → BREP, wraps `graph-validate` |
-| `recognize_features` | Pockets + holes for a scene body — resolves bodyId, wraps `feature-recognize` |
-| `apply_feature` | Apply a single feature spec to a scene body — wraps `occtkit reconstruct` |
-| `generate_drawing` | Multi-view ISO 128-30 DXF for a scene body — wraps `occtkit drawing-export` |
-| `compute_metrics` | Volume / area / centroid / bbox / principal axes — wraps `occtkit metrics` |
-| `query_topology` | Find faces/edges/vertices matching criteria — wraps `occtkit query-topology` |
-| `measure_distance` | Min distance + contacts between two bodies — wraps `occtkit measure-distance` |
-| `check_thickness` | Wall-thickness analysis — wraps `occtkit check-thickness` |
-| `analyze_clearance` | Pairwise interference / clearance — wraps `occtkit analyze-clearance` |
-| `generate_mesh` | Triangle mesh + quality metrics — wraps `occtkit mesh` |
-| `transform_body` | Translate / rotate / uniform-scale a body (in place or new) — wraps `occtkit transform` |
-| `boolean_op` | Union / subtract / intersect / split between two bodies — wraps `occtkit boolean` |
-| `mirror_or_pattern` | Mirror / linear / circular pattern — wraps `occtkit pattern` |
-| `heal_shape` | Heal imported / non-watertight geometry — wraps `occtkit heal` |
-| `read_brep` | Add a `.brep` from disk to the scene — wraps `occtkit load-brep` (staged + merged) |
-| `import_file` | STEP / IGES / STL / OBJ import — wraps `occtkit import` (staged + merged) |
-| `simplify_mesh` | QEM mesh decimation to .stl/.obj — wraps `occtkit simplify-mesh` (which wraps OCCTSwiftMesh's `Mesh.simplified`, vendoring meshoptimizer) |
-| `render_preview` | One-shot PNG render of the scene — wraps `occtkit render-preview` |
-| `inspect_assembly` | Walk an XCAF assembly tree — wraps `occtkit inspect-assembly` |
-| `set_assembly_metadata` | Modify XCAF document or per-component metadata — wraps `occtkit set-metadata` |
-
-The five graph/feature tools (`graph_*`, `feature_recognize`) are thin one-shot wrappers around pre-compiled occtkit verbs defined in `src/graph-tools.ts`. They go through the same `resolveOcctkit()` discovery as `execute_script` but bypass serve mode — these verbs don't compile Swift at call time, so there's no amortisation benefit. Each takes a BREP file path (use `export_model` to list available ones) and returns the verb's JSON report verbatim.
-
-The scene-mutation tools (`remove_body`, `clear_scene`, `rename_body`, `set_appearance`, `compare_versions`) are pure manifest manipulation — they don't shell out to occtkit at all. `export_scene` is the exception: it generates a small templated Swift program that loads the relevant BREPs and calls `Exporter.writeXxx`, run via `occtkit run` (one-shot, not serve). The `validate_geometry` / `recognize_features` / `apply_feature` / `generate_drawing` tools resolve a `bodyId` against the manifest and delegate to the corresponding occtkit verb.
-
-All 26 tools from [#6](https://github.com/gsdali/OCCTMCP/issues/6) are built. Mesh-domain algorithms beyond decimation live in [OCCTSwiftMesh](https://github.com/gsdali/OCCTSwiftMesh) (sibling to OCCTSwift, vendors permissive implementations because OCCT-Open ships only mesh generation, not post-processing). As more verbs land in OCCTSwiftMesh → OCCTSwiftScripts (smoothing, repair, remeshing, subdivision per the OCCTSwiftMesh roadmap), wire them as additional MCP tools using the same `runVerbJSON` pattern.
+49 tools across both implementations (Swift); 36 in Node (no selection / remap / annotations / history). See README.md for the categorized table — that's the LLM-facing surface and stays canonical.
 
 ## Script Template
 
-Scripts must follow this structure:
+Scripts passed to `execute_script` must follow this structure:
 
 ```swift
 import OCCTSwift

--- a/README.md
+++ b/README.md
@@ -1,21 +1,26 @@
 # OCCTMCP
 
-MCP server that gives LLMs the ability to create and iterate on 3D CAD models using [OpenCASCADE](https://www.opencascade.com/) via [OCCTSwift](https://github.com/gsdali/OCCTSwift).
+[![Swift 6.1](https://img.shields.io/badge/Swift-6.1-orange.svg)](https://swift.org)
+[![License: LGPL v2.1+](https://img.shields.io/badge/License-LGPL--2.1--or--later-blue.svg)](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.en.html)
+
+MCP server that gives LLMs the ability to author, inspect, and iterate on 3D CAD models with [OpenCASCADE](https://www.opencascade.com/) via the [OCCTSwift](https://github.com/gsdali/OCCTSwift) family.
+
+The Swift implementation calls OCCT directly in-process — no subprocess, no JSONL marshalling — and exposes 49 typed MCP tools that cover authoring, scene reads, mutation, introspection, construction, analysis, I/O, mesh, drawing, selection / remap, and dimension overlays.
 
 ## How It Works
 
 ```
-LLM writes Swift CAD code via execute_script
-  → OCCTSwiftScripts compiles & runs it (~0.5s incremental)
-  → Outputs BREP/STEP files + manifest.json
-  → OCCTSwiftViewport auto-reloads the 3D model
+LLM picks a typed tool (boolean_op, transform_body, render_preview, …)
+  → OCCTMCP runs the OCCT operation directly via OCCTSwift / Tools / AIS / Mesh
+  → Writes BREP/STEP/PNG + manifest.json + annotations.json
+  → OCCTSwiftViewport (optional) auto-reloads the 3D model
 ```
 
-The LLM has full access to OCCTSwift's 900+ CAD operations: primitives, booleans, fillets, sweeps, lofts, patterns, healing, measurement, import/export, and more.
+For novel geometry the typed tools don't cover, the LLM falls back to `execute_script`: arbitrary Swift code with the full OCCTSwift API, compiled and run in-process.
 
 ## Tools
 
-36 tools, organized below. Call `get_api_reference({ category: "mcp_tools" })` to dump every tool's JSON Schema in one shot — useful for LLM auto-discovery. Most LLM flows can answer "what's the volume?", "make it red", "boolean-subtract these", "render a preview", "export to STEP", and "draw this" without ever round-tripping through `execute_script` — that's reserved for novel geometry the typed tools don't cover.
+49 tools, organized below. Call `get_api_reference({ category: "mcp_tools" })` to dump every tool's JSON Schema in one shot — useful for LLM auto-discovery. Most flows can answer "what's the volume?", "make it red", "boolean-subtract these", "render a preview", "add a dimension between these two faces", "export to STEP", and "draw this" without ever touching `execute_script`.
 
 ### Authoring
 
@@ -58,8 +63,8 @@ The LLM has full access to OCCTSwift's 900+ CAD operations: primitives, booleans
 | Tool | Purpose |
 |------|---------|
 | `apply_feature` | Drill / fillet / chamfer / extrude / revolve / thread / boolean (FeatureSpec) |
-| `transform_body` | Translate / rotate / uniform-scale (in place or new body) |
-| `boolean_op` | Union / subtract / intersect / split between two bodies |
+| `transform_body` | Translate / rotate / uniform-scale (records identity history for remap) |
+| `boolean_op` | Union / subtract / intersect / split (records per-input history for remap) |
 | `mirror_or_pattern` | Mirror / linear / circular pattern → N new bodies |
 
 ### Engineering analysis
@@ -69,6 +74,28 @@ The LLM has full access to OCCTSwift's 900+ CAD operations: primitives, booleans
 | `check_thickness` | Wall-thickness analysis with thin-region flags |
 | `analyze_clearance` | Pairwise interference / minimum clearance |
 | `heal_shape` | Heal imported / non-watertight geometry; before/after stats |
+
+### Selection & remap
+
+| Tool | Purpose |
+|------|---------|
+| `select_topology` | Pick faces / edges / vertices, get a stable `selectionId` |
+| `remap_selection` | Carry `selectionId`s across mutations (history-based for transform / heal / boolean; centroid heuristic fallback otherwise) |
+| `select_by_feature` | Bulk pick by feature kind (e.g. all hole edges) |
+| `list_selections` | Inspect the in-memory selection registry |
+| `clear_selections` | Wipe the registry |
+
+### Annotations & overlays
+
+| Tool | Purpose |
+|------|---------|
+| `add_dimension` | Add a linear / angular / radial dimension; renders in `render_preview` |
+| `add_scene_primitive` | Add trihedron / workPlane / axis / pointCloud / boundingBox / diffMarker |
+| `auto_dimension` | Heuristic dimension drop for the principal extents |
+| `show_bounding_box` | Add a body's AABB as an overlay |
+| `diff_overlay` | Visualize the diff between two snapshots |
+| `remove_scene_annotation` | Remove a dimension or primitive by id |
+| `list_annotations` | Inspect the annotations sidecar |
 
 ### I/O
 
@@ -85,7 +112,7 @@ The LLM has full access to OCCTSwift's 900+ CAD operations: primitives, booleans
 |------|---------|
 | `generate_mesh` | Tessellate to triangles + quality metrics |
 | `simplify_mesh` | QEM mesh decimation to .stl/.obj — wraps OCCTSwiftMesh's `Mesh.simplified` (vendored meshoptimizer) |
-| `render_preview` | One-shot PNG render |
+| `render_preview` | One-shot PNG render with measurement labels and primitive overlays |
 | `generate_drawing` | Multi-view ISO 128-30 DXF technical drawing |
 
 ### Topology graph (low-level)
@@ -98,22 +125,44 @@ The LLM has full access to OCCTSwift's 900+ CAD operations: primitives, booleans
 | `graph_ml` | Export topology + UV/edge samples as ML-friendly JSON |
 | `feature_recognize` | Pockets + holes (raw BREP path; `recognize_features` is the scene-aware wrapper) |
 
+## Implementations
+
+This repo ships two implementations side-by-side:
+
+- **Swift** (`Sources/`, `Package.swift`) — the **primary** server. In-process against OCCTSwift / OCCTSwiftMesh / OCCTSwiftTools / OCCTSwiftAIS / DrawingComposer using the [official Swift MCP SDK](https://swiftpackageindex.com/modelcontextprotocol/swift-sdk). 49 tools. macOS 15+ (the OCCT.xcframework arm64 platform).
+- **Node / TypeScript** (`src/`, `dist/`) — the original implementation. Shells out to the `occtkit` CLI for everything Swift-side. 36 tools (the pre-v0.4 surface; selection / remap / annotations are Swift-only). Useful if you can't run a macOS binary.
+
+Both speak stdio MCP and read/write the same manifest format.
+
 ## Prerequisites
 
-- [OCCTSwift](https://github.com/gsdali/OCCTSwift) — Swift wrapper for OpenCASCADE
-- [OCCTSwiftScripts](https://github.com/gsdali/OCCTSwiftScripts) — Script runner (sibling directory)
-- [OCCTSwiftViewport](https://github.com/gsdali/OCCTSwiftViewport) — Metal viewport for live preview (optional)
-- Node.js 18+
-- Swift 6.0+ / Xcode 16+
+- macOS 15+ (for the Swift implementation)
+- Swift 6.1+ / Xcode 16+
+- For the Node implementation only: Node.js 18+, plus a sibling clone of [OCCTSwiftScripts](https://github.com/gsdali/OCCTSwiftScripts) so `occtkit` is on `$PATH` (or `make install` it)
 
 ## Setup
 
-Two implementations live in this repo, side-by-side:
+### Swift implementation (recommended)
 
-- **Node / TypeScript** (`src/`, `dist/`) — the production server. Shells out to the `occtkit` CLI for everything Swift-side. 36 tools, including `execute_script`.
-- **Swift** (`Sources/`, `Package.swift`) — an in-process port using the [official Swift MCP SDK](https://swiftpackageindex.com/modelcontextprotocol/swift-sdk). Currently 32 of 36 tools, all running directly against OCCTSwift / OCCTSwiftMesh / DrawingComposer with no subprocess. `execute_script`, `set_assembly_metadata`, `render_preview`, `check_thickness`, and `graph_ml` are still pending.
+```bash
+git clone https://github.com/gsdali/OCCTMCP.git
+cd OCCTMCP
+swift build -c release
+```
 
-Pick whichever fits your platform: Node runs anywhere; the Swift binary is macOS-only (since OCCT.xcframework targets arm64 macOS 12+ / iOS 15+) but eliminates the cold-start of the SwiftPM workspace and the JSONL marshalling overhead.
+In Claude Code's `.mcp.json`:
+
+```json
+{
+  "mcpServers": {
+    "occtmcp": {
+      "command": "/path/to/OCCTMCP/.build/release/occtmcp-server"
+    }
+  }
+}
+```
+
+The Swift package is published on the [Swift Package Index](https://swiftpackageindex.com/gsdali/OCCTMCP).
 
 ### Node implementation
 
@@ -124,7 +173,7 @@ npm install
 npm run build
 ```
 
-In Claude Code's `.mcp.json`:
+In `.mcp.json`:
 
 ```json
 {
@@ -137,29 +186,19 @@ In Claude Code's `.mcp.json`:
 }
 ```
 
-### Swift implementation
-
-```bash
-swift build -c release
-```
-
-In `.mcp.json`:
-
-```json
-{
-  "mcpServers": {
-    "occtmcp": {
-      "command": "/path/to/OCCTMCP/.build/release/occtmcp-server"
-    }
-  }
-}
-```
-
-The Swift package is intended for [Swift Package Index](https://swiftpackageindex.com) publication once `execute_script` lands and the integration test suite is in place. Track progress in [PR #11](https://github.com/gsdali/OCCTMCP/pull/11) and the follow-up Phase 5.4 work.
-
 ## Example
 
-Once configured, an LLM can create CAD models by writing Swift code:
+The LLM can author CAD models by composing typed tools — most everyday flows never touch `execute_script`:
+
+```text
+boolean_op(op: "subtract", aBodyId: "block", bBodyId: "hole", outputBodyId: "drilled")
+  → "drilled" body added to the scene
+select_topology(bodyId: "drilled", kind: "face", limit: 1)
+  → returns selectionId "sel:drilled#face[12]"
+add_dimension(kind: "linear", anchors: [...]) ; render_preview()
+```
+
+For novel geometry, drop into `execute_script` with the full OCCTSwift API:
 
 ```swift
 import OCCTSwift
@@ -168,7 +207,6 @@ import ScriptHarness
 let ctx = ScriptContext()
 let C = ScriptContext.Colors.self
 
-// Create a filleted box with a hole
 let box = Shape.box(width: 40, height: 30, depth: 20)!
 let hole = Shape.cylinder(radius: 5, height: 30)!
     .translated(by: SIMD3(20, -1, 10))!
@@ -193,6 +231,13 @@ The `get_api_reference` tool provides documentation for:
 - **surfaces** — plane, cylinder, cone, sphere, extrusion, revolution, plate
 - **analysis** — volume, area, distance, bounds, validation
 - **import_export** — STL, STEP, IGES, BREP, OBJ, PLY
+- **mcp_tools** — every MCP tool's JSON Schema (handy for LLM auto-discovery)
+
+## Versioning
+
+OCCTMCP follows [Semantic Versioning](https://semver.org/). The Swift port reached **v1.0.0** on 2026-05-09 — feature-complete against the original Node implementation, plus a layer of selection / remap / annotation tools that are Swift-only.
+
+Releases are tagged on GitHub. The `main` branch is what SPI tracks.
 
 ## License
 


### PR DESCRIPTION
## Summary

- **v1.0.0 — first SPI-eligible release.** No code changes from v0.10; this is the milestone tag plus a docs refresh that's been overdue since the v0.4 tool surface landed.
- **README.md** rewritten: tool count goes from 36 (last accurate at v0.3 / Node parity) to 49, with the selection / remap / annotations / overlay tools documented for the first time. Swift positioned as the primary implementation; Node section preserved but framed as the original pre-v0.4 surface.
- **CLAUDE.md** rewritten Swift-first: per-file architecture map for `Sources/OCCTMCPCore`, the per-tool history opt-in matrix (transform / heal / boolean wired; apply_feature + mirror_or_pattern still on the heuristic pending OCCTSwift#165 Tier 2/3 + the `find_correspondences` design), and why Viewport stays at 0.55.x despite v1.0.0 being tagged (Tools / AIS / Scripts v1.0 still pin Viewport `<1.0.0`).
- **`.spi.yml`** added: `documentation_targets: [OCCTMCPCore]`, `platform: macos` so SPI renders DocC.

## Test plan

- [x] `swift build` clean
- [x] `swift test` — 22/22 (no behaviour change from v0.10)
- [ ] After merge, tag `v1.0.0`, create GitHub release, submit to https://swiftpackageindex.com/add-a-package

🤖 Generated with [Claude Code](https://claude.com/claude-code)