### PR TITLE
Cohort bump: full apply_feature history + visible point clouds (v1.2)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,7 +74,7 @@ npm run test:integration  # node:test end-to-end chain through occtkit (slow; ~3
 
 ### Layered architecture (post-Tools / AIS split)
 
-OCCTSwift / OCCTSwiftViewport are kernel layers. `OCCTSwiftTools` is the bridge (Shape ↔ ViewportBody, plus Curve / Surface / Wire / **Point** converters). `OCCTSwiftAIS` is the interactive-services layer (selection, manipulators, dimensions). `render_preview` depends on **Tools + Viewport**, not Viewport alone — that's why we hold OCCTSwiftViewport at 0.55.x even though v1.0.0 is tagged: Tools / AIS / Scripts v1.0 still pin Viewport `from: 0.55.0` (`<1.0.0`). It bumps when those bump.
+OCCTSwift / OCCTSwiftViewport are kernel layers. `OCCTSwiftTools` is the bridge (Shape ↔ ViewportBody, plus Curve / Surface / Wire / **Point** converters). `OCCTSwiftAIS` is the interactive-services layer (selection, manipulators, dimensions). `render_preview` depends on **Tools + Viewport**. The whole cohort is now aligned at v1.0.x — Tools / AIS / Scripts v1.0 graduated their Viewport floors to 1.0.x, so the v0.10–v1.1 hold at Viewport 0.55.x is gone.
 
 ### History wiring (selectionId remap across mutations)
 
@@ -90,7 +90,7 @@ Per-tool opt-in status:
 | `transform_body` | identity history (topology preserved)     | every node maps 1:1 |
 | `heal_shape`     | identity history if pre/post counts match | falls back to heuristic if shape repair changed topology |
 | `boolean_op`     | per-input history via `recordBooleanHistory` | OCCTSwift `*WithFullHistory` variants; recorded under output + both inputs |
-| `apply_feature`  | per-feature history via `recordSingleInputHistory` | OCCTSwift v1.0.3 `FeatureReconstructor.BuildResult.histories[id]` — populated for boolean / hole / second-additive specs with non-nil ids; fillet/chamfer paths still hit the heuristic until `applyFillet` / `applyChamfer` go through `*WithFullHistory` upstream |
+| `apply_feature`  | per-feature history via `recordSingleInputHistory` | OCCTSwift v1.0.4 `FeatureReconstructor.BuildResult.histories[id]` — every spec kind (boolean / hole / second-additive / fillet / chamfer) populates a `ShapeHistoryRef` when the spec carries a non-nil id |
 | `mirror_or_pattern` | heuristic only                         | doesn't fit the contract — needs a `find_correspondences` tool |
 
 ### Data flow for `execute_script`
@@ -125,12 +125,12 @@ The Node server does not expose the v0.4+ tool surface (selection / remap / anno
 
 ### Swift implementation
 
-- **OCCTSwift** ≥ 1.0.3 — kernel wrapper around OpenCASCADE, ships `*WithFullHistory` for booleans + Tier 2 modifications + `FeatureReconstructor.BuildResult.histories`
+- **OCCTSwift** ≥ 1.0.4 — kernel wrapper around OpenCASCADE; full per-input history coverage for booleans + every `FeatureSpec` kind in `BuildResult.histories[id]`
 - **OCCTSwiftMesh** ≥ 1.0.0 — mesh-domain algorithms (QEM decimation today; smoothing / repair / remeshing in roadmap)
-- **OCCTSwiftScripts** ≥ 1.0.0 — provides `occtkit` (only used by `execute_script` and `export_scene`); also ships `ScriptHarness` + `DrawingComposer` consumed in-process
-- **OCCTSwiftTools** ≥ 1.0.1 — Shape↔ViewportBody bridge, ships `PointConverter`
-- **OCCTSwiftViewport** ≥ 0.55.2 — Metal viewport + offscreen renderer. Held under 1.0 because Tools/AIS/Scripts v1.0 still pin Viewport `<1.0.0`
-- **OCCTSwiftAIS** ≥ 1.0.0 — selection, manipulators, dimensions
+- **OCCTSwiftScripts** ≥ 1.0.2 — provides `occtkit` (only used by `execute_script` and `export_scene`); also ships `ScriptHarness` + `DrawingComposer` consumed in-process
+- **OCCTSwiftTools** ≥ 1.1.0 — Shape↔ViewportBody bridge; ships `PointConverter` and wires `pointRadius` / `vertexColors` through to `ViewportBody`
+- **OCCTSwiftViewport** ≥ 1.0.2 — Metal viewport + offscreen renderer; v1.0.2 added the point-sprite pipeline that makes `pointCloud` overlays actually render
+- **OCCTSwiftAIS** ≥ 1.0.1 — selection, manipulators, dimensions
 - **modelcontextprotocol/swift-sdk** ≥ 0.11.0 — MCP transport + types
 
 ### Node implementation

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "f8dae866e313915e5b83a3494645ae57e433a9878fe2f71c9291963934226329",
+  "originHash" : "66bfe2c6f785cadbd449d90d08c8a8b97ac64391ce4535dcd1a3ca34fa1f8313",
   "pins" : [
     {
       "identity" : "eventsource",
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/gsdali/OCCTSwift.git",
       "state" : {
-        "revision" : "c479b1e7f74b701600bdb8e469a30d9f19973bdd",
-        "version" : "1.0.3"
+        "revision" : "1944312d7d2ed68dbb6ebe9c2626d3df3ab35475",
+        "version" : "1.0.4"
       }
     },
     {
@@ -24,8 +24,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/gsdali/OCCTSwiftAIS.git",
       "state" : {
-        "revision" : "1c18da5d5fd4e42fe7637d9be10d75d1804167f6",
-        "version" : "1.0.0"
+        "revision" : "550f7897aa59b8cf358993f1f19485651143528f",
+        "version" : "1.0.1"
       }
     },
     {
@@ -51,8 +51,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/gsdali/OCCTSwiftScripts.git",
       "state" : {
-        "revision" : "790d49053f296db9cebc933b9f793335fcd6a275",
-        "version" : "1.0.0"
+        "revision" : "be3c89d651e6dcdfe0f0f52c08e4c520b90f3134",
+        "version" : "1.0.2"
       }
     },
     {
@@ -60,8 +60,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/gsdali/OCCTSwiftTools.git",
       "state" : {
-        "revision" : "bb7fcf102d98dfbc0e7b756fb1d5e78223f99edd",
-        "version" : "1.0.1"
+        "revision" : "5f00acaf8164f5de68234741cb2b193ed4e9a9dd",
+        "version" : "1.1.0"
       }
     },
     {
@@ -69,8 +69,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/gsdali/OCCTSwiftViewport.git",
       "state" : {
-        "revision" : "aaea62742ed6ae4e075e582c49292f397613c649",
-        "version" : "0.55.3"
+        "revision" : "b6c0e7c14c30332f9aa9df11243595ad7e3a61a8",
+        "version" : "1.0.2"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -22,23 +22,24 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/modelcontextprotocol/swift-sdk.git", from: "0.11.0"),
-        // OCCT 8.0.0 GA shipped 2026-05-09. The whole OCCT-Swift
-        // family tagged v1.0 alongside it; this cohort is what we pin
-        // against now. OCCTSwift 1.0.3 closes gsdali/OCCTSwift#165:
-        //   Tier 1 (v1.0.2): per-input boolean history → boolean_op
-        //   Tier 2 (v1.0.3): fillet/chamfer/shell/defeature history
-        //   Tier 3 (v1.0.3): FeatureReconstructor.BuildResult.histories
-        // → drives apply_feature's history-based remap_selection in v1.1.
-        .package(url: "https://github.com/gsdali/OCCTSwift.git", from: "1.0.3"),
+        // OCCT 8.0.0 GA cohort, fully aligned at v1.0.x.
+        //
+        // OCCTSwift 1.0.4 closes gsdali/OCCTSwift#166: applyFillet /
+        // applyChamfer in FeatureReconstructor go through
+        // *WithFullHistory and populate BuildResult.histories[id] for
+        // every spec kind. apply_feature picks this up transparently
+        // (no consumer code change since v1.1).
+        //
+        // OCCTSwiftViewport 1.0.2 closes #28: Metal point-sprite
+        // pipeline. Combined with OCCTSwiftTools 1.1.0 wiring
+        // pointRadius / vertexColors through to ViewportBody, the
+        // pointCloud annotation now actually renders.
+        .package(url: "https://github.com/gsdali/OCCTSwift.git", from: "1.0.4"),
         .package(url: "https://github.com/gsdali/OCCTSwiftMesh.git", from: "1.0.0"),
-        .package(url: "https://github.com/gsdali/OCCTSwiftScripts.git", from: "1.0.1"),
-        // OCCTSwiftTools 1.0.2 graduates onto OCCTSwiftViewport 1.0.x and
-        // pulls the v1.0.3 history APIs from OCCTSwift.
-        .package(url: "https://github.com/gsdali/OCCTSwiftTools.git", from: "1.0.2"),
-        // OCCTSwiftViewport v1.0.x — the rest of the cohort has graduated
-        // (Tools 1.0.2, Scripts 1.0.1) so the 0.55.x hold no longer applies.
-        .package(url: "https://github.com/gsdali/OCCTSwiftViewport.git", from: "1.0.1"),
-        .package(url: "https://github.com/gsdali/OCCTSwiftAIS.git", from: "1.0.0"),
+        .package(url: "https://github.com/gsdali/OCCTSwiftScripts.git", from: "1.0.2"),
+        .package(url: "https://github.com/gsdali/OCCTSwiftTools.git", from: "1.1.0"),
+        .package(url: "https://github.com/gsdali/OCCTSwiftViewport.git", from: "1.0.2"),
+        .package(url: "https://github.com/gsdali/OCCTSwiftAIS.git", from: "1.0.1"),
     ],
     targets: [
         .target(

--- a/SwiftTests/OCCTMCPCoreTests/IntegrationTests.swift
+++ b/SwiftTests/OCCTMCPCoreTests/IntegrationTests.swift
@@ -523,6 +523,109 @@ struct IntegrationTests {
         }
     }
 
+    @Test("history-based remap survives apply_feature(fillet) post-OCCTSwift v1.0.4")
+    func historyRemapAcrossFilletFeature() async throws {
+        guard let binary = Self.binaryURL else {
+            Issue.record("Binary not built — run `swift build` first.")
+            return
+        }
+        let scene = NSTemporaryDirectory() + "occtmcp-it-fillet-\(UUID().uuidString)"
+        try FileManager.default.createDirectory(atPath: scene, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(atPath: scene) }
+
+        guard let box = Shape.box(width: 30, height: 30, depth: 30) else {
+            Issue.record("Failed to synthesise box")
+            return
+        }
+        try Exporter.writeBREP(shape: box, to: URL(fileURLWithPath: "\(scene)/part.brep"))
+        try ManifestStore(path: "\(scene)/manifest.json").write(ScriptManifest(
+            description: "fillet history test",
+            bodies: [BodyDescriptor(id: "part", file: "part.brep", color: [1, 0, 0, 1])]
+        ))
+
+        let harness = try Harness(
+            binary: binary,
+            extraEnv: ["OCCTMCP_OUTPUT_DIR": scene]
+        )
+        defer { harness.terminate() }
+        try harness.handshake()
+
+        try harness.send(.init(
+            id: 70, method: "tools/call",
+            params: .object([
+                "name": .string("select_topology"),
+                "arguments": .object([
+                    "bodyId": .string("part"),
+                    "kind": .string("face"),
+                    "limit": .int(1),
+                ]),
+            ])
+        ))
+        let selResp = try harness.recv(timeout: 10)
+        guard case .object(let r1)? = selResp["result"],
+              case .array(let c1)? = r1["content"],
+              case .object(let f1)? = c1.first,
+              let t1 = f1["text"]?.stringValue,
+              let d1 = t1.data(using: .utf8),
+              let p1 = try JSONSerialization.jsonObject(with: d1) as? [String: Any],
+              let sels = p1["selections"] as? [[String: Any]],
+              let firstSel = sels.first,
+              let selectionId = firstSel["selectionId"] as? String else {
+            Issue.record("select_topology response shape unexpected")
+            return
+        }
+
+        // Fillet spec with non-nil id — exercises OCCTSwift v1.0.4's
+        // applyFillet → filletedWithFullHistory wiring (closes #166).
+        // EdgeSelector defaults to .all in the JSON path.
+        try harness.send(.init(
+            id: 71, method: "tools/call",
+            params: .object([
+                "name": .string("apply_feature"),
+                "arguments": .object([
+                    "bodyId": .string("part"),
+                    "feature": .object([
+                        "id": .string("f1"),
+                        "kind": .string("fillet"),
+                        "radius": .double(2.0),
+                    ]),
+                ]),
+            ])
+        ))
+        let applyResp = try harness.recv(timeout: 30)
+        #expect(applyResp["error"] == nil, "apply_feature(fillet) errored: \(applyResp)")
+
+        try harness.send(.init(
+            id: 72, method: "tools/call",
+            params: .object([
+                "name": .string("remap_selection"),
+                "arguments": .object([
+                    "selectionIds": .array([.string(selectionId)]),
+                ]),
+            ])
+        ))
+        let rmResp = try harness.recv(timeout: 5)
+        guard case .object(let r2)? = rmResp["result"],
+              case .array(let c2)? = r2["content"],
+              case .object(let f2)? = c2.first,
+              let t2 = f2["text"]?.stringValue,
+              let d2 = t2.data(using: .utf8),
+              let p2 = try JSONSerialization.jsonObject(with: d2) as? [String: Any],
+              let remapped = p2["remapped"] as? [[String: Any]],
+              let entry = remapped.first else {
+            Issue.record("remap_selection response shape unexpected")
+            return
+        }
+        let fate = entry["fate"] as? String ?? "<missing>"
+        #expect(
+            fate == "preserved" || fate == "split",
+            "fillet history should resolve to preserved or split (got \(fate))"
+        )
+        if let conf = entry["confidenceMm"] as? Double {
+            #expect(conf == 0, "history path should report confidenceMm=0, got \(conf)")
+        }
+    }
+
     @Test("annotation tools round-trip via the sidecar")
     func annotationsRoundTrip() async throws {
         guard let binary = Self.binaryURL else {


### PR DESCRIPTION
## Summary

Three upstream releases consumed — all source-compatible, no OCCTMCP API changes.

- **[OCCTSwift v1.0.4](https://github.com/gsdali/OCCTSwift/releases/tag/v1.0.4)** (closes [#166](https://github.com/gsdali/OCCTSwift/issues/166)) — `applyFillet` / `applyChamfer` in `FeatureReconstructor` go through `*WithFullHistory` and populate `BuildResult.histories[id]` for every spec kind. Last hole in `apply_feature` history coverage is closed. Bonus: chamfer's `.nearPoint` / `.onFeature` selectors are now wired upstream.
- **[OCCTSwiftViewport v1.0.2](https://github.com/gsdali/OCCTSwiftViewport/releases/tag/v1.0.2)** (closes [#28](https://github.com/gsdali/OCCTSwiftViewport/issues/28)) — Metal point-sprite pipeline. `ViewportBody.primitiveKind` enum (`.mesh / .point / .wire`) plus `pointRadius` / `vertexColors` fields. Source-compatible — defaults to `.mesh`.
- **[OCCTSwiftTools v1.1.0](https://github.com/gsdali/OCCTSwiftTools/releases/tag/v1.1.0)** — `PointConverter.pointsToBody` actually populates the new ViewportBody fields and stamps `primitiveKind = .point`. The `pointCloud` annotation we've routed through `PointConverter` since v0.10 now actually renders visibly.

Plus cosmetic floor bumps: OCCTSwiftScripts 1.0.2, OCCTSwiftAIS 1.0.1.

`Package.swift` comment block rewritten — v1.0 cohort is fully aligned at v1.0.x now; the Viewport-stays-at-0.55.x note is gone. CLAUDE.md history matrix and dep-list versions updated.

## Test plan

- [x] `swift build` clean
- [x] `swift test` — 24 tests pass (was 23)
- [x] New stdio integration test `historyRemapAcrossFilletFeature` picks a face on a 30³ box, applies `fillet(radius: 2)` with a non-nil id, calls `remap_selection`. Asserts `fate=preserved|split` + `confidenceMm=0` to prove the OCCTSwift v1.0.4 wiring drove the answer rather than the heuristic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)