### PR TITLE
find_correspondences (closes #24) + identity-flag history fix + int/double dispatch fix

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 MCP server that gives LLMs the ability to author, inspect, and iterate on 3D CAD models with OpenCASCADE via the OCCTSwift family. Two implementations live side-by-side:
 
-- **Swift** (`Sources/`, `Package.swift`) — the **primary**, in-process server. Uses the official Swift MCP SDK, calls OCCTSwift / OCCTSwiftMesh / OCCTSwiftTools / OCCTSwiftAIS / DrawingComposer directly. 49 typed tools. macOS 15+.
+- **Swift** (`Sources/`, `Package.swift`) — the **primary**, in-process server. Uses the official Swift MCP SDK, calls OCCTSwift / OCCTSwiftMesh / OCCTSwiftTools / OCCTSwiftAIS / DrawingComposer directly. 50 typed tools. macOS 15+.
 - **Node / TypeScript** (`src/`, `dist/`) — the original implementation. Shells out to the `occtkit` CLI via `OCCTSwiftScripts`. 36 tools (the pre-v0.4 surface; selection / remap / annotations are Swift-only).
 
 Both speak stdio MCP and read/write the same `manifest.json` + `annotations.json` files in the output directory. Pick whichever fits the host: the Swift binary eliminates JSONL marshalling and per-call subprocess spawn; the Node server runs anywhere a Node 18+ runtime exists, but needs `occtkit` on `$PATH`.
@@ -41,7 +41,7 @@ npm run test:integration  # node:test end-to-end chain through occtkit (slow; ~3
 
 `Sources/OCCTMCPCore/` (library) + `Sources/OCCTMCPServer/` (executable that connects stdio).
 
-- `Server.swift` — `createServer()` factory: registers all 49 tools with their JSON Schemas, returns an `MCP.Server` ready to bind to a transport. Tests import `createServer()` to introspect the registry without binding stdio. The `get_api_reference` tool's `mcp_tools` category dumps the live registry as JSON Schema for LLM auto-discovery.
+- `Server.swift` — `createServer()` factory: registers all 50 tools with their JSON Schemas, returns an `MCP.Server` ready to bind to a transport. Tests import `createServer()` to introspect the registry without binding stdio. The `get_api_reference` tool's `mcp_tools` category dumps the live registry as JSON Schema for LLM auto-discovery.
 - `Tools/` — one file per tool family:
   - `CoreTools.swift` — `get_scene`, `get_script`, `export_model`, `get_api_reference`
   - `ExecuteScriptTool.swift` — `execute_script` (writes Swift to tempfile, `occtkit run` via the resolved binary, parses manifest)
@@ -80,18 +80,22 @@ OCCTSwift / OCCTSwiftViewport are kernel layers. `OCCTSwiftTools` is the bridge 
 
 `remap_selection` resolves a `selectionId` against the post-mutation state of a body via:
 
-1. `HistoryRegistry.graph(for: bodyId)` — if recorded, walk `TopologyGraph.findDerived(originalRef:)`. fate ∈ {preserved, split, lost}, confidenceMm = 0.
+1. `HistoryRegistry.entry(for: bodyId)` — if recorded:
+   - Walk `TopologyGraph.findDerived(originalRef:)`. Non-empty result → fate ∈ {preserved, split}, confidenceMm = 0.
+   - Empty result + `isIdentityPreserving` flag set → preserved at same index, confidenceMm = 0. (OCCT's `findDerived` skips identity records — original==replacement entries are no-ops in the OCCT history log — so we track topology-preserving ops via a flag and short-circuit instead of writing self-referencing records.)
+   - Empty result, flag not set → fall through to the heuristic (we can't tell unmodified from deleted without per-record introspection).
 2. Centroid heuristic — load pre and post BREPs, find nearest face/edge/vertex within an epsilon. fate is preserved if within ε, lost otherwise. confidenceMm reports the centroid distance.
 
 Per-tool opt-in status:
 
 | Tool             | History path                              | Notes |
 |------------------|-------------------------------------------|-------|
-| `transform_body` | identity history (topology preserved)     | every node maps 1:1 |
-| `heal_shape`     | identity history if pre/post counts match | falls back to heuristic if shape repair changed topology |
+| `transform_body` | identity flag (topology preserved)        | every node maps 1:1 — `recordIdentityHistory` sets `isIdentityPreserving=true` |
+| `heal_shape`     | identity flag if pre/post counts match    | falls back to heuristic if shape repair changed topology |
 | `boolean_op`     | per-input history via `recordBooleanHistory` | OCCTSwift `*WithFullHistory` variants; recorded under output + both inputs |
 | `apply_feature`  | per-feature history via `recordSingleInputHistory` | OCCTSwift v1.0.4 `FeatureReconstructor.BuildResult.histories[id]` — every spec kind (boolean / hole / second-additive / fillet / chamfer) populates a `ShapeHistoryRef` when the spec carries a non-nil id |
-| `mirror_or_pattern` | heuristic only                         | doesn't fit the contract — needs a `find_correspondences` tool |
+
+`mirror_or_pattern` doesn't fit `remap_selection`'s contract (it produces new bodies rather than mutating in place). For that case use `find_correspondences`, which takes a source body, target body, and explicit `transform` (translate / mirror / rotate), applies the transform to each source anchor's centroid, and finds the nearest same-kind sub-shape on the target. Pure geometry, no OCCT history involved — appropriate because pattern instances aren't OCCT-derivatives of the source.
 
 ### Data flow for `execute_script`
 
@@ -141,7 +145,7 @@ The Node server does not expose the v0.4+ tool surface (selection / remap / anno
 
 ## MCP Tools
 
-49 tools across both implementations (Swift); 36 in Node (no selection / remap / annotations / history). See README.md for the categorized table — that's the LLM-facing surface and stays canonical.
+50 tools across both implementations (Swift); 36 in Node (no selection / remap / annotations / history). See README.md for the categorized table — that's the LLM-facing surface and stays canonical.
 
 ## Script Template
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ MCP server that gives LLMs the ability to author, inspect, and iterate on 3D CAD
 
 Part of the [OCCTSwift ecosystem](https://github.com/gsdali/OCCTSwift/blob/main/docs/ecosystem.md) — see the ecosystem map for how this package sits on top of the kernel, viewport, bridge, and AIS layers. SemVer-stable from v1.0.0.
 
-The Swift implementation calls OCCT directly in-process — no subprocess, no JSONL marshalling — and exposes 49 typed MCP tools that cover authoring, scene reads, mutation, introspection, construction, analysis, I/O, mesh, drawing, selection / remap, and dimension overlays.
+The Swift implementation calls OCCT directly in-process — no subprocess, no JSONL marshalling — and exposes 50 typed MCP tools that cover authoring, scene reads, mutation, introspection, construction, analysis, I/O, mesh, drawing, selection / remap, and dimension overlays.
 
 ## How It Works
 
@@ -22,7 +22,7 @@ For novel geometry the typed tools don't cover, the LLM falls back to `execute_s
 
 ## Tools
 
-49 tools, organized below. Call `get_api_reference({ category: "mcp_tools" })` to dump every tool's JSON Schema in one shot — useful for LLM auto-discovery. Most flows can answer "what's the volume?", "make it red", "boolean-subtract these", "render a preview", "add a dimension between these two faces", "export to STEP", and "draw this" without ever touching `execute_script`.
+50 tools, organized below. Call `get_api_reference({ category: "mcp_tools" })` to dump every tool's JSON Schema in one shot — useful for LLM auto-discovery. Most flows can answer "what's the volume?", "make it red", "boolean-subtract these", "render a preview", "add a dimension between these two faces", "export to STEP", and "draw this" without ever touching `execute_script`.
 
 ### Authoring
 
@@ -82,7 +82,8 @@ For novel geometry the typed tools don't cover, the LLM falls back to `execute_s
 | Tool | Purpose |
 |------|---------|
 | `select_topology` | Pick faces / edges / vertices, get a stable `selectionId` |
-| `remap_selection` | Carry `selectionId`s across mutations (history-based for transform / heal / boolean; centroid heuristic fallback otherwise) |
+| `remap_selection` | Carry `selectionId`s across mutations of the same body (history-based for transform / heal / boolean / apply_feature; centroid heuristic fallback otherwise) |
+| `find_correspondences` | Map `selectionId`s from a source body onto a target body that's a known transform of the source — `mirror_or_pattern` outputs are the typical case |
 | `select_by_feature` | Bulk pick by feature kind (e.g. all hole edges) |
 | `list_selections` | Inspect the in-memory selection registry |
 | `clear_selections` | Wipe the registry |
@@ -131,7 +132,7 @@ For novel geometry the typed tools don't cover, the LLM falls back to `execute_s
 
 This repo ships two implementations side-by-side:
 
-- **Swift** (`Sources/`, `Package.swift`) — the **primary** server. In-process against OCCTSwift / OCCTSwiftMesh / OCCTSwiftTools / OCCTSwiftAIS / DrawingComposer using the [official Swift MCP SDK](https://swiftpackageindex.com/modelcontextprotocol/swift-sdk). 49 tools. macOS 15+ (the OCCT.xcframework arm64 platform).
+- **Swift** (`Sources/`, `Package.swift`) — the **primary** server. In-process against OCCTSwift / OCCTSwiftMesh / OCCTSwiftTools / OCCTSwiftAIS / DrawingComposer using the [official Swift MCP SDK](https://swiftpackageindex.com/modelcontextprotocol/swift-sdk). 50 tools. macOS 15+ (the OCCT.xcframework arm64 platform).
 - **Node / TypeScript** (`src/`, `dist/`) — the original implementation. Shells out to the `occtkit` CLI for everything Swift-side. 36 tools (the pre-v0.4 surface; selection / remap / annotations are Swift-only). Useful if you can't run a macOS binary.
 
 Both speak stdio MCP and read/write the same manifest format.

--- a/Sources/OCCTMCPCore/HistoryRegistry.swift
+++ b/Sources/OCCTMCPCore/HistoryRegistry.swift
@@ -25,30 +25,44 @@ import OCCTSwift
 public actor HistoryRegistry {
     public static let shared = HistoryRegistry()
 
-    /// `bodyId → TopologyGraph` — populated by tools that opt into
-    /// history capture. Eviction is automatic when the body is
-    /// re-mutated (the new graph replaces the old).
-    private var graphs: [String: TopologyGraph] = [:]
+    /// Per-body cached state. `isIdentityPreserving` is true when the
+    /// recorded mutation didn't change topology indices — every
+    /// pre-mutation node maps to the same index post-mutation. Used so
+    /// remap_selection can short-circuit `findDerived` (which OCCT
+    /// only populates for *changed* nodes — explicit
+    /// "original==replacement" identity records are no-ops in OCCT) and
+    /// just return the same index. Cleared/replaced when the body is
+    /// re-mutated.
+    public struct Entry: Sendable {
+        public let graph: TopologyGraph
+        public let isIdentityPreserving: Bool
+    }
+
+    private var entries: [String: Entry] = [:]
 
     public init() {}
 
     /// Record a post-mutation graph for `bodyId`. Replaces any prior
-    /// graph for the same body — older selectionIds remap against the
+    /// entry for the same body — older selectionIds remap against the
     /// most recent state only.
     public func record(bodyId: String, graph: TopologyGraph) {
-        graphs[bodyId] = graph
+        entries[bodyId] = Entry(graph: graph, isIdentityPreserving: false)
+    }
+
+    public func entry(for bodyId: String) -> Entry? {
+        return entries[bodyId]
     }
 
     public func graph(for bodyId: String) -> TopologyGraph? {
-        return graphs[bodyId]
+        return entries[bodyId]?.graph
     }
 
     public func clear() {
-        graphs.removeAll()
+        entries.removeAll()
     }
 
     public func count() -> Int {
-        return graphs.count
+        return entries.count
     }
 }
 
@@ -78,6 +92,7 @@ extension HistoryRegistry {
         operationName: String
     ) {
         guard let postGraph = TopologyGraph(shape: output) else { return }
+        postGraph.isHistoryEnabled = true
 
         // Pre-compute output sub-shape centroids so per-input lookup
         // is O(N+M) total rather than O(N*M).
@@ -102,9 +117,10 @@ extension HistoryRegistry {
         // Same graph under all three keys so remap_selection finds it
         // regardless of which input the selectionId was originally
         // recorded against.
-        graphs[outId] = postGraph
-        graphs[aBodyId] = postGraph
-        graphs[bBodyId] = postGraph
+        let entry = Entry(graph: postGraph, isIdentityPreserving: false)
+        entries[outId] = entry
+        entries[aBodyId] = entry
+        entries[bBodyId] = entry
     }
 
     /// Translate a single-input `ShapeHistoryRef` (gsdali/OCCTSwift#165
@@ -121,6 +137,7 @@ extension HistoryRegistry {
         operationName: String
     ) {
         guard let postGraph = TopologyGraph(shape: output) else { return }
+        postGraph.isHistoryEnabled = true
         let postFaces = output.subShapes(ofType: .face)
         let postEdges = output.subShapes(ofType: .edge)
         let postVertices = output.subShapes(ofType: .vertex)
@@ -133,7 +150,7 @@ extension HistoryRegistry {
             faceCentres: faceCentres, edgeCentres: edgeCentres, vertexCentres: vertexCentres,
             ref: ref, operationName: operationName
         )
-        graphs[bodyId] = postGraph
+        entries[bodyId] = Entry(graph: postGraph, isIdentityPreserving: false)
     }
 
     private func recordSide(
@@ -235,27 +252,15 @@ extension HistoryRegistry {
         postMutationShape: Shape,
         operationName: String
     ) {
+        // OCCT's history API treats `original == replacement` records
+        // as no-ops — `findDerived` returns empty for an identity-only
+        // record. Don't write anything; just register the post graph
+        // with the identity-preserving flag so RemapTools can
+        // short-circuit `findDerived` empties to "preserved at same
+        // index".
+        _ = operationName
         guard let graph = TopologyGraph(shape: postMutationShape) else { return }
-        // Faces / edges / vertices are the only kinds we surface as
-        // selectionIds, so we only need to record those.
-        for kind in [TopologyGraph.NodeKind.face, .edge, .vertex] {
-            let count: Int
-            switch kind {
-            case .face:    count = graph.faceCount
-            case .edge:    count = graph.edgeCount
-            case .vertex:  count = graph.vertexCount
-            default:       count = 0
-            }
-            for i in 0..<count {
-                let ref = TopologyGraph.NodeRef(kind: kind, index: i)
-                graph.recordHistory(
-                    operationName: operationName,
-                    original: ref,
-                    replacements: [ref]
-                )
-            }
-        }
-        graphs[bodyId] = graph
+        entries[bodyId] = Entry(graph: graph, isIdentityPreserving: true)
     }
 
     /// Conditional version of `recordIdentityHistory` — only records
@@ -281,24 +286,10 @@ extension HistoryRegistry {
               pre.vertexCount == post.vertexCount else {
             return false
         }
-        for kind in [TopologyGraph.NodeKind.face, .edge, .vertex] {
-            let count: Int
-            switch kind {
-            case .face:    count = post.faceCount
-            case .edge:    count = post.edgeCount
-            case .vertex:  count = post.vertexCount
-            default:       count = 0
-            }
-            for i in 0..<count {
-                let ref = TopologyGraph.NodeRef(kind: kind, index: i)
-                post.recordHistory(
-                    operationName: operationName,
-                    original: ref,
-                    replacements: [ref]
-                )
-            }
-        }
-        graphs[bodyId] = post
+        // Same reasoning as `recordIdentityHistory` — skip the
+        // self-referencing record loop and just flag the entry.
+        _ = operationName
+        entries[bodyId] = Entry(graph: post, isIdentityPreserving: true)
         return true
     }
 }

--- a/Sources/OCCTMCPCore/Server.swift
+++ b/Sources/OCCTMCPCore/Server.swift
@@ -15,6 +15,18 @@ public enum OCCTMCPVersion {
     public static let serverVersion = "0.1.0"
 }
 
+extension Value {
+    /// Numeric coercion for tool dispatch — JSON whole numbers
+    /// (`[0, 0, 1]`) decode as `.int` per the SDK's Codable, but every
+    /// numeric coordinate / scalar in our schemas wants a `Double`.
+    /// `doubleValue` alone misses ints; this helper accepts either.
+    var asDouble: Double? {
+        if let d = doubleValue { return d }
+        if let i = intValue { return Double(i) }
+        return nil
+    }
+}
+
 /// Build a fully-configured MCP server with every OCCTMCP tool registered.
 /// Caller is responsible for `start(transport:)` and `waitUntilCompleted()`.
 public func makeOCCTMCPServer() async -> Server {
@@ -390,6 +402,66 @@ func catalogTools() -> [Tool] {
                     ]),
                 ]),
                 "required": .array([.string("selectionIds")]),
+                "additionalProperties": .bool(false),
+            ])
+        ),
+        Tool(
+            name: "find_correspondences",
+            description: "Map selectionIds from a source body onto a target body that's a known transform of the source (typically a mirror_or_pattern output). Apply `transform` to each source anchor's centroid, then find the nearest same-kind sub-shape on the target. Returns each source id mapped to one target selectionId (or null) with confidenceMm + fate ('matched' | 'lost'). Use this for cross-body workflows; remap_selection is for the within-body case.",
+            inputSchema: .object([
+                "type": .string("object"),
+                "properties": .object([
+                    "sourceSelectionIds": .object([
+                        "type": .string("array"),
+                        "items": .object(["type": .string("string")]),
+                    ]),
+                    "targetBodyId": .object(["type": .string("string")]),
+                    "transform": .object([
+                        "type": .string("object"),
+                        "description": .string("Transform applied to source anchors before nearest-neighbour search on the target. Exactly one of `translate` / `mirror` / `rotate` is required."),
+                        "properties": .object([
+                            "kind": .object([
+                                "type": .string("string"),
+                                "enum": .array([.string("translate"), .string("mirror"), .string("rotate")]),
+                            ]),
+                            "offset": .object([
+                                "type": .string("array"),
+                                "description": .string("translate: [dx, dy, dz]"),
+                                "items": .object(["type": .string("number")]),
+                            ]),
+                            "planeOrigin": .object([
+                                "type": .string("array"),
+                                "description": .string("mirror: a point on the mirror plane"),
+                                "items": .object(["type": .string("number")]),
+                            ]),
+                            "planeNormal": .object([
+                                "type": .string("array"),
+                                "description": .string("mirror: plane normal (any length, normalized internally)"),
+                                "items": .object(["type": .string("number")]),
+                            ]),
+                            "axisOrigin": .object([
+                                "type": .string("array"),
+                                "description": .string("rotate: a point on the rotation axis"),
+                                "items": .object(["type": .string("number")]),
+                            ]),
+                            "axisDirection": .object([
+                                "type": .string("array"),
+                                "description": .string("rotate: axis direction (any length)"),
+                                "items": .object(["type": .string("number")]),
+                            ]),
+                            "angleDeg": .object([
+                                "type": .string("number"),
+                                "description": .string("rotate: angle in degrees, right-hand rule about axisDirection"),
+                            ]),
+                        ]),
+                        "required": .array([.string("kind")]),
+                    ]),
+                    "toleranceMmFraction": .object([
+                        "type": .string("number"),
+                        "description": .string("Fraction of target bbox diagonal to use as the match tolerance. Default 0.01."),
+                    ]),
+                ]),
+                "required": .array([.string("sourceSelectionIds"), .string("targetBodyId"), .string("transform")]),
                 "additionalProperties": .bool(false),
             ])
         ),
@@ -911,7 +983,7 @@ func parseRenderOptions(_ value: Value?) -> RenderPreviewTool.Options {
     }
     func vec3(_ key: String) -> SIMD3<Float>? {
         guard let arr = o[key]?.arrayValue, arr.count == 3,
-              let x = arr[0].doubleValue, let y = arr[1].doubleValue, let z = arr[2].doubleValue else { return nil }
+              let x = arr[0].asDouble, let y = arr[1].asDouble, let z = arr[2].asDouble else { return nil }
         return SIMD3(Float(x), Float(y), Float(z))
     }
     opts.cameraPosition = vec3("cameraPosition")
@@ -1001,9 +1073,65 @@ func dispatch(callName: String, arguments: [String: Value]) async -> CallTool.Re
         guard let ids = arguments["selectionIds"]?.arrayValue?.compactMap({ $0.stringValue }), !ids.isEmpty else {
             return ToolText("remap_selection requires `selectionIds` array.", isError: true).asCallToolResult()
         }
-        let tol = arguments["toleranceMmFraction"]?.doubleValue ?? 0.01
+        let tol = arguments["toleranceMmFraction"]?.asDouble ?? 0.01
         return await RemapTools.remapSelection(
             selectionIds: ids, toleranceMmFraction: tol
+        ).asCallToolResult()
+
+    case "find_correspondences":
+        guard let ids = arguments["sourceSelectionIds"]?.arrayValue?.compactMap({ $0.stringValue }), !ids.isEmpty else {
+            return ToolText("find_correspondences requires `sourceSelectionIds` array.", isError: true).asCallToolResult()
+        }
+        guard let targetId = arguments["targetBodyId"]?.stringValue else {
+            return ToolText("find_correspondences requires `targetBodyId`.", isError: true).asCallToolResult()
+        }
+        guard case .object(let t)? = arguments["transform"],
+              let kind = t["kind"]?.stringValue else {
+            return ToolText("find_correspondences requires `transform.kind`.", isError: true).asCallToolResult()
+        }
+        let transform: CorrespondenceTools.TransformHint
+        switch kind {
+        case "translate":
+            guard let arr = t["offset"]?.arrayValue, arr.count == 3,
+                  let x = arr[0].asDouble, let y = arr[1].asDouble, let z = arr[2].asDouble else {
+                return ToolText("translate requires `offset: [x, y, z]`.", isError: true).asCallToolResult()
+            }
+            transform = .translate(offset: SIMD3(x, y, z))
+        case "mirror":
+            guard let nArr = t["planeNormal"]?.arrayValue, nArr.count == 3,
+                  let nx = nArr[0].asDouble, let ny = nArr[1].asDouble, let nz = nArr[2].asDouble else {
+                return ToolText("mirror requires `planeNormal: [x, y, z]`.", isError: true).asCallToolResult()
+            }
+            let origin: SIMD3<Double>
+            if let oArr = t["planeOrigin"]?.arrayValue, oArr.count == 3,
+               let ox = oArr[0].asDouble, let oy = oArr[1].asDouble, let oz = oArr[2].asDouble {
+                origin = SIMD3(ox, oy, oz)
+            } else {
+                origin = .zero
+            }
+            transform = .mirror(planeOrigin: origin, planeNormal: SIMD3(nx, ny, nz))
+        case "rotate":
+            guard let oArr = t["axisOrigin"]?.arrayValue, oArr.count == 3,
+                  let ox = oArr[0].asDouble, let oy = oArr[1].asDouble, let oz = oArr[2].asDouble,
+                  let dArr = t["axisDirection"]?.arrayValue, dArr.count == 3,
+                  let dx = dArr[0].asDouble, let dy = dArr[1].asDouble, let dz = dArr[2].asDouble,
+                  let angle = t["angleDeg"]?.asDouble else {
+                return ToolText("rotate requires `axisOrigin`, `axisDirection`, `angleDeg`.", isError: true).asCallToolResult()
+            }
+            transform = .rotate(
+                axisOrigin: SIMD3(ox, oy, oz),
+                axisDirection: SIMD3(dx, dy, dz),
+                angleDeg: angle
+            )
+        default:
+            return ToolText("transform.kind must be one of `translate`, `mirror`, `rotate`.", isError: true).asCallToolResult()
+        }
+        let tol = arguments["toleranceMmFraction"]?.asDouble ?? 0.01
+        return await CorrespondenceTools.findCorrespondences(
+            sourceSelectionIds: ids,
+            targetBodyId: targetId,
+            transform: transform,
+            toleranceMmFraction: tol
         ).asCallToolResult()
 
     case "list_selections":
@@ -1038,7 +1166,7 @@ func dispatch(callName: String, arguments: [String: Value]) async -> CallTool.Re
             filter.minLength = f["minLength"]?.doubleValue
             filter.maxLength = f["maxLength"]?.doubleValue
             if let arr = f["normalDirection"]?.arrayValue, arr.count == 3,
-               let x = arr[0].doubleValue, let y = arr[1].doubleValue, let z = arr[2].doubleValue {
+               let x = arr[0].asDouble, let y = arr[1].asDouble, let z = arr[2].asDouble {
                 filter.normalDirection = SIMD3(x, y, z)
             }
             filter.normalTolerance = f["normalTolerance"]?.doubleValue
@@ -1291,16 +1419,16 @@ func dispatch(callName: String, arguments: [String: Value]) async -> CallTool.Re
         }
         var opts = ConstructionTools.TransformOptions()
         if let arr = arguments["translate"]?.arrayValue, arr.count == 3,
-           let x = arr[0].doubleValue, let y = arr[1].doubleValue, let z = arr[2].doubleValue {
+           let x = arr[0].asDouble, let y = arr[1].asDouble, let z = arr[2].asDouble {
             opts.translate = SIMD3(x, y, z)
         }
         if let arr = arguments["rotateAxisAngle"]?.arrayValue, arr.count == 4,
-           let x = arr[0].doubleValue, let y = arr[1].doubleValue, let z = arr[2].doubleValue,
+           let x = arr[0].asDouble, let y = arr[1].asDouble, let z = arr[2].asDouble,
            let r = arr[3].doubleValue {
             opts.rotateAxisAngle = (SIMD3(x, y, z), r)
         }
         if let arr = arguments["rotateEulerXyz"]?.arrayValue, arr.count == 3,
-           let x = arr[0].doubleValue, let y = arr[1].doubleValue, let z = arr[2].doubleValue {
+           let x = arr[0].asDouble, let y = arr[1].asDouble, let z = arr[2].asDouble {
             opts.rotateEulerXyz = SIMD3(x, y, z)
         }
         opts.scale = arguments["scale"]?.doubleValue
@@ -1331,25 +1459,25 @@ func dispatch(callName: String, arguments: [String: Value]) async -> CallTool.Re
         var p = ConstructionTools.PatternParams()
         if case .object(let f)? = arguments["params"] {
             if let arr = f["planeOrigin"]?.arrayValue, arr.count == 3,
-               let x = arr[0].doubleValue, let y = arr[1].doubleValue, let z = arr[2].doubleValue {
+               let x = arr[0].asDouble, let y = arr[1].asDouble, let z = arr[2].asDouble {
                 p.planeOrigin = SIMD3(x, y, z)
             }
             if let arr = f["planeNormal"]?.arrayValue, arr.count == 3,
-               let x = arr[0].doubleValue, let y = arr[1].doubleValue, let z = arr[2].doubleValue {
+               let x = arr[0].asDouble, let y = arr[1].asDouble, let z = arr[2].asDouble {
                 p.planeNormal = SIMD3(x, y, z)
             }
             if let arr = f["direction"]?.arrayValue, arr.count == 3,
-               let x = arr[0].doubleValue, let y = arr[1].doubleValue, let z = arr[2].doubleValue {
+               let x = arr[0].asDouble, let y = arr[1].asDouble, let z = arr[2].asDouble {
                 p.direction = SIMD3(x, y, z)
             }
-            p.spacing = f["spacing"]?.doubleValue
+            p.spacing = f["spacing"]?.asDouble
             p.count = f["count"]?.intValue
             if let arr = f["axisOrigin"]?.arrayValue, arr.count == 3,
-               let x = arr[0].doubleValue, let y = arr[1].doubleValue, let z = arr[2].doubleValue {
+               let x = arr[0].asDouble, let y = arr[1].asDouble, let z = arr[2].asDouble {
                 p.axisOrigin = SIMD3(x, y, z)
             }
             if let arr = f["axisDirection"]?.arrayValue, arr.count == 3,
-               let x = arr[0].doubleValue, let y = arr[1].doubleValue, let z = arr[2].doubleValue {
+               let x = arr[0].asDouble, let y = arr[1].asDouble, let z = arr[2].asDouble {
                 p.axisDirection = SIMD3(x, y, z)
             }
             p.totalCount = f["totalCount"]?.intValue

--- a/Sources/OCCTMCPCore/Tools/CorrespondenceTools.swift
+++ b/Sources/OCCTMCPCore/Tools/CorrespondenceTools.swift
@@ -1,0 +1,287 @@
+// CorrespondenceTools — find_correspondences. Maps selectionIds from a
+// source body onto a target body that's a known transform of the source
+// (typically a `mirror_or_pattern` output, but works for any pair of
+// same-topology bodies under a given transform).
+//
+// Different contract from `remap_selection`:
+//   - remap_selection: "selectionId X mutated into selectionId Y on the
+//     SAME body". Returns fate per id.
+//   - find_correspondences: "selectionId X on body A corresponds to
+//     selectionId Y on body B under transform T". Returns target
+//     selectionId per source id.
+//
+// pattern instances aren't OCCT-derivatives of the source — they're
+// independent Shapes that share topology under a transform. There's no
+// history relationship to walk; the algorithm is pure geometry: apply
+// the transform to each source anchor's centroid, then find the
+// nearest target sub-shape of the same kind.
+//
+// Tracks #24. v1 supports translate / mirror / rotate hints; compound
+// hints + bbox-alignment inference + reading mirror_or_pattern manifest
+// metadata are listed in the issue and queued for follow-ups.
+
+import Foundation
+import simd
+import OCCTSwift
+import ScriptHarness
+
+public enum CorrespondenceTools {
+
+    public enum TransformHint: Sendable {
+        case translate(offset: SIMD3<Double>)
+        case mirror(planeOrigin: SIMD3<Double>, planeNormal: SIMD3<Double>)
+        case rotate(axisOrigin: SIMD3<Double>, axisDirection: SIMD3<Double>, angleDeg: Double)
+
+        /// Apply to a single point.
+        func apply(_ p: SIMD3<Double>) -> SIMD3<Double> {
+            switch self {
+            case .translate(let offset):
+                return p + offset
+            case .mirror(let origin, let normal):
+                let n = simd_normalize(normal)
+                let d = simd_dot(p - origin, n)
+                return p - 2.0 * d * n
+            case .rotate(let origin, let dir, let angleDeg):
+                let axis = simd_normalize(dir)
+                let theta = angleDeg * .pi / 180.0
+                let c = cos(theta), s = sin(theta), oneMinusC = 1 - c
+                let v = p - origin
+                // Rodrigues rotation
+                let rotated =
+                    v * c
+                    + simd_cross(axis, v) * s
+                    + axis * simd_dot(axis, v) * oneMinusC
+                return origin + rotated
+            }
+        }
+    }
+
+    public struct Correspondence: Encodable {
+        public let sourceSelectionId: String
+        public let targetSelectionId: String?
+        public let confidenceMm: Double?   // distance from transformed source anchor to chosen target centroid
+        public let fate: String            // "matched" | "lost"
+    }
+
+    public struct CorrespondencesReport: Encodable {
+        public let correspondences: [Correspondence]
+    }
+
+    /// Resolve correspondences from `sourceSelectionIds` onto `targetBodyId`
+    /// under the given `transform`. Each source id resolves through the
+    /// SelectionRegistry to its anchor; the anchor's centroid (cached in
+    /// the snapshot, or recomputed from the source BREP) is transformed,
+    /// then matched against the same-kind sub-shapes of the target body
+    /// by minimum centroid distance. Tolerance defaults to 1% of the
+    /// target body's bbox diagonal — same sizing as remap_selection's
+    /// heuristic so confidence values are directly comparable.
+    public static func findCorrespondences(
+        sourceSelectionIds: [String],
+        targetBodyId: String,
+        transform: TransformHint,
+        toleranceMmFraction: Double = 0.01,
+        store: ManifestStore = ManifestStore(),
+        registry: SelectionRegistry = .shared
+    ) async -> ToolText {
+        guard let manifest = try? store.read() else {
+            return .init("No scene loaded.")
+        }
+        guard let targetBody = manifest.body(withId: targetBodyId) else {
+            return .init("Target body not found: \(targetBodyId)")
+        }
+        let outputDir = (store.path as NSString).deletingLastPathComponent
+        let targetPath = "\(outputDir)/\(targetBody.file)"
+        guard FileManager.default.fileExists(atPath: targetPath),
+              let targetShape = try? Shape.loadBREP(fromPath: targetPath) else {
+            return .init("Target BREP missing or unreadable: \(targetPath)")
+        }
+
+        let bb = targetShape.bounds
+        let diag = simd_length(bb.max - bb.min)
+        let tolerance = max(diag * toleranceMmFraction, 1e-6)
+
+        // Pre-compute target sub-shape centroids once per kind — every
+        // source id of the same kind reuses the array.
+        let targetFaceCentres: [SIMD3<Double>] = targetShape.faces().map {
+            SelectionTools.faceCenterAndNormal(face: $0).0
+        }
+        let targetEdgeCentres: [SIMD3<Double>] = targetShape.edges().compactMap {
+            SelectionTools.edgeMidpoint(edge: $0)
+        }
+        let targetVertices: [SIMD3<Double>] = targetShape.vertices()
+
+        // Cache source-shape loads per source bodyId — multiple
+        // selectionIds typically share a source.
+        var sourceShapes: [String: Shape] = [:]
+
+        var out: [Correspondence] = []
+        for sid in sourceSelectionIds {
+            guard let anchor = await registry.anchor(for: sid) else {
+                out.append(.init(
+                    sourceSelectionId: sid,
+                    targetSelectionId: nil,
+                    confidenceMm: nil,
+                    fate: "lost"
+                ))
+                continue
+            }
+
+            // Resolve source centroid — registry snapshot first (cheap),
+            // BREP recompute as fallback.
+            let snapshot = await registry.snapshot(for: sid)
+            let sourceCentroid: SIMD3<Double>?
+            if let snap = snapshot, snap.center.count == 3 {
+                sourceCentroid = SIMD3(snap.center[0], snap.center[1], snap.center[2])
+            } else {
+                sourceCentroid = await loadSourceCentroid(
+                    anchor: anchor,
+                    manifest: manifest,
+                    outputDir: outputDir,
+                    cache: &sourceShapes
+                )
+            }
+            guard let sc = sourceCentroid else {
+                out.append(.init(
+                    sourceSelectionId: sid,
+                    targetSelectionId: nil,
+                    confidenceMm: nil,
+                    fate: "lost"
+                ))
+                continue
+            }
+
+            let transformed = transform.apply(sc)
+
+            switch anchor {
+            case .body:
+                // Whole-body picks always rebind to the target body —
+                // no geometry matching needed.
+                let newAnchor = TopologyAnchor.body(bodyId: targetBodyId)
+                out.append(.init(
+                    sourceSelectionId: sid,
+                    targetSelectionId: newAnchor.selectionId,
+                    confidenceMm: 0,
+                    fate: "matched"
+                ))
+
+            case .face:
+                let entry = pickNearest(
+                    sid: sid,
+                    transformed: transformed,
+                    centres: targetFaceCentres,
+                    tolerance: tolerance
+                ) { idx in TopologyAnchor.face(bodyId: targetBodyId, index: idx) }
+                if let newAnchor = entry.anchor, let snap = snapshot {
+                    await registry.record(anchor: newAnchor, snapshot: snap)
+                }
+                out.append(entry.report)
+
+            case .edge:
+                let entry = pickNearest(
+                    sid: sid,
+                    transformed: transformed,
+                    centres: targetEdgeCentres,
+                    tolerance: tolerance
+                ) { idx in TopologyAnchor.edge(bodyId: targetBodyId, index: idx) }
+                if let newAnchor = entry.anchor, let snap = snapshot {
+                    await registry.record(anchor: newAnchor, snapshot: snap)
+                }
+                out.append(entry.report)
+
+            case .vertex:
+                let entry = pickNearest(
+                    sid: sid,
+                    transformed: transformed,
+                    centres: targetVertices,
+                    tolerance: tolerance
+                ) { idx in TopologyAnchor.vertex(bodyId: targetBodyId, index: idx) }
+                if let newAnchor = entry.anchor, let snap = snapshot {
+                    await registry.record(anchor: newAnchor, snapshot: snap)
+                }
+                out.append(entry.report)
+            }
+        }
+
+        return IntrospectionTools.encode(CorrespondencesReport(correspondences: out))
+    }
+
+    private struct PickResult {
+        let report: Correspondence
+        let anchor: TopologyAnchor?
+    }
+
+    private static func pickNearest(
+        sid: String,
+        transformed: SIMD3<Double>,
+        centres: [SIMD3<Double>],
+        tolerance: Double,
+        anchorMaker: (Int) -> TopologyAnchor
+    ) -> PickResult {
+        guard !centres.isEmpty else {
+            return PickResult(
+                report: .init(sourceSelectionId: sid, targetSelectionId: nil,
+                              confidenceMm: nil, fate: "lost"),
+                anchor: nil
+            )
+        }
+        var bestIdx = 0
+        var bestDist = simd_length(centres[0] - transformed)
+        for i in 1..<centres.count {
+            let d = simd_length(centres[i] - transformed)
+            if d < bestDist { bestDist = d; bestIdx = i }
+        }
+        if bestDist > tolerance {
+            return PickResult(
+                report: .init(sourceSelectionId: sid, targetSelectionId: nil,
+                              confidenceMm: bestDist, fate: "lost"),
+                anchor: nil
+            )
+        }
+        let newAnchor = anchorMaker(bestIdx)
+        return PickResult(
+            report: .init(sourceSelectionId: sid, targetSelectionId: newAnchor.selectionId,
+                          confidenceMm: bestDist, fate: "matched"),
+            anchor: newAnchor
+        )
+    }
+
+    /// Recompute the source anchor centroid from the source BREP. Only
+    /// needed when the SelectionRegistry snapshot was evicted or never
+    /// captured (e.g. selectionIds constructed by hand).
+    private static func loadSourceCentroid(
+        anchor: TopologyAnchor,
+        manifest: ScriptManifest,
+        outputDir: String,
+        cache: inout [String: Shape]
+    ) async -> SIMD3<Double>? {
+        let bodyId = anchor.bodyId
+        let shape: Shape
+        if let cached = cache[bodyId] {
+            shape = cached
+        } else {
+            guard let body = manifest.body(withId: bodyId),
+                  let loaded = try? Shape.loadBREP(fromPath: "\(outputDir)/\(body.file)") else {
+                return nil
+            }
+            cache[bodyId] = loaded
+            shape = loaded
+        }
+        switch anchor {
+        case .body:
+            let bb = shape.bounds
+            return (bb.min + bb.max) * 0.5
+        case .face(_, let idx):
+            let faces = shape.faces()
+            guard idx < faces.count else { return nil }
+            return SelectionTools.faceCenterAndNormal(face: faces[idx]).0
+        case .edge(_, let idx):
+            let edges = shape.edges()
+            guard idx < edges.count else { return nil }
+            return SelectionTools.edgeMidpoint(edge: edges[idx])
+        case .vertex(_, let idx):
+            let vs = shape.vertices()
+            guard idx < vs.count else { return nil }
+            return vs[idx]
+        }
+    }
+}

--- a/Sources/OCCTMCPCore/Tools/RemapTools.swift
+++ b/Sources/OCCTMCPCore/Tools/RemapTools.swift
@@ -87,7 +87,7 @@ public enum RemapTools {
 
             // v0.6: prefer the recorded TopologyGraph history over the
             // centroid heuristic when a mutating tool opted in.
-            let recordedGraph = await historyRegistry.graph(for: bodyId)
+            let recordedEntry = await historyRegistry.entry(for: bodyId)
 
             for id in ids {
                 guard let anchor = await registry.anchor(for: id) else {
@@ -99,11 +99,12 @@ public enum RemapTools {
                     ))
                     continue
                 }
-                if let graph = recordedGraph,
+                if let recorded = recordedEntry,
                    let entry = remapViaHistory(
                        originalId: id,
                        anchor: anchor,
-                       graph: graph,
+                       graph: recorded.graph,
+                       isIdentityPreserving: recorded.isIdentityPreserving,
                        bodyId: bodyId
                    ) {
                     // Refresh the registry so the new selectionId
@@ -138,10 +139,19 @@ public enum RemapTools {
     /// algorithm: TopologyGraph.findDerived(of:) walks history records.
     /// Returns nil if the anchor isn't a face/edge/vertex (body always
     /// rebinds; whole-body picks aren't routed here).
+    ///
+    /// `isIdentityPreserving` flags ops like transform_body / heal_shape
+    /// where the topology graph is index-stable across the mutation —
+    /// every pre-mutation node maps 1:1 to the same index post-mutation.
+    /// OCCT's `findDerived` only walks recorded modifications, so an
+    /// untouched node returns an empty derivative list. For
+    /// identity-preserving ops we treat that as "preserved at the same
+    /// index" rather than falling back to the heuristic.
     static func remapViaHistory(
         originalId: String,
         anchor: TopologyAnchor,
         graph: TopologyGraph,
+        isIdentityPreserving: Bool,
         bodyId: String
     ) -> RemapEntry? {
         let kind: TopologyGraph.NodeKind
@@ -161,24 +171,38 @@ public enum RemapTools {
         case .vertex(_, let idx):
             kind = .vertex; originalIndex = idx
         }
+        let kindCount: Int
+        switch kind {
+        case .face:    kindCount = graph.faceCount
+        case .edge:    kindCount = graph.edgeCount
+        case .vertex:  kindCount = graph.vertexCount
+        default:       kindCount = 0
+        }
         let derived = graph.findDerived(of: .init(kind: kind, index: originalIndex))
         if derived.isEmpty {
-            // No record means either "deleted" or "not mentioned —
-            // presumed unchanged". For 1:1 ops this normally means
-            // the explicit identity record was suppressed; emit "lost"
-            // so callers don't silently inherit a stale index.
+            // Identity-preserving op + valid index → preserved at same
+            // index. Otherwise we can't tell (deleted vs untouched);
+            // hand off to the heuristic.
+            if isIdentityPreserving && originalIndex < kindCount {
+                let sameId: String
+                switch kind {
+                case .face:   sameId = TopologyAnchor.face(bodyId: bodyId, index: originalIndex).selectionId
+                case .edge:   sameId = TopologyAnchor.edge(bodyId: bodyId, index: originalIndex).selectionId
+                case .vertex: sameId = TopologyAnchor.vertex(bodyId: bodyId, index: originalIndex).selectionId
+                default:      return nil
+                }
+                return RemapEntry(
+                    originalSelectionId: originalId,
+                    newSelectionIds: [sameId],
+                    fate: "preserved",
+                    confidenceMm: 0
+                )
+            }
             return nil
         }
         // Filter to same-kind derivatives and clamp to the live graph.
-        let count: Int
-        switch kind {
-        case .face:    count = graph.faceCount
-        case .edge:    count = graph.edgeCount
-        case .vertex:  count = graph.vertexCount
-        default:       count = 0
-        }
         let validIndices = derived
-            .filter { $0.kind == kind && $0.index < count }
+            .filter { $0.kind == kind && $0.index < kindCount }
             .map(\.index)
         if validIndices.isEmpty {
             return nil

--- a/SwiftTests/OCCTMCPCoreTests/IntegrationTests.swift
+++ b/SwiftTests/OCCTMCPCoreTests/IntegrationTests.swift
@@ -626,6 +626,145 @@ struct IntegrationTests {
         }
     }
 
+    @Test("find_correspondences maps a face across a mirror_or_pattern mirror")
+    func findCorrespondencesAcrossMirror() async throws {
+        guard let binary = Self.binaryURL else {
+            Issue.record("Binary not built — run `swift build` first.")
+            return
+        }
+        let scene = NSTemporaryDirectory() + "occtmcp-it-corr-\(UUID().uuidString)"
+        try FileManager.default.createDirectory(atPath: scene, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(atPath: scene) }
+
+        // Place a 20×20×20 box at +X so it doesn't straddle the YZ plane —
+        // the mirror produces a clearly-separated copy at -X.
+        guard let box = Shape.box(width: 20, height: 20, depth: 20),
+              let translated = box.translated(by: SIMD3(20, 0, 0)) else {
+            Issue.record("Failed to synthesise box")
+            return
+        }
+        try Exporter.writeBREP(shape: translated, to: URL(fileURLWithPath: "\(scene)/src.brep"))
+        try ManifestStore(path: "\(scene)/manifest.json").write(ScriptManifest(
+            description: "find_correspondences mirror test",
+            bodies: [BodyDescriptor(id: "src", file: "src.brep", color: [1, 0, 0, 1])]
+        ))
+
+        let harness = try Harness(
+            binary: binary,
+            extraEnv: ["OCCTMCP_OUTPUT_DIR": scene]
+        )
+        defer { harness.terminate() }
+        try harness.handshake()
+
+        // Mirror the source about the YZ plane → produces "mirror-src" body.
+        try harness.send(.init(
+            id: 80, method: "tools/call",
+            params: .object([
+                "name": .string("mirror_or_pattern"),
+                "arguments": .object([
+                    "bodyId": .string("src"),
+                    "kind": .string("mirror"),
+                    "params": .object([
+                        "planeOrigin": .array([.double(0), .double(0), .double(0)]),
+                        "planeNormal": .array([.double(1), .double(0), .double(0)]),
+                    ]),
+                ]),
+            ])
+        ))
+        let mirrorResp = try harness.recv(timeout: 30)
+        #expect(mirrorResp["error"] == nil, "mirror_or_pattern errored: \(mirrorResp)")
+        if case .object(let mr)? = mirrorResp["result"],
+           case .array(let mc)? = mr["content"],
+           case .object(let mf)? = mc.first,
+           let mt = mf["text"]?.stringValue {
+            #expect(mt.contains("→ \"mirror-src\""),
+                    "mirror_or_pattern didn't produce mirror-src body: \(mt)")
+        }
+
+        // Pick a face on the source. Any face — `find_correspondences` is
+        // about transporting the pick, not about which face it is.
+        try harness.send(.init(
+            id: 81, method: "tools/call",
+            params: .object([
+                "name": .string("select_topology"),
+                "arguments": .object([
+                    "bodyId": .string("src"),
+                    "kind": .string("face"),
+                    "limit": .int(1),
+                ]),
+            ])
+        ))
+        let selResp = try harness.recv(timeout: 10)
+        guard case .object(let r1)? = selResp["result"],
+              case .array(let c1)? = r1["content"],
+              case .object(let f1)? = c1.first,
+              let t1 = f1["text"]?.stringValue else {
+            Issue.record("select_topology response missing text content: \(selResp)")
+            return
+        }
+        guard let d1 = t1.data(using: .utf8) else {
+            Issue.record("select_topology text not utf8: \(t1)")
+            return
+        }
+        guard let parsed = try? JSONSerialization.jsonObject(with: d1),
+              let p1 = parsed as? [String: Any] else {
+            Issue.record("select_topology text wasn't JSON object: t1=[\(t1)] selResp=\(selResp)")
+            return
+        }
+        guard let sels = p1["selections"] as? [[String: Any]],
+              let firstSel = sels.first,
+              let selectionId = firstSel["selectionId"] as? String else {
+            Issue.record("select_topology missing selections array: \(t1)")
+            return
+        }
+
+        // Same mirror plane the pattern used.
+        try harness.send(.init(
+            id: 82, method: "tools/call",
+            params: .object([
+                "name": .string("find_correspondences"),
+                "arguments": .object([
+                    "sourceSelectionIds": .array([.string(selectionId)]),
+                    "targetBodyId": .string("mirror-src"),
+                    "transform": .object([
+                        "kind": .string("mirror"),
+                        "planeOrigin": .array([.double(0), .double(0), .double(0)]),
+                        "planeNormal": .array([.double(1), .double(0), .double(0)]),
+                    ]),
+                ]),
+            ])
+        ))
+        let corrResp = try harness.recv(timeout: 10)
+        guard case .object(let r2)? = corrResp["result"],
+              case .array(let c2)? = r2["content"],
+              case .object(let f2)? = c2.first,
+              let t2 = f2["text"]?.stringValue else {
+            Issue.record("find_correspondences response missing text content: \(corrResp)")
+            return
+        }
+        guard let d2 = t2.data(using: .utf8),
+              let parsedCorr = try? JSONSerialization.jsonObject(with: d2),
+              let p2 = parsedCorr as? [String: Any] else {
+            Issue.record("find_correspondences text wasn't JSON object: t2=[\(t2)] corrResp=\(corrResp)")
+            return
+        }
+        guard let arr = p2["correspondences"] as? [[String: Any]],
+              let entry = arr.first else {
+            Issue.record("find_correspondences missing correspondences array: \(t2)")
+            return
+        }
+        let fate = entry["fate"] as? String ?? "<missing>"
+        #expect(fate == "matched", "expected matched, got \(fate) (entry: \(entry))")
+        let target = entry["targetSelectionId"] as? String ?? ""
+        #expect(target.hasPrefix("sel:mirror-src#face["),
+                "target selectionId should resolve onto the mirror body, got \(target)")
+        if let conf = entry["confidenceMm"] as? Double {
+            // Mirror is exact for axis-aligned faces; allow a generous
+            // floor for OCCT-tessellation centroid noise.
+            #expect(conf < 0.01, "expected near-zero match distance, got \(conf)")
+        }
+    }
+
     @Test("annotation tools round-trip via the sidecar")
     func annotationsRoundTrip() async throws {
         guard let binary = Self.binaryURL else {
@@ -817,7 +956,6 @@ final class Harness {
     func recv(timeout seconds: TimeInterval) throws -> [String: Value] {
         let deadline = Date().addingTimeInterval(seconds)
         while Date() < deadline {
-            // Try to peel a line out of pending.
             if let line = nextLine() {
                 let parsed = try JSONDecoder().decode(Value.self, from: line)
                 guard case .object(let dict) = parsed else {
@@ -825,7 +963,6 @@ final class Harness {
                 }
                 return dict
             }
-            // Read more from stdout, non-blocking-ish.
             let chunk = stdout.availableData
             if chunk.isEmpty {
                 try? Task.checkCancellation()


### PR DESCRIPTION
Closes #24.

## Summary

Three changes that ended up tangled together because implementing the new tool surfaced two latent bugs that hid each other.

### `find_correspondences` — new tool

`Sources/OCCTMCPCore/Tools/CorrespondenceTools.swift`. Maps `selectionId`s from a source body onto a target body that's a known transform of the source — typically a `mirror_or_pattern` output.

- Different contract from `remap_selection`: not "X mutated into Y on the same body" but "X on body A corresponds to Y on body B under transform T". Pattern instances aren't OCCT-derivatives of the source — pure-geometry algorithm: apply transform to each source anchor's centroid, find nearest target sub-shape of the same kind, report `matched | lost` with `confidenceMm`.
- v1 supports `translate / mirror / rotate` transform hints. Compound transforms, bbox-alignment inference, and reading `mirror_or_pattern` manifest metadata for transform defaults are listed in #24 and queued for follow-ups.
- Schema: `sourceSelectionIds`, `targetBodyId`, `transform.kind ∈ translate/mirror/rotate`. `toleranceMmFraction` defaults to 0.01 of the target bbox diagonal — same sizing as `remap_selection` so `confidenceMm` values are directly comparable.

### Bug fix — identity history was a placebo

OCCT's `TopologyGraph.findDerived` returns empty for identity records (`original == replacement`). The `recordIdentityHistory` loop in `HistoryRegistry` was writing exactly such no-op records for every face/edge/vertex, so `findDerived` always returned empty for them and `RemapTools` fell back to the centroid heuristic.

This was masked because every existing test that asserted `fate=preserved + confidenceMm=0` chose mutations where the centroid heuristic *also* returns 0: non-overlapping unions, holes on opposite-side faces, fillets that don't move face centroids — and translates that silently failed to parse (see next bug).

**Fix:** `HistoryRegistry` stores an `Entry { graph, isIdentityPreserving }` per `bodyId`. `recordIdentityHistory*` set the flag and skip the self-record loop. `recordBooleanHistory` / `recordSingleInputHistory` keep their explicit modified/generated/deleted records and clear the flag. `RemapTools.remapViaHistory` treats `findDerived empty + identityPreserving == true` as preserved-at-same-index. With this, `transform_body`'s history path is real for the first time.

### Bug fix — JSON ints decoding as `Value.int`, `doubleValue` returned nil

When a client encodes `Value.double(0)`, `JSONEncoder` writes `0` (no decimal). On the server, `Value`'s decoder tries `Int` first and gets `.int(0)`. Tool dispatches that read coordinate arrays via `arr[N].doubleValue` got nil, so `SIMD3` construction failed silently. LLMs sending `[0, 0, 1]` (the natural JSON shape for unit vectors) hit this constantly.

**Fix:** new `Value.asDouble` extension that accepts either `.int` or `.double`. Replaced 11 `arr[N].doubleValue` sites across `translate / rotate / mirror / pattern / circular / select_topology` dispatches plus the new `find_correspondences`. Three scalar sites also fixed: `angleDeg / spacing / toleranceMmFraction`.

The `transform_body` history test exposed both bugs at once: under bug 2, translate was a no-op so the centroid stayed put, masking bug 1. Fixing bug 2 alone made the test fail loudly, forcing the bug 1 fix.

## Test plan

- [x] `swift build` clean
- [x] `swift test` — 25 tests pass (was 24); added `findCorrespondencesAcrossMirror` end-to-end stdio: builds a 20³ box at +X, mirrors about YZ, picks a face on the source, calls `find_correspondences` with `kind=mirror`, asserts `fate=matched + target.hasPrefix("sel:mirror-src#face[") + confidenceMm < 0.01`.
- [x] Existing `historyRemapPreservesAcrossTransform` now actually exercises the history path (was a placebo) — verified by deliberately translating the body 20mm and asserting `confidenceMm == 0` (i.e. history short-circuited the heuristic that would have reported 20.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)