### PR TITLE
Consume OCCTSwift 1.1.0 (closes #167) + drop isIdentityPreserving workaround

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,18 +80,20 @@ OCCTSwift / OCCTSwiftViewport are kernel layers. `OCCTSwiftTools` is the bridge 
 
 `remap_selection` resolves a `selectionId` against the post-mutation state of a body via:
 
-1. `HistoryRegistry.entry(for: bodyId)` — if recorded:
-   - Walk `TopologyGraph.findDerived(originalRef:)`. Non-empty result → fate ∈ {preserved, split}, confidenceMm = 0.
-   - Empty result + `isIdentityPreserving` flag set → preserved at same index, confidenceMm = 0. (OCCT's `findDerived` skips identity records — original==replacement entries are no-ops in the OCCT history log — so we track topology-preserving ops via a flag and short-circuit instead of writing self-referencing records.)
-   - Empty result, flag not set → fall through to the heuristic (we can't tell unmodified from deleted without per-record introspection).
+1. `HistoryRegistry.graph(for: bodyId)` — if recorded, call `TopologyGraph.findDerivedOrSelf(originalRef:)` (OCCTSwift v1.1.0+):
+   - Non-empty derivatives → fate ∈ {preserved, split}, confidenceMm = 0.
+   - Empty result → explicitly recorded as deleted, fate = lost.
+   - `[self]` (no record at all) → preserved at same index, confidenceMm = 0.
 2. Centroid heuristic — load pre and post BREPs, find nearest face/edge/vertex within an epsilon. fate is preserved if within ε, lost otherwise. confidenceMm reports the centroid distance.
+
+`recordSingleInputHistory` and `recordBooleanHistory` skip writing identity records (`original → [original]`) so they fall through to the implicit `[self]` branch above. Without this, an OCCT-reported "modified to same index" would be conflated with an explicit delete by `findDerivedOrSelf`.
 
 Per-tool opt-in status:
 
 | Tool             | History path                              | Notes |
 |------------------|-------------------------------------------|-------|
-| `transform_body` | identity flag (topology preserved)        | every node maps 1:1 — `recordIdentityHistory` sets `isIdentityPreserving=true` |
-| `heal_shape`     | identity flag if pre/post counts match    | falls back to heuristic if shape repair changed topology |
+| `transform_body` | implicit identity (no records written)    | every node maps 1:1; `findDerivedOrSelf` returns `[self]` |
+| `heal_shape`     | implicit identity if pre/post counts match | falls back to heuristic if shape repair changed topology |
 | `boolean_op`     | per-input history via `recordBooleanHistory` | OCCTSwift `*WithFullHistory` variants; recorded under output + both inputs |
 | `apply_feature`  | per-feature history via `recordSingleInputHistory` | OCCTSwift v1.0.4 `FeatureReconstructor.BuildResult.histories[id]` — every spec kind (boolean / hole / second-additive / fillet / chamfer) populates a `ShapeHistoryRef` when the spec carries a non-nil id |
 
@@ -129,7 +131,7 @@ The Node server does not expose the v0.4+ tool surface (selection / remap / anno
 
 ### Swift implementation
 
-- **OCCTSwift** ≥ 1.0.4 — kernel wrapper around OpenCASCADE; full per-input history coverage for booleans + every `FeatureSpec` kind in `BuildResult.histories[id]`
+- **OCCTSwift** ≥ 1.1.0 — kernel wrapper around OpenCASCADE; full per-input history coverage for booleans + every `FeatureSpec` kind in `BuildResult.histories[id]`, plus `TopologyGraph.findDerivedOrSelf` / `hasHistoryRecord` for unambiguous untouched-vs-deleted resolution
 - **OCCTSwiftMesh** ≥ 1.0.0 — mesh-domain algorithms (QEM decimation today; smoothing / repair / remeshing in roadmap)
 - **OCCTSwiftScripts** ≥ 1.0.2 — provides `occtkit` (only used by `execute_script` and `export_scene`); also ships `ScriptHarness` + `DrawingComposer` consumed in-process
 - **OCCTSwiftTools** ≥ 1.1.0 — Shape↔ViewportBody bridge; ships `PointConverter` and wires `pointRadius` / `vertexColors` through to `ViewportBody`

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "66bfe2c6f785cadbd449d90d08c8a8b97ac64391ce4535dcd1a3ca34fa1f8313",
+  "originHash" : "3e4fe2f7f6a83e26bbf65eded57c297cfedf70cfc3359826e5f02e46b637edb4",
   "pins" : [
     {
       "identity" : "eventsource",
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/gsdali/OCCTSwift.git",
       "state" : {
-        "revision" : "1944312d7d2ed68dbb6ebe9c2626d3df3ab35475",
-        "version" : "1.0.4"
+        "revision" : "2124f0c63ed5750886b9235838cd3b866d3367ee",
+        "version" : "1.1.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -22,19 +22,23 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/modelcontextprotocol/swift-sdk.git", from: "0.11.0"),
-        // OCCT 8.0.0 GA cohort, fully aligned at v1.0.x.
+        // OCCT 8.0.0 GA cohort.
+        //
+        // OCCTSwift 1.1.0 closes gsdali/OCCTSwift#167: TopologyGraph
+        // gains `findDerivedOrSelf(of:)` and `hasHistoryRecord(for:)` —
+        // single-call disambiguation between untouched / modified /
+        // deleted nodes. Lets RemapTools drop its v1.3
+        // isIdentityPreserving flag workaround.
         //
         // OCCTSwift 1.0.4 closes gsdali/OCCTSwift#166: applyFillet /
-        // applyChamfer in FeatureReconstructor go through
-        // *WithFullHistory and populate BuildResult.histories[id] for
-        // every spec kind. apply_feature picks this up transparently
-        // (no consumer code change since v1.1).
+        // applyChamfer go through *WithFullHistory and populate
+        // BuildResult.histories[id] for every FeatureSpec kind.
         //
         // OCCTSwiftViewport 1.0.2 closes #28: Metal point-sprite
         // pipeline. Combined with OCCTSwiftTools 1.1.0 wiring
         // pointRadius / vertexColors through to ViewportBody, the
         // pointCloud annotation now actually renders.
-        .package(url: "https://github.com/gsdali/OCCTSwift.git", from: "1.0.4"),
+        .package(url: "https://github.com/gsdali/OCCTSwift.git", from: "1.1.0"),
         .package(url: "https://github.com/gsdali/OCCTSwiftMesh.git", from: "1.0.0"),
         .package(url: "https://github.com/gsdali/OCCTSwiftScripts.git", from: "1.0.2"),
         .package(url: "https://github.com/gsdali/OCCTSwiftTools.git", from: "1.1.0"),

--- a/Sources/OCCTMCPCore/HistoryRegistry.swift
+++ b/Sources/OCCTMCPCore/HistoryRegistry.swift
@@ -25,20 +25,10 @@ import OCCTSwift
 public actor HistoryRegistry {
     public static let shared = HistoryRegistry()
 
-    /// Per-body cached state. `isIdentityPreserving` is true when the
-    /// recorded mutation didn't change topology indices — every
-    /// pre-mutation node maps to the same index post-mutation. Used so
-    /// remap_selection can short-circuit `findDerived` (which OCCT
-    /// only populates for *changed* nodes — explicit
-    /// "original==replacement" identity records are no-ops in OCCT) and
-    /// just return the same index. Cleared/replaced when the body is
-    /// re-mutated.
-    public struct Entry: Sendable {
-        public let graph: TopologyGraph
-        public let isIdentityPreserving: Bool
-    }
-
-    private var entries: [String: Entry] = [:]
+    /// Per-body post-mutation `TopologyGraph`. Replaced when the body
+    /// is re-mutated. Consumed by `RemapTools` via
+    /// `TopologyGraph.findDerivedOrSelf` (OCCTSwift 1.1.0+).
+    private var graphs: [String: TopologyGraph] = [:]
 
     public init() {}
 
@@ -46,23 +36,19 @@ public actor HistoryRegistry {
     /// entry for the same body — older selectionIds remap against the
     /// most recent state only.
     public func record(bodyId: String, graph: TopologyGraph) {
-        entries[bodyId] = Entry(graph: graph, isIdentityPreserving: false)
-    }
-
-    public func entry(for bodyId: String) -> Entry? {
-        return entries[bodyId]
+        graphs[bodyId] = graph
     }
 
     public func graph(for bodyId: String) -> TopologyGraph? {
-        return entries[bodyId]?.graph
+        return graphs[bodyId]
     }
 
     public func clear() {
-        entries.removeAll()
+        graphs.removeAll()
     }
 
     public func count() -> Int {
-        return entries.count
+        return graphs.count
     }
 }
 
@@ -117,10 +103,9 @@ extension HistoryRegistry {
         // Same graph under all three keys so remap_selection finds it
         // regardless of which input the selectionId was originally
         // recorded against.
-        let entry = Entry(graph: postGraph, isIdentityPreserving: false)
-        entries[outId] = entry
-        entries[aBodyId] = entry
-        entries[bBodyId] = entry
+        graphs[outId] = postGraph
+        graphs[aBodyId] = postGraph
+        graphs[bBodyId] = postGraph
     }
 
     /// Translate a single-input `ShapeHistoryRef` (gsdali/OCCTSwift#165
@@ -150,7 +135,7 @@ extension HistoryRegistry {
             faceCentres: faceCentres, edgeCentres: edgeCentres, vertexCentres: vertexCentres,
             ref: ref, operationName: operationName
         )
-        entries[bodyId] = Entry(graph: postGraph, isIdentityPreserving: false)
+        graphs[bodyId] = postGraph
     }
 
     private func recordSide(
@@ -218,6 +203,16 @@ extension HistoryRegistry {
             // unrecorded so remap_selection's heuristic can still make
             // a guess rather than locking in "lost".
             guard !postIndices.isEmpty else { continue }
+            // Skip identity records (input mapped to its own index).
+            // OCCTSwift v1.1.0's `findDerivedOrSelf` returns [] when
+            // any history record names the original — including
+            // identity ones — which would conflate "modified to self"
+            // with "deleted". Leaving the identity case unrecorded
+            // makes findDerivedOrSelf return [self] correctly via the
+            // "no record at all → untouched" branch.
+            if !record.isDeleted && postIndices == [inputIndex] {
+                continue
+            }
             postGraph.recordHistory(
                 operationName: operationName,
                 original: TopologyGraph.NodeRef(kind: kind, index: inputIndex),
@@ -252,15 +247,13 @@ extension HistoryRegistry {
         postMutationShape: Shape,
         operationName: String
     ) {
-        // OCCT's history API treats `original == replacement` records
-        // as no-ops — `findDerived` returns empty for an identity-only
-        // record. Don't write anything; just register the post graph
-        // with the identity-preserving flag so RemapTools can
-        // short-circuit `findDerived` empties to "preserved at same
-        // index".
+        // No history records to write — transforms preserve topology
+        // 1:1 by construction. Register the post-mutation graph and
+        // let RemapTools' `findDerivedOrSelf` resolve every node to
+        // self (since none are mentioned in any record).
         _ = operationName
         guard let graph = TopologyGraph(shape: postMutationShape) else { return }
-        entries[bodyId] = Entry(graph: graph, isIdentityPreserving: true)
+        graphs[bodyId] = graph
     }
 
     /// Conditional version of `recordIdentityHistory` — only records
@@ -286,10 +279,10 @@ extension HistoryRegistry {
               pre.vertexCount == post.vertexCount else {
             return false
         }
-        // Same reasoning as `recordIdentityHistory` — skip the
-        // self-referencing record loop and just flag the entry.
+        // Topology preserved 1:1 — no records to write. RemapTools'
+        // `findDerivedOrSelf` resolves every node to self.
         _ = operationName
-        entries[bodyId] = Entry(graph: post, isIdentityPreserving: true)
+        graphs[bodyId] = post
         return true
     }
 }

--- a/Sources/OCCTMCPCore/Tools/RemapTools.swift
+++ b/Sources/OCCTMCPCore/Tools/RemapTools.swift
@@ -87,7 +87,7 @@ public enum RemapTools {
 
             // v0.6: prefer the recorded TopologyGraph history over the
             // centroid heuristic when a mutating tool opted in.
-            let recordedEntry = await historyRegistry.entry(for: bodyId)
+            let recordedGraph = await historyRegistry.graph(for: bodyId)
 
             for id in ids {
                 guard let anchor = await registry.anchor(for: id) else {
@@ -99,12 +99,11 @@ public enum RemapTools {
                     ))
                     continue
                 }
-                if let recorded = recordedEntry,
+                if let graph = recordedGraph,
                    let entry = remapViaHistory(
                        originalId: id,
                        anchor: anchor,
-                       graph: recorded.graph,
-                       isIdentityPreserving: recorded.isIdentityPreserving,
+                       graph: graph,
                        bodyId: bodyId
                    ) {
                     // Refresh the registry so the new selectionId
@@ -136,22 +135,16 @@ public enum RemapTools {
     }
 
     /// History-based remap path. Mirrors the AIS InteractiveContext.remap
-    /// algorithm: TopologyGraph.findDerived(of:) walks history records.
-    /// Returns nil if the anchor isn't a face/edge/vertex (body always
-    /// rebinds; whole-body picks aren't routed here).
-    ///
-    /// `isIdentityPreserving` flags ops like transform_body / heal_shape
-    /// where the topology graph is index-stable across the mutation —
-    /// every pre-mutation node maps 1:1 to the same index post-mutation.
-    /// OCCT's `findDerived` only walks recorded modifications, so an
-    /// untouched node returns an empty derivative list. For
-    /// identity-preserving ops we treat that as "preserved at the same
-    /// index" rather than falling back to the heuristic.
+    /// algorithm: TopologyGraph.findDerivedOrSelf(of:) returns either
+    /// the modification chain (touched nodes), [self] (untouched —
+    /// either no record or implicit identity), or [] (explicitly
+    /// recorded as deleted). Returns nil if the anchor isn't a
+    /// face/edge/vertex (body always rebinds; whole-body picks aren't
+    /// routed here).
     static func remapViaHistory(
         originalId: String,
         anchor: TopologyAnchor,
         graph: TopologyGraph,
-        isIdentityPreserving: Bool,
         bodyId: String
     ) -> RemapEntry? {
         let kind: TopologyGraph.NodeKind
@@ -178,27 +171,15 @@ public enum RemapTools {
         case .vertex:  kindCount = graph.vertexCount
         default:       kindCount = 0
         }
-        let derived = graph.findDerived(of: .init(kind: kind, index: originalIndex))
+        let derived = graph.findDerivedOrSelf(of: .init(kind: kind, index: originalIndex))
         if derived.isEmpty {
-            // Identity-preserving op + valid index → preserved at same
-            // index. Otherwise we can't tell (deleted vs untouched);
-            // hand off to the heuristic.
-            if isIdentityPreserving && originalIndex < kindCount {
-                let sameId: String
-                switch kind {
-                case .face:   sameId = TopologyAnchor.face(bodyId: bodyId, index: originalIndex).selectionId
-                case .edge:   sameId = TopologyAnchor.edge(bodyId: bodyId, index: originalIndex).selectionId
-                case .vertex: sameId = TopologyAnchor.vertex(bodyId: bodyId, index: originalIndex).selectionId
-                default:      return nil
-                }
-                return RemapEntry(
-                    originalSelectionId: originalId,
-                    newSelectionIds: [sameId],
-                    fate: "preserved",
-                    confidenceMm: 0
-                )
-            }
-            return nil
+            // Explicitly recorded as deleted — definitive.
+            return RemapEntry(
+                originalSelectionId: originalId,
+                newSelectionIds: [],
+                fate: "lost",
+                confidenceMm: 0
+            )
         }
         // Filter to same-kind derivatives and clamp to the live graph.
         let validIndices = derived


### PR DESCRIPTION
## Summary

[OCCTSwift v1.1.0](https://github.com/gsdali/OCCTSwift/releases/tag/v1.1.0) closes [#167](https://github.com/gsdali/OCCTSwift/issues/167) by shipping `TopologyGraph.findDerivedOrSelf(of:)` and `hasHistoryRecord(for:)` — unambiguous answers to "where did this node end up?":

- non-empty derivatives → modified
- `[]` → explicitly deleted
- `[self]` → no record at all (untouched)

This PR consumes that and collapses the v1.3 `isIdentityPreserving` flag back out.

- **`HistoryRegistry`** — `Entry { graph, isIdentityPreserving }` reverts to plain `[String: TopologyGraph]`. `recordIdentityHistory*` keep their topology-count guard but no longer write self-records or set a flag — the implicit-untouched branch of `findDerivedOrSelf` handles it.
- **`RemapTools.remapViaHistory`** — switches from `findDerived` + flag plumbing to `findDerivedOrSelf`. Empty result is now a definitive `fate=lost` (instead of falling through to the heuristic). Cleaner control flow.
- **`recordKind`** (inside `recordBoolean` / `recordSingleInputHistory`) — now skips writing identity records (input mapped to its own index in the post graph). Without this skip, OCCT-reported "modified to same index" cases get conflated with explicit deletes by `findDerivedOrSelf` — the fillet integration test exposed this on the cutover. Identity records add no information; leaving them implicit lets `findDerivedOrSelf`'s "no record → [self]" branch handle them correctly.
- **`Package.swift`** — OCCTSwift floor `1.0.4` → `1.1.0`.

CLAUDE.md history matrix + deps section updated.

## Test plan

- [x] `swift build` clean
- [x] `swift test` — 25/25 (same surface as v1.3.0; no new tests, no removed tests)
- [x] All four history-asserting integration tests still pass: `historyRemapPreservesAcrossTransform` / `historyRemapAcrossBooleanOp` / `historyRemapAcrossApplyFeature` / `historyRemapAcrossFilletFeature`. The fillet one only passes after the recordKind identity-skip fix landed — proves we're now exercising the `findDerivedOrSelf` semantics correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)