### PR TITLE
chore: pin swift-sdk to fork branch shipping numberValue

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "3e4fe2f7f6a83e26bbf65eded57c297cfedf70cfc3359826e5f02e46b637edb4",
+  "originHash" : "e0b7a2f3ec455ed401f83f59070c829b14888ac3852815897476c4eacce31acc",
   "pins" : [
     {
       "identity" : "eventsource",
@@ -87,8 +87,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-collections.git",
       "state" : {
-        "revision" : "6675bc0ff86e61436e615df6fc5174e043e57924",
-        "version" : "1.4.1"
+        "revision" : "03cc312c2c933ed87abace34044a5dff7a3117c1",
+        "version" : "1.5.0"
       }
     },
     {
@@ -112,10 +112,10 @@
     {
       "identity" : "swift-sdk",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/modelcontextprotocol/swift-sdk.git",
+      "location" : "https://github.com/gsdali/swift-sdk.git",
       "state" : {
-        "revision" : "6132fd4b5b4217ce4717c4775e4607f5c3120129",
-        "version" : "0.12.0"
+        "branch" : "add-value-numbervalue",
+        "revision" : "62ac56f107f02728f63764d38176a7cf20e47785"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -21,7 +21,13 @@ let package = Package(
         .executable(name: "occtmcp-server", targets: ["OCCTMCPServer"]),
     ],
     dependencies: [
-        .package(url: "https://github.com/modelcontextprotocol/swift-sdk.git", from: "0.11.0"),
+        // Temporary pin against gsdali's swift-sdk fork while
+        // modelcontextprotocol/swift-sdk#226 is in review. Upstream
+        // tag floor goes back to `from: "0.11.0"` once the PR merges.
+        // The branch ships `Value.numberValue` (proposed in upstream
+        // #225) — Server.swift consumes it directly so we delete our
+        // own back-port the moment upstream lands.
+        .package(url: "https://github.com/gsdali/swift-sdk.git", branch: "add-value-numbervalue"),
         // OCCT 8.0.0 GA cohort.
         //
         // OCCTSwift 1.1.0 closes gsdali/OCCTSwift#167: TopologyGraph

--- a/Sources/OCCTMCPCore/Server.swift
+++ b/Sources/OCCTMCPCore/Server.swift
@@ -15,18 +15,6 @@ public enum OCCTMCPVersion {
     public static let serverVersion = "0.1.0"
 }
 
-extension Value {
-    /// Numeric coercion for tool dispatch — JSON whole numbers
-    /// (`[0, 0, 1]`) decode as `.int` per the SDK's Codable, but every
-    /// numeric coordinate / scalar in our schemas wants a `Double`.
-    /// `doubleValue` alone misses ints; this helper accepts either.
-    var asDouble: Double? {
-        if let d = doubleValue { return d }
-        if let i = intValue { return Double(i) }
-        return nil
-    }
-}
-
 /// Build a fully-configured MCP server with every OCCTMCP tool registered.
 /// Caller is responsible for `start(transport:)` and `waitUntilCompleted()`.
 public func makeOCCTMCPServer() async -> Server {
@@ -983,7 +971,7 @@ func parseRenderOptions(_ value: Value?) -> RenderPreviewTool.Options {
     }
     func vec3(_ key: String) -> SIMD3<Float>? {
         guard let arr = o[key]?.arrayValue, arr.count == 3,
-              let x = arr[0].asDouble, let y = arr[1].asDouble, let z = arr[2].asDouble else { return nil }
+              let x = arr[0].numberValue, let y = arr[1].numberValue, let z = arr[2].numberValue else { return nil }
         return SIMD3(Float(x), Float(y), Float(z))
     }
     opts.cameraPosition = vec3("cameraPosition")
@@ -1073,7 +1061,7 @@ func dispatch(callName: String, arguments: [String: Value]) async -> CallTool.Re
         guard let ids = arguments["selectionIds"]?.arrayValue?.compactMap({ $0.stringValue }), !ids.isEmpty else {
             return ToolText("remap_selection requires `selectionIds` array.", isError: true).asCallToolResult()
         }
-        let tol = arguments["toleranceMmFraction"]?.asDouble ?? 0.01
+        let tol = arguments["toleranceMmFraction"]?.numberValue ?? 0.01
         return await RemapTools.remapSelection(
             selectionIds: ids, toleranceMmFraction: tol
         ).asCallToolResult()
@@ -1093,18 +1081,18 @@ func dispatch(callName: String, arguments: [String: Value]) async -> CallTool.Re
         switch kind {
         case "translate":
             guard let arr = t["offset"]?.arrayValue, arr.count == 3,
-                  let x = arr[0].asDouble, let y = arr[1].asDouble, let z = arr[2].asDouble else {
+                  let x = arr[0].numberValue, let y = arr[1].numberValue, let z = arr[2].numberValue else {
                 return ToolText("translate requires `offset: [x, y, z]`.", isError: true).asCallToolResult()
             }
             transform = .translate(offset: SIMD3(x, y, z))
         case "mirror":
             guard let nArr = t["planeNormal"]?.arrayValue, nArr.count == 3,
-                  let nx = nArr[0].asDouble, let ny = nArr[1].asDouble, let nz = nArr[2].asDouble else {
+                  let nx = nArr[0].numberValue, let ny = nArr[1].numberValue, let nz = nArr[2].numberValue else {
                 return ToolText("mirror requires `planeNormal: [x, y, z]`.", isError: true).asCallToolResult()
             }
             let origin: SIMD3<Double>
             if let oArr = t["planeOrigin"]?.arrayValue, oArr.count == 3,
-               let ox = oArr[0].asDouble, let oy = oArr[1].asDouble, let oz = oArr[2].asDouble {
+               let ox = oArr[0].numberValue, let oy = oArr[1].numberValue, let oz = oArr[2].numberValue {
                 origin = SIMD3(ox, oy, oz)
             } else {
                 origin = .zero
@@ -1112,10 +1100,10 @@ func dispatch(callName: String, arguments: [String: Value]) async -> CallTool.Re
             transform = .mirror(planeOrigin: origin, planeNormal: SIMD3(nx, ny, nz))
         case "rotate":
             guard let oArr = t["axisOrigin"]?.arrayValue, oArr.count == 3,
-                  let ox = oArr[0].asDouble, let oy = oArr[1].asDouble, let oz = oArr[2].asDouble,
+                  let ox = oArr[0].numberValue, let oy = oArr[1].numberValue, let oz = oArr[2].numberValue,
                   let dArr = t["axisDirection"]?.arrayValue, dArr.count == 3,
-                  let dx = dArr[0].asDouble, let dy = dArr[1].asDouble, let dz = dArr[2].asDouble,
-                  let angle = t["angleDeg"]?.asDouble else {
+                  let dx = dArr[0].numberValue, let dy = dArr[1].numberValue, let dz = dArr[2].numberValue,
+                  let angle = t["angleDeg"]?.numberValue else {
                 return ToolText("rotate requires `axisOrigin`, `axisDirection`, `angleDeg`.", isError: true).asCallToolResult()
             }
             transform = .rotate(
@@ -1126,7 +1114,7 @@ func dispatch(callName: String, arguments: [String: Value]) async -> CallTool.Re
         default:
             return ToolText("transform.kind must be one of `translate`, `mirror`, `rotate`.", isError: true).asCallToolResult()
         }
-        let tol = arguments["toleranceMmFraction"]?.asDouble ?? 0.01
+        let tol = arguments["toleranceMmFraction"]?.numberValue ?? 0.01
         return await CorrespondenceTools.findCorrespondences(
             sourceSelectionIds: ids,
             targetBodyId: targetId,
@@ -1166,7 +1154,7 @@ func dispatch(callName: String, arguments: [String: Value]) async -> CallTool.Re
             filter.minLength = f["minLength"]?.doubleValue
             filter.maxLength = f["maxLength"]?.doubleValue
             if let arr = f["normalDirection"]?.arrayValue, arr.count == 3,
-               let x = arr[0].asDouble, let y = arr[1].asDouble, let z = arr[2].asDouble {
+               let x = arr[0].numberValue, let y = arr[1].numberValue, let z = arr[2].numberValue {
                 filter.normalDirection = SIMD3(x, y, z)
             }
             filter.normalTolerance = f["normalTolerance"]?.doubleValue
@@ -1419,16 +1407,16 @@ func dispatch(callName: String, arguments: [String: Value]) async -> CallTool.Re
         }
         var opts = ConstructionTools.TransformOptions()
         if let arr = arguments["translate"]?.arrayValue, arr.count == 3,
-           let x = arr[0].asDouble, let y = arr[1].asDouble, let z = arr[2].asDouble {
+           let x = arr[0].numberValue, let y = arr[1].numberValue, let z = arr[2].numberValue {
             opts.translate = SIMD3(x, y, z)
         }
         if let arr = arguments["rotateAxisAngle"]?.arrayValue, arr.count == 4,
-           let x = arr[0].asDouble, let y = arr[1].asDouble, let z = arr[2].asDouble,
+           let x = arr[0].numberValue, let y = arr[1].numberValue, let z = arr[2].numberValue,
            let r = arr[3].doubleValue {
             opts.rotateAxisAngle = (SIMD3(x, y, z), r)
         }
         if let arr = arguments["rotateEulerXyz"]?.arrayValue, arr.count == 3,
-           let x = arr[0].asDouble, let y = arr[1].asDouble, let z = arr[2].asDouble {
+           let x = arr[0].numberValue, let y = arr[1].numberValue, let z = arr[2].numberValue {
             opts.rotateEulerXyz = SIMD3(x, y, z)
         }
         opts.scale = arguments["scale"]?.doubleValue
@@ -1459,25 +1447,25 @@ func dispatch(callName: String, arguments: [String: Value]) async -> CallTool.Re
         var p = ConstructionTools.PatternParams()
         if case .object(let f)? = arguments["params"] {
             if let arr = f["planeOrigin"]?.arrayValue, arr.count == 3,
-               let x = arr[0].asDouble, let y = arr[1].asDouble, let z = arr[2].asDouble {
+               let x = arr[0].numberValue, let y = arr[1].numberValue, let z = arr[2].numberValue {
                 p.planeOrigin = SIMD3(x, y, z)
             }
             if let arr = f["planeNormal"]?.arrayValue, arr.count == 3,
-               let x = arr[0].asDouble, let y = arr[1].asDouble, let z = arr[2].asDouble {
+               let x = arr[0].numberValue, let y = arr[1].numberValue, let z = arr[2].numberValue {
                 p.planeNormal = SIMD3(x, y, z)
             }
             if let arr = f["direction"]?.arrayValue, arr.count == 3,
-               let x = arr[0].asDouble, let y = arr[1].asDouble, let z = arr[2].asDouble {
+               let x = arr[0].numberValue, let y = arr[1].numberValue, let z = arr[2].numberValue {
                 p.direction = SIMD3(x, y, z)
             }
-            p.spacing = f["spacing"]?.asDouble
+            p.spacing = f["spacing"]?.numberValue
             p.count = f["count"]?.intValue
             if let arr = f["axisOrigin"]?.arrayValue, arr.count == 3,
-               let x = arr[0].asDouble, let y = arr[1].asDouble, let z = arr[2].asDouble {
+               let x = arr[0].numberValue, let y = arr[1].numberValue, let z = arr[2].numberValue {
                 p.axisOrigin = SIMD3(x, y, z)
             }
             if let arr = f["axisDirection"]?.arrayValue, arr.count == 3,
-               let x = arr[0].asDouble, let y = arr[1].asDouble, let z = arr[2].asDouble {
+               let x = arr[0].numberValue, let y = arr[1].numberValue, let z = arr[2].numberValue {
                 p.axisDirection = SIMD3(x, y, z)
             }
             p.totalCount = f["totalCount"]?.intValue


### PR DESCRIPTION
## Summary

Eats our own dog food on [modelcontextprotocol/swift-sdk#226](https://github.com/modelcontextprotocol/swift-sdk/pull/226) (closes upstream [#225](https://github.com/modelcontextprotocol/swift-sdk/issues/225)). The fork branch (`gsdali/swift-sdk#add-value-numbervalue`) ships `Value.numberValue` — exactly the helper our `Server.swift` dispatch wanted.

- **Package.swift** — dep flips from `modelcontextprotocol/swift-sdk from: "0.11.0"` to `gsdali/swift-sdk branch: "add-value-numbervalue"` with a comment noting the pin is temporary and reverts to the upstream tag floor once #226 merges.
- **Server.swift** — drops the local `extension Value { var asDouble }` back-port (added in v1.3) and switches all 19 dispatch sites (translate / rotate / mirror / pattern / circular / select_topology / find_correspondences scalar + array reads) from `.asDouble` to `.numberValue`. Identical semantics; we just stop maintaining a private copy.

No release tag for this — main is intentionally on a fork pin until upstream merges. The moment upstream lands we revert `Package.swift` to `from: "0.11.0"` and tag a release.

## Test plan

- [x] `swift build` clean
- [x] `swift test` — 25/25
- [x] `swift package resolve` pulls the fork branch (`gsdali/swift-sdk @ add-value-numbervalue (62ac56f)`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)