### PR TITLE
apply_feature consumes Tier 3 history (v1.1)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,7 +90,7 @@ Per-tool opt-in status:
 | `transform_body` | identity history (topology preserved)     | every node maps 1:1 |
 | `heal_shape`     | identity history if pre/post counts match | falls back to heuristic if shape repair changed topology |
 | `boolean_op`     | per-input history via `recordBooleanHistory` | OCCTSwift `*WithFullHistory` variants; recorded under output + both inputs |
-| `apply_feature`  | heuristic only                            | needs OCCTSwift#165 Tier 2 (fillet/chamfer/shell) + Tier 3 (FeatureReconstructor) — not yet shipped |
+| `apply_feature`  | per-feature history via `recordSingleInputHistory` | OCCTSwift v1.0.3 `FeatureReconstructor.BuildResult.histories[id]` — populated for boolean / hole / second-additive specs with non-nil ids; fillet/chamfer paths still hit the heuristic until `applyFillet` / `applyChamfer` go through `*WithFullHistory` upstream |
 | `mirror_or_pattern` | heuristic only                         | doesn't fit the contract — needs a `find_correspondences` tool |
 
 ### Data flow for `execute_script`
@@ -125,7 +125,7 @@ The Node server does not expose the v0.4+ tool surface (selection / remap / anno
 
 ### Swift implementation
 
-- **OCCTSwift** ≥ 1.0.2 — kernel wrapper around OpenCASCADE, ships `*WithFullHistory` boolean variants
+- **OCCTSwift** ≥ 1.0.3 — kernel wrapper around OpenCASCADE, ships `*WithFullHistory` for booleans + Tier 2 modifications + `FeatureReconstructor.BuildResult.histories`
 - **OCCTSwiftMesh** ≥ 1.0.0 — mesh-domain algorithms (QEM decimation today; smoothing / repair / remeshing in roadmap)
 - **OCCTSwiftScripts** ≥ 1.0.0 — provides `occtkit` (only used by `execute_script` and `export_scene`); also ships `ScriptHarness` + `DrawingComposer` consumed in-process
 - **OCCTSwiftTools** ≥ 1.0.1 — Shape↔ViewportBody bridge, ships `PointConverter`

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "01e0f9d3a5d62c085ceaaf6be7fc855ac293f3589e6efc1abd790da4e4855bbf",
+  "originHash" : "f8dae866e313915e5b83a3494645ae57e433a9878fe2f71c9291963934226329",
   "pins" : [
     {
       "identity" : "eventsource",
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/gsdali/OCCTSwift.git",
       "state" : {
-        "revision" : "3ea46d2907bab1b3577bf79d189e8bb817e0228e",
-        "version" : "1.0.2"
+        "revision" : "c479b1e7f74b701600bdb8e469a30d9f19973bdd",
+        "version" : "1.0.3"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -24,10 +24,12 @@ let package = Package(
         .package(url: "https://github.com/modelcontextprotocol/swift-sdk.git", from: "0.11.0"),
         // OCCT 8.0.0 GA shipped 2026-05-09. The whole OCCT-Swift
         // family tagged v1.0 alongside it; this cohort is what we pin
-        // against now. OCCTSwift 1.0.2 ships per-input boolean history
-        // (gsdali/OCCTSwift#165 Tier 1) — drives boolean_op's
-        // history-based remap_selection in v0.10.
-        .package(url: "https://github.com/gsdali/OCCTSwift.git", from: "1.0.2"),
+        // against now. OCCTSwift 1.0.3 closes gsdali/OCCTSwift#165:
+        //   Tier 1 (v1.0.2): per-input boolean history → boolean_op
+        //   Tier 2 (v1.0.3): fillet/chamfer/shell/defeature history
+        //   Tier 3 (v1.0.3): FeatureReconstructor.BuildResult.histories
+        // → drives apply_feature's history-based remap_selection in v1.1.
+        .package(url: "https://github.com/gsdali/OCCTSwift.git", from: "1.0.3"),
         .package(url: "https://github.com/gsdali/OCCTSwiftMesh.git", from: "1.0.0"),
         .package(url: "https://github.com/gsdali/OCCTSwiftScripts.git", from: "1.0.0"),
         // OCCTSwiftTools 1.0.1 ships PointConverter

--- a/Sources/OCCTMCPCore/HistoryRegistry.swift
+++ b/Sources/OCCTMCPCore/HistoryRegistry.swift
@@ -107,6 +107,35 @@ extension HistoryRegistry {
         graphs[bBodyId] = postGraph
     }
 
+    /// Translate a single-input `ShapeHistoryRef` (gsdali/OCCTSwift#165
+    /// Tier 2 / Tier 3 — fillet / chamfer / shell / defeature, plus
+    /// `FeatureReconstructor.BuildResult.histories[id]`) into
+    /// `TopologyGraph.recordHistory` entries on the post-mutation graph.
+    /// Same per-kind matching logic as `recordBooleanHistory`'s
+    /// per-side path, just without a second input shape.
+    public func recordSingleInputHistory(
+        bodyId: String,
+        inputShape: Shape,
+        output: Shape,
+        ref: ShapeHistoryRef,
+        operationName: String
+    ) {
+        guard let postGraph = TopologyGraph(shape: output) else { return }
+        let postFaces = output.subShapes(ofType: .face)
+        let postEdges = output.subShapes(ofType: .edge)
+        let postVertices = output.subShapes(ofType: .vertex)
+        let faceCentres: [SIMD3<Double>] = postFaces.map { $0.centerOfMass ?? .zero }
+        let edgeCentres: [SIMD3<Double>] = postEdges.map { $0.centerOfMass ?? .zero }
+        let vertexCentres: [SIMD3<Double>] = postVertices.map { $0.centerOfMass ?? .zero }
+
+        recordSide(
+            inputShape: inputShape, postGraph: postGraph,
+            faceCentres: faceCentres, edgeCentres: edgeCentres, vertexCentres: vertexCentres,
+            ref: ref, operationName: operationName
+        )
+        graphs[bodyId] = postGraph
+    }
+
     private func recordSide(
         inputShape: Shape,
         postGraph: TopologyGraph,

--- a/Sources/OCCTMCPCore/Tools/FeatureTools.swift
+++ b/Sources/OCCTMCPCore/Tools/FeatureTools.swift
@@ -91,6 +91,35 @@ public enum FeatureTools {
         }
 
         await history.snapshot(store: store)
+
+        // Tier 3 (gsdali/OCCTSwift#165) — record per-feature history
+        // against the body that took the mutation. Only one feature is
+        // submitted per `apply_feature` call (`features: [feature]`
+        // above), so at most one entry in `result.histories` is
+        // populated and we record it under the post-mutation body id.
+        // Multi-feature chaining lives in `execute_script`, not here.
+        let mutatedBodyId = (isInPlace || outputBodyId == nil) ? bodyId : outputBodyId!
+        for (_, ref) in result.histories {
+            await HistoryRegistry.shared.recordSingleInputHistory(
+                bodyId: mutatedBodyId,
+                inputShape: inputShape,
+                output: outputShape,
+                ref: ref,
+                operationName: "apply_feature"
+            )
+            // record under the source bodyId too when emitting a new
+            // body, so a selectionId taken on the source remaps cleanly
+            if mutatedBodyId != bodyId {
+                await HistoryRegistry.shared.recordSingleInputHistory(
+                    bodyId: bodyId,
+                    inputShape: inputShape,
+                    output: outputShape,
+                    ref: ref,
+                    operationName: "apply_feature"
+                )
+            }
+        }
+
         if !isInPlace, let newId = outputBodyId {
             let newFile = (outputPath as NSString).lastPathComponent
             var bodies = manifest.bodies

--- a/SwiftTests/OCCTMCPCoreTests/IntegrationTests.swift
+++ b/SwiftTests/OCCTMCPCoreTests/IntegrationTests.swift
@@ -415,6 +415,114 @@ struct IntegrationTests {
         }
     }
 
+    @Test("history-based remap survives apply_feature via FeatureReconstructor.histories")
+    func historyRemapAcrossApplyFeature() async throws {
+        guard let binary = Self.binaryURL else {
+            Issue.record("Binary not built — run `swift build` first.")
+            return
+        }
+        let scene = NSTemporaryDirectory() + "occtmcp-it-feat-\(UUID().uuidString)"
+        try FileManager.default.createDirectory(atPath: scene, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(atPath: scene) }
+
+        // 40×40×40 box, drill a hole down the +Z axis offset to one
+        // corner so most of the box's six faces survive the operation
+        // (we'll select one and assert it remaps).
+        guard let box = Shape.box(width: 40, height: 40, depth: 40) else {
+            Issue.record("Failed to synthesise box")
+            return
+        }
+        try Exporter.writeBREP(shape: box, to: URL(fileURLWithPath: "\(scene)/part.brep"))
+        let manifest = ScriptManifest(
+            description: "apply_feature history test",
+            bodies: [BodyDescriptor(id: "part", file: "part.brep", color: [1, 0, 0, 1])]
+        )
+        try ManifestStore(path: "\(scene)/manifest.json").write(manifest)
+
+        let harness = try Harness(
+            binary: binary,
+            extraEnv: ["OCCTMCP_OUTPUT_DIR": scene]
+        )
+        defer { harness.terminate() }
+        try harness.handshake()
+
+        try harness.send(.init(
+            id: 60, method: "tools/call",
+            params: .object([
+                "name": .string("select_topology"),
+                "arguments": .object([
+                    "bodyId": .string("part"),
+                    "kind": .string("face"),
+                    "limit": .int(1),
+                ]),
+            ])
+        ))
+        let selResp = try harness.recv(timeout: 10)
+        guard case .object(let r1)? = selResp["result"],
+              case .array(let c1)? = r1["content"],
+              case .object(let f1)? = c1.first,
+              let t1 = f1["text"]?.stringValue,
+              let d1 = t1.data(using: .utf8),
+              let p1 = try JSONSerialization.jsonObject(with: d1) as? [String: Any],
+              let sels = p1["selections"] as? [[String: Any]],
+              let firstSel = sels.first,
+              let selectionId = firstSel["selectionId"] as? String else {
+            Issue.record("select_topology response shape unexpected")
+            return
+        }
+
+        // Hole feature with non-nil id — populates BuildResult.histories
+        // per OCCTSwift v1.0.3. Drill near a corner so most faces survive.
+        try harness.send(.init(
+            id: 61, method: "tools/call",
+            params: .object([
+                "name": .string("apply_feature"),
+                "arguments": .object([
+                    "bodyId": .string("part"),
+                    "feature": .object([
+                        "id": .string("h1"),
+                        "kind": .string("hole"),
+                        "axisPoint": .array([.double(5), .double(5), .double(0)]),
+                        "axisDirection": .array([.double(0), .double(0), .double(1)]),
+                        "diameter": .double(4),
+                    ]),
+                ]),
+            ])
+        ))
+        let applyResp = try harness.recv(timeout: 30)
+        #expect(applyResp["error"] == nil, "apply_feature errored: \(applyResp)")
+
+        try harness.send(.init(
+            id: 62, method: "tools/call",
+            params: .object([
+                "name": .string("remap_selection"),
+                "arguments": .object([
+                    "selectionIds": .array([.string(selectionId)]),
+                ]),
+            ])
+        ))
+        let rmResp = try harness.recv(timeout: 5)
+        guard case .object(let r2)? = rmResp["result"],
+              case .array(let c2)? = r2["content"],
+              case .object(let f2)? = c2.first,
+              let t2 = f2["text"]?.stringValue,
+              let d2 = t2.data(using: .utf8),
+              let p2 = try JSONSerialization.jsonObject(with: d2) as? [String: Any],
+              let remapped = p2["remapped"] as? [[String: Any]],
+              let entry = remapped.first else {
+            Issue.record("remap_selection response shape unexpected")
+            return
+        }
+        let fate = entry["fate"] as? String ?? "<missing>"
+        #expect(
+            fate == "preserved" || fate == "split",
+            "apply_feature(hole) history should resolve to preserved or split (got \(fate))"
+        )
+        if let conf = entry["confidenceMm"] as? Double {
+            #expect(conf == 0, "history path should report confidenceMm=0, got \(conf)")
+        }
+    }
+
     @Test("annotation tools round-trip via the sidecar")
     func annotationsRoundTrip() async throws {
         guard let binary = Self.binaryURL else {


### PR DESCRIPTION
## Summary

[OCCTSwift v1.0.3](https://github.com/gsdali/OCCTSwift/releases/tag/v1.0.3) closed [#165](https://github.com/gsdali/OCCTSwift/issues/165) by shipping Tier 2 + Tier 3. This PR consumes Tier 3 — Tier 2 fillet / chamfer / shell ops don't surface as separate MCP tools (they're reached through `apply_feature`), so the win is concentrated there.

- **Package.swift** — OCCTSwift floor `1.0.2` → `1.0.3`.
- **`HistoryRegistry.recordSingleInputHistory(bodyId:inputShape:output:ref:operationName:)`** — same per-kind centroid-match logic as the per-side path inside `recordBooleanHistory`, just without a second input shape. Reuses the existing `recordSide` helper.
- **`apply_feature`** — after `FeatureReconstructor.buildJSON` returns, iterate `result.histories` (keyed by feature id) and record each `ShapeHistoryRef` under the post-mutation body via `recordSingleInputHistory`. For new-body output, record under both the source and target ids so a selectionId taken on either side remaps cleanly.
- **CLAUDE.md** — history opt-in matrix updated; OCCTSwift floor in the deps section bumped.

Per the upstream notes, `histories[id]` is populated for boolean specs, hole specs, and second-additive features with non-nil ids. Fillet / chamfer paths still go through the non-history primitives and fall back to the centroid heuristic — that's a pending OCCTSwift refinement, not blocking.

## Test plan

- [x] `swift build` clean
- [x] `swift test` — 23 tests pass (was 22)
- [x] New stdio integration test `historyRemapAcrossApplyFeature` drills a Ø4 hole near a corner of a 40³ box, picks a face beforehand, asserts `fate=preserved|split` + `confidenceMm=0` (history path drove the answer, not the heuristic)

🤖 Generated with [Claude Code](https://claude.com/claude-code)