### PR TITLE
find_correspondences extras: compound + provenance + bbox inference (closes the rest of #24)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,7 +97,14 @@ Per-tool opt-in status:
 | `boolean_op`     | per-input history via `recordBooleanHistory` | OCCTSwift `*WithFullHistory` variants; recorded under output + both inputs |
 | `apply_feature`  | per-feature history via `recordSingleInputHistory` | OCCTSwift v1.0.4 `FeatureReconstructor.BuildResult.histories[id]` — every spec kind (boolean / hole / second-additive / fillet / chamfer) populates a `ShapeHistoryRef` when the spec carries a non-nil id |
 
-`mirror_or_pattern` doesn't fit `remap_selection`'s contract (it produces new bodies rather than mutating in place). For that case use `find_correspondences`, which takes a source body, target body, and explicit `transform` (translate / mirror / rotate), applies the transform to each source anchor's centroid, and finds the nearest same-kind sub-shape on the target. Pure geometry, no OCCT history involved — appropriate because pattern instances aren't OCCT-derivatives of the source.
+`mirror_or_pattern` doesn't fit `remap_selection`'s contract (it produces new bodies rather than mutating in place). For that case use `find_correspondences`, which takes a source body and target body and applies a transform to each source anchor's centroid before nearest-neighbour search on the target. Pure geometry, no OCCT history involved — pattern instances aren't OCCT-derivatives of the source.
+
+`find_correspondences`'s `transform` is optional. Resolution order:
+1. **Explicit hint** — `translate` / `mirror` / `rotate` / `compound { steps: [...] }` (the last one is a recursive composition applied in array order). Codable, so the same JSON shape works in tool args and on disk.
+2. **`<output_dir>/provenance.json`** — `mirror_or_pattern` writes its mirror plane here for every output body it produces. (Linear / circular patterns produce N copies, which don't fit the single-target return shape, so they're skipped.)
+3. **Bbox-translation inference** — if source and target bbox sizes match, transform is the centroid delta. Catch-all for `execute_script`-built duplicates that didn't record anything.
+
+The response includes `transformSource ∈ {explicit, provenance, bbox-inference, identity-fallback}` so callers can tell which path resolved.
 
 ### Data flow for `execute_script`
 

--- a/Sources/OCCTMCPCore/Provenance.swift
+++ b/Sources/OCCTMCPCore/Provenance.swift
@@ -1,0 +1,70 @@
+// Provenance — `<output_dir>/provenance.json` sidecar that records how
+// derived bodies were created from source bodies. Currently populated
+// only by `mirror_or_pattern` so `find_correspondences` can default
+// `transformHint` from the manifest when the LLM omits it.
+//
+// Format is a top-level object keyed by body id:
+// {
+//   "mirror-src": {
+//     "sourceBodyId": "src",
+//     "transform": { "kind": "mirror", "planeOrigin": [...], "planeNormal": [...] }
+//   }
+// }
+//
+// Sibling-not-substitute to the scene manifest. Manifest is owned by
+// ScriptHarness and we don't want to fork its schema; provenance is a
+// separate file that only OCCTMCP reads/writes.
+
+import Foundation
+
+public struct ProvenanceRecord: Codable, Sendable {
+    public let sourceBodyId: String
+    public let transform: CorrespondenceTools.TransformHint
+
+    public init(sourceBodyId: String, transform: CorrespondenceTools.TransformHint) {
+        self.sourceBodyId = sourceBodyId
+        self.transform = transform
+    }
+}
+
+public struct ProvenanceStore: Sendable {
+    public let path: String
+
+    public init(outputDir: String) {
+        self.path = "\(outputDir)/provenance.json"
+    }
+
+    /// Whole-file read. Returns an empty dictionary when the sidecar
+    /// doesn't exist yet — callers don't need to distinguish "no
+    /// provenance recorded for this body" from "no sidecar at all".
+    public func read() -> [String: ProvenanceRecord] {
+        guard FileManager.default.fileExists(atPath: path),
+              let data = try? Data(contentsOf: URL(fileURLWithPath: path)) else {
+            return [:]
+        }
+        return (try? JSONDecoder().decode([String: ProvenanceRecord].self, from: data)) ?? [:]
+    }
+
+    /// Merge `record` for `bodyId` into the sidecar, replacing any
+    /// prior entry under the same id. Atomic write so partial state
+    /// can never be observed.
+    public func upsert(bodyId: String, record: ProvenanceRecord) {
+        var current = read()
+        current[bodyId] = record
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        guard let data = try? encoder.encode(current) else { return }
+        try? data.write(to: URL(fileURLWithPath: path), options: .atomic)
+    }
+
+    /// Drop `bodyId`'s record. No-op if not present. Used by the
+    /// scene-mutation tools that delete bodies.
+    public func remove(bodyId: String) {
+        var current = read()
+        guard current.removeValue(forKey: bodyId) != nil else { return }
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        guard let data = try? encoder.encode(current) else { return }
+        try? data.write(to: URL(fileURLWithPath: path), options: .atomic)
+    }
+}

--- a/Sources/OCCTMCPCore/Server.swift
+++ b/Sources/OCCTMCPCore/Server.swift
@@ -395,7 +395,7 @@ func catalogTools() -> [Tool] {
         ),
         Tool(
             name: "find_correspondences",
-            description: "Map selectionIds from a source body onto a target body that's a known transform of the source (typically a mirror_or_pattern output). Apply `transform` to each source anchor's centroid, then find the nearest same-kind sub-shape on the target. Returns each source id mapped to one target selectionId (or null) with confidenceMm + fate ('matched' | 'lost'). Use this for cross-body workflows; remap_selection is for the within-body case.",
+            description: "Map selectionIds from a source body onto a target body that's a known transform of the source (typically a mirror_or_pattern output). Returns each source id mapped to one target selectionId (or null) with confidenceMm + fate ('matched' | 'lost'). `transform` is optional: when omitted, falls back to provenance metadata recorded by mirror_or_pattern, then to bbox-translation inference. Use this for cross-body workflows; remap_selection is for the within-body case.",
             inputSchema: .object([
                 "type": .string("object"),
                 "properties": .object([
@@ -406,11 +406,14 @@ func catalogTools() -> [Tool] {
                     "targetBodyId": .object(["type": .string("string")]),
                     "transform": .object([
                         "type": .string("object"),
-                        "description": .string("Transform applied to source anchors before nearest-neighbour search on the target. Exactly one of `translate` / `mirror` / `rotate` is required."),
+                        "description": .string("Optional. Transform applied to source anchors before nearest-neighbour search. Exactly one of `translate` / `mirror` / `rotate` / `compound` per object. `compound.steps` is an array of nested transform objects applied in order."),
                         "properties": .object([
                             "kind": .object([
                                 "type": .string("string"),
-                                "enum": .array([.string("translate"), .string("mirror"), .string("rotate")]),
+                                "enum": .array([
+                                    .string("translate"), .string("mirror"),
+                                    .string("rotate"),    .string("compound"),
+                                ]),
                             ]),
                             "offset": .object([
                                 "type": .string("array"),
@@ -441,6 +444,11 @@ func catalogTools() -> [Tool] {
                                 "type": .string("number"),
                                 "description": .string("rotate: angle in degrees, right-hand rule about axisDirection"),
                             ]),
+                            "steps": .object([
+                                "type": .string("array"),
+                                "description": .string("compound: array of transform objects applied in order"),
+                                "items": .object(["type": .string("object")]),
+                            ]),
                         ]),
                         "required": .array([.string("kind")]),
                     ]),
@@ -449,7 +457,7 @@ func catalogTools() -> [Tool] {
                         "description": .string("Fraction of target bbox diagonal to use as the match tolerance. Default 0.01."),
                     ]),
                 ]),
-                "required": .array([.string("sourceSelectionIds"), .string("targetBodyId"), .string("transform")]),
+                "required": .array([.string("sourceSelectionIds"), .string("targetBodyId")]),
                 "additionalProperties": .bool(false),
             ])
         ),
@@ -1073,46 +1081,20 @@ func dispatch(callName: String, arguments: [String: Value]) async -> CallTool.Re
         guard let targetId = arguments["targetBodyId"]?.stringValue else {
             return ToolText("find_correspondences requires `targetBodyId`.", isError: true).asCallToolResult()
         }
-        guard case .object(let t)? = arguments["transform"],
-              let kind = t["kind"]?.stringValue else {
-            return ToolText("find_correspondences requires `transform.kind`.", isError: true).asCallToolResult()
-        }
-        let transform: CorrespondenceTools.TransformHint
-        switch kind {
-        case "translate":
-            guard let arr = t["offset"]?.arrayValue, arr.count == 3,
-                  let x = arr[0].numberValue, let y = arr[1].numberValue, let z = arr[2].numberValue else {
-                return ToolText("translate requires `offset: [x, y, z]`.", isError: true).asCallToolResult()
+        // transform is now optional — find_correspondences falls back
+        // to provenance metadata (mirror_or_pattern emits this) and
+        // then bbox-translation inference when omitted.
+        var transform: CorrespondenceTools.TransformHint?
+        if let transformValue = arguments["transform"] {
+            do {
+                let data = try JSONEncoder().encode(transformValue)
+                transform = try JSONDecoder().decode(CorrespondenceTools.TransformHint.self, from: data)
+            } catch {
+                return ToolText(
+                    "transform parse failed: \(error.localizedDescription)",
+                    isError: true
+                ).asCallToolResult()
             }
-            transform = .translate(offset: SIMD3(x, y, z))
-        case "mirror":
-            guard let nArr = t["planeNormal"]?.arrayValue, nArr.count == 3,
-                  let nx = nArr[0].numberValue, let ny = nArr[1].numberValue, let nz = nArr[2].numberValue else {
-                return ToolText("mirror requires `planeNormal: [x, y, z]`.", isError: true).asCallToolResult()
-            }
-            let origin: SIMD3<Double>
-            if let oArr = t["planeOrigin"]?.arrayValue, oArr.count == 3,
-               let ox = oArr[0].numberValue, let oy = oArr[1].numberValue, let oz = oArr[2].numberValue {
-                origin = SIMD3(ox, oy, oz)
-            } else {
-                origin = .zero
-            }
-            transform = .mirror(planeOrigin: origin, planeNormal: SIMD3(nx, ny, nz))
-        case "rotate":
-            guard let oArr = t["axisOrigin"]?.arrayValue, oArr.count == 3,
-                  let ox = oArr[0].numberValue, let oy = oArr[1].numberValue, let oz = oArr[2].numberValue,
-                  let dArr = t["axisDirection"]?.arrayValue, dArr.count == 3,
-                  let dx = dArr[0].numberValue, let dy = dArr[1].numberValue, let dz = dArr[2].numberValue,
-                  let angle = t["angleDeg"]?.numberValue else {
-                return ToolText("rotate requires `axisOrigin`, `axisDirection`, `angleDeg`.", isError: true).asCallToolResult()
-            }
-            transform = .rotate(
-                axisOrigin: SIMD3(ox, oy, oz),
-                axisDirection: SIMD3(dx, dy, dz),
-                angleDeg: angle
-            )
-        default:
-            return ToolText("transform.kind must be one of `translate`, `mirror`, `rotate`.", isError: true).asCallToolResult()
         }
         let tol = arguments["toleranceMmFraction"]?.numberValue ?? 0.01
         return await CorrespondenceTools.findCorrespondences(

--- a/Sources/OCCTMCPCore/Tools/ConstructionTools.swift
+++ b/Sources/OCCTMCPCore/Tools/ConstructionTools.swift
@@ -422,6 +422,26 @@ public enum ConstructionTools {
         )
         try? store.write(updated)
 
+        // Mirror provenance — single-target case fits
+        // find_correspondences's "one target id per source id" contract.
+        // Linear / circular patterns produce N copies, so a single
+        // TransformHint can't describe the full mapping; skip those
+        // until find_correspondences grows a multi-target return type.
+        if kind == .mirror,
+           let normal = params.planeNormal {
+            let provenance = ProvenanceStore(outputDir: outputDir)
+            provenance.upsert(
+                bodyId: outId,
+                record: ProvenanceRecord(
+                    sourceBodyId: bodyId,
+                    transform: .mirror(
+                        planeOrigin: params.planeOrigin ?? .zero,
+                        planeNormal: normal
+                    )
+                )
+            )
+        }
+
         return .init("Pattern \(kind.rawValue) on \"\(bodyId)\" → \"\(outId)\" (\(outFile)).")
     }
 

--- a/Sources/OCCTMCPCore/Tools/CorrespondenceTools.swift
+++ b/Sources/OCCTMCPCore/Tools/CorrespondenceTools.swift
@@ -27,10 +27,84 @@ import ScriptHarness
 
 public enum CorrespondenceTools {
 
-    public enum TransformHint: Sendable {
+    public indirect enum TransformHint: Sendable, Codable {
         case translate(offset: SIMD3<Double>)
         case mirror(planeOrigin: SIMD3<Double>, planeNormal: SIMD3<Double>)
         case rotate(axisOrigin: SIMD3<Double>, axisDirection: SIMD3<Double>, angleDeg: Double)
+        case compound(steps: [TransformHint])
+
+        private enum CodingKeys: String, CodingKey {
+            case kind, offset, planeOrigin, planeNormal, axisOrigin, axisDirection, angleDeg, steps
+        }
+
+        public init(from decoder: Decoder) throws {
+            let c = try decoder.container(keyedBy: CodingKeys.self)
+            let kind = try c.decode(String.self, forKey: .kind)
+            switch kind {
+            case "translate":
+                let arr = try c.decode([Double].self, forKey: .offset)
+                guard arr.count == 3 else {
+                    throw DecodingError.dataCorruptedError(forKey: .offset, in: c,
+                        debugDescription: "translate.offset must be [x, y, z]")
+                }
+                self = .translate(offset: SIMD3(arr[0], arr[1], arr[2]))
+            case "mirror":
+                let nArr = try c.decode([Double].self, forKey: .planeNormal)
+                guard nArr.count == 3 else {
+                    throw DecodingError.dataCorruptedError(forKey: .planeNormal, in: c,
+                        debugDescription: "mirror.planeNormal must be [x, y, z]")
+                }
+                let origin: SIMD3<Double>
+                if let oArr = try c.decodeIfPresent([Double].self, forKey: .planeOrigin),
+                   oArr.count == 3 {
+                    origin = SIMD3(oArr[0], oArr[1], oArr[2])
+                } else {
+                    origin = .zero
+                }
+                self = .mirror(planeOrigin: origin,
+                               planeNormal: SIMD3(nArr[0], nArr[1], nArr[2]))
+            case "rotate":
+                let oArr = try c.decode([Double].self, forKey: .axisOrigin)
+                let dArr = try c.decode([Double].self, forKey: .axisDirection)
+                let angle = try c.decode(Double.self, forKey: .angleDeg)
+                guard oArr.count == 3, dArr.count == 3 else {
+                    throw DecodingError.dataCorruptedError(forKey: .axisOrigin, in: c,
+                        debugDescription: "rotate.axisOrigin / axisDirection must be [x, y, z]")
+                }
+                self = .rotate(
+                    axisOrigin: SIMD3(oArr[0], oArr[1], oArr[2]),
+                    axisDirection: SIMD3(dArr[0], dArr[1], dArr[2]),
+                    angleDeg: angle
+                )
+            case "compound":
+                let steps = try c.decode([TransformHint].self, forKey: .steps)
+                self = .compound(steps: steps)
+            default:
+                throw DecodingError.dataCorruptedError(forKey: .kind, in: c,
+                    debugDescription: "unknown transform kind: \(kind)")
+            }
+        }
+
+        public func encode(to encoder: Encoder) throws {
+            var c = encoder.container(keyedBy: CodingKeys.self)
+            switch self {
+            case .translate(let o):
+                try c.encode("translate", forKey: .kind)
+                try c.encode([o.x, o.y, o.z], forKey: .offset)
+            case .mirror(let origin, let normal):
+                try c.encode("mirror", forKey: .kind)
+                try c.encode([origin.x, origin.y, origin.z], forKey: .planeOrigin)
+                try c.encode([normal.x, normal.y, normal.z], forKey: .planeNormal)
+            case .rotate(let origin, let dir, let angle):
+                try c.encode("rotate", forKey: .kind)
+                try c.encode([origin.x, origin.y, origin.z], forKey: .axisOrigin)
+                try c.encode([dir.x, dir.y, dir.z], forKey: .axisDirection)
+                try c.encode(angle, forKey: .angleDeg)
+            case .compound(let steps):
+                try c.encode("compound", forKey: .kind)
+                try c.encode(steps, forKey: .steps)
+            }
+        }
 
         /// Apply to a single point.
         func apply(_ p: SIMD3<Double>) -> SIMD3<Double> {
@@ -52,6 +126,8 @@ public enum CorrespondenceTools {
                     + simd_cross(axis, v) * s
                     + axis * simd_dot(axis, v) * oneMinusC
                 return origin + rotated
+            case .compound(let steps):
+                return steps.reduce(p) { $1.apply($0) }
             }
         }
     }
@@ -65,6 +141,13 @@ public enum CorrespondenceTools {
 
     public struct CorrespondencesReport: Encodable {
         public let correspondences: [Correspondence]
+        /// Where the effective transform came from:
+        /// `"explicit"` (caller-supplied), `"provenance"` (read from
+        /// `<output_dir>/provenance.json`), `"bbox-inference"`
+        /// (translation derived from bbox alignment), or
+        /// `"identity-fallback"` (no hint and inference failed —
+        /// returns a zero-translation default).
+        public let transformSource: String
     }
 
     /// Resolve correspondences from `sourceSelectionIds` onto `targetBodyId`
@@ -75,10 +158,18 @@ public enum CorrespondenceTools {
     /// by minimum centroid distance. Tolerance defaults to 1% of the
     /// target body's bbox diagonal — same sizing as remap_selection's
     /// heuristic so confidence values are directly comparable.
+    ///
+    /// `transform` is optional. When omitted:
+    ///   1. read `<output_dir>/provenance.json` — `mirror_or_pattern`
+    ///      records its mirror plane there for every output body.
+    ///   2. fall back to bbox-translation inference: source and
+    ///      target bbox sizes match, transform is the centroid delta.
+    /// Both fallbacks are best-effort. Callers that want a specific
+    /// transform should pass it explicitly.
     public static func findCorrespondences(
         sourceSelectionIds: [String],
         targetBodyId: String,
-        transform: TransformHint,
+        transform: TransformHint?,
         toleranceMmFraction: Double = 0.01,
         store: ManifestStore = ManifestStore(),
         registry: SelectionRegistry = .shared
@@ -94,6 +185,30 @@ public enum CorrespondenceTools {
         guard FileManager.default.fileExists(atPath: targetPath),
               let targetShape = try? Shape.loadBREP(fromPath: targetPath) else {
             return .init("Target BREP missing or unreadable: \(targetPath)")
+        }
+
+        // Resolve the effective transform — explicit hint wins; then
+        // provenance.json (mirror_or_pattern's record); then bbox
+        // inference. If all three fail we report transform=nil but
+        // continue with identity, since the caller might just want
+        // index-aligned matching on truly identical bodies.
+        let resolvedTransform: TransformHint
+        let transformSource: String
+        if let hint = transform {
+            resolvedTransform = hint
+            transformSource = "explicit"
+        } else if let prov = ProvenanceStore(outputDir: outputDir).read()[targetBodyId] {
+            resolvedTransform = prov.transform
+            transformSource = "provenance"
+        } else if let inferred = inferTranslation(
+            manifest: manifest, outputDir: outputDir,
+            targetShape: targetShape, targetBodyId: targetBodyId
+        ) {
+            resolvedTransform = inferred
+            transformSource = "bbox-inference"
+        } else {
+            resolvedTransform = .translate(offset: .zero)
+            transformSource = "identity-fallback"
         }
 
         let bb = targetShape.bounds
@@ -150,7 +265,7 @@ public enum CorrespondenceTools {
                 continue
             }
 
-            let transformed = transform.apply(sc)
+            let transformed = resolvedTransform.apply(sc)
 
             switch anchor {
             case .body:
@@ -202,7 +317,10 @@ public enum CorrespondenceTools {
             }
         }
 
-        return IntrospectionTools.encode(CorrespondencesReport(correspondences: out))
+        return IntrospectionTools.encode(CorrespondencesReport(
+            correspondences: out,
+            transformSource: transformSource
+        ))
     }
 
     private struct PickResult {
@@ -283,5 +401,40 @@ public enum CorrespondenceTools {
             guard idx < vs.count else { return nil }
             return vs[idx]
         }
+    }
+
+    /// Infer a translation transform from how source and target
+    /// bounding boxes align. Returns nil if the boxes have meaningfully
+    /// different sizes (which would imply rotation / scale / mirror —
+    /// none of which we attempt to recover from bbox alone).
+    ///
+    /// The provenance path handles `mirror_or_pattern` outputs cleanly;
+    /// this is the catch-all for "the LLM duplicated something via
+    /// `execute_script` and didn't bother to record a transform."
+    private static func inferTranslation(
+        manifest: ScriptManifest,
+        outputDir: String,
+        targetShape: Shape,
+        targetBodyId: String
+    ) -> TransformHint? {
+        // Pick any source body that isn't the target. Multi-source
+        // selection workflows pass the source explicitly via the
+        // selectionId prefix, but for inference we just need ONE shape
+        // to compare bboxes against.
+        guard let sourceBody = manifest.bodies.first(where: { $0.id != targetBodyId }),
+              let sourceShape = try? Shape.loadBREP(fromPath: "\(outputDir)/\(sourceBody.file)") else {
+            return nil
+        }
+        let s = sourceShape.bounds
+        let t = targetShape.bounds
+        let sourceSize = s.max - s.min
+        let targetSize = t.max - t.min
+        let sizeDiag = simd_length(sourceSize)
+        let sizeDelta = simd_length(sourceSize - targetSize)
+        // Allow 0.1% size mismatch for tessellation / numerical noise.
+        guard sizeDiag > 1e-6, sizeDelta / sizeDiag < 1e-3 else { return nil }
+        let sourceCentre = (s.min + s.max) * 0.5
+        let targetCentre = (t.min + t.max) * 0.5
+        return .translate(offset: targetCentre - sourceCentre)
     }
 }

--- a/SwiftTests/OCCTMCPCoreTests/IntegrationTests.swift
+++ b/SwiftTests/OCCTMCPCoreTests/IntegrationTests.swift
@@ -765,6 +765,302 @@ struct IntegrationTests {
         }
     }
 
+    @Test("find_correspondences accepts a compound (translate then mirror) transform")
+    func findCorrespondencesCompoundTransform() async throws {
+        guard let binary = Self.binaryURL else {
+            Issue.record("Binary not built — run `swift build` first.")
+            return
+        }
+        let scene = NSTemporaryDirectory() + "occtmcp-it-corrcomp-\(UUID().uuidString)"
+        try FileManager.default.createDirectory(atPath: scene, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(atPath: scene) }
+
+        // Source at +X corner, target is the same shape translated +5X
+        // then mirrored about the YZ plane → final position at -X-side.
+        // We pass the compound transform as one transform argument and
+        // expect the target face to resolve to a low-distance match.
+        guard let box = Shape.box(width: 20, height: 20, depth: 20),
+              let src = box.translated(by: SIMD3(20, 0, 0)) else {
+            Issue.record("Failed to synthesise box")
+            return
+        }
+        // Compose the same transform on the test side to construct
+        // the target BREP that the server will be asked to match.
+        guard let translated = src.translated(by: SIMD3(5, 0, 0)) else {
+            Issue.record("translated failed")
+            return
+        }
+        guard let mirrored = translated.mirrored(planeNormal: SIMD3(1, 0, 0), planeOrigin: .zero) else {
+            Issue.record("mirrored failed")
+            return
+        }
+        try Exporter.writeBREP(shape: src, to: URL(fileURLWithPath: "\(scene)/src.brep"))
+        try Exporter.writeBREP(shape: mirrored, to: URL(fileURLWithPath: "\(scene)/tgt.brep"))
+        try ManifestStore(path: "\(scene)/manifest.json").write(ScriptManifest(
+            description: "compound transform test",
+            bodies: [
+                BodyDescriptor(id: "src", file: "src.brep", color: [1, 0, 0, 1]),
+                BodyDescriptor(id: "tgt", file: "tgt.brep", color: [0, 1, 0, 1]),
+            ]
+        ))
+
+        let harness = try Harness(binary: binary, extraEnv: ["OCCTMCP_OUTPUT_DIR": scene])
+        defer { harness.terminate() }
+        try harness.handshake()
+
+        try harness.send(.init(
+            id: 100, method: "tools/call",
+            params: .object([
+                "name": .string("select_topology"),
+                "arguments": .object([
+                    "bodyId": .string("src"),
+                    "kind": .string("face"),
+                    "limit": .int(1),
+                ]),
+            ])
+        ))
+        let selResp = try harness.recv(timeout: 10)
+        guard case .object(let r1)? = selResp["result"],
+              case .array(let c1)? = r1["content"],
+              case .object(let f1)? = c1.first,
+              let t1 = f1["text"]?.stringValue,
+              let d1 = t1.data(using: .utf8),
+              let p1 = (try? JSONSerialization.jsonObject(with: d1)) as? [String: Any],
+              let sels = p1["selections"] as? [[String: Any]],
+              let firstSel = sels.first,
+              let selectionId = firstSel["selectionId"] as? String else {
+            Issue.record("select_topology response shape unexpected: \(selResp)")
+            return
+        }
+
+        // compound: translate +5X, then mirror about YZ.
+        try harness.send(.init(
+            id: 101, method: "tools/call",
+            params: .object([
+                "name": .string("find_correspondences"),
+                "arguments": .object([
+                    "sourceSelectionIds": .array([.string(selectionId)]),
+                    "targetBodyId": .string("tgt"),
+                    "transform": .object([
+                        "kind": .string("compound"),
+                        "steps": .array([
+                            .object([
+                                "kind": .string("translate"),
+                                "offset": .array([.double(5), .double(0), .double(0)]),
+                            ]),
+                            .object([
+                                "kind": .string("mirror"),
+                                "planeOrigin": .array([.double(0), .double(0), .double(0)]),
+                                "planeNormal": .array([.double(1), .double(0), .double(0)]),
+                            ]),
+                        ]),
+                    ]),
+                ]),
+            ])
+        ))
+        let resp = try harness.recv(timeout: 10)
+        guard case .object(let r2)? = resp["result"],
+              case .array(let c2)? = r2["content"],
+              case .object(let f2)? = c2.first,
+              let t2 = f2["text"]?.stringValue,
+              let d2 = t2.data(using: .utf8),
+              let parsed = (try? JSONSerialization.jsonObject(with: d2)) as? [String: Any],
+              let arr = parsed["correspondences"] as? [[String: Any]],
+              let entry = arr.first else {
+            Issue.record("find_correspondences response unexpected: \(resp)")
+            return
+        }
+        #expect(parsed["transformSource"] as? String == "explicit",
+                "compound was caller-supplied; transformSource should be 'explicit'")
+        #expect(entry["fate"] as? String == "matched",
+                "expected matched, got \(entry)")
+        if let conf = entry["confidenceMm"] as? Double {
+            #expect(conf < 0.01, "expected near-zero distance, got \(conf)")
+        }
+    }
+
+    @Test("find_correspondences reads provenance when transform omitted (mirror_or_pattern path)")
+    func findCorrespondencesProvenanceFallback() async throws {
+        guard let binary = Self.binaryURL else {
+            Issue.record("Binary not built — run `swift build` first.")
+            return
+        }
+        let scene = NSTemporaryDirectory() + "occtmcp-it-corrprov-\(UUID().uuidString)"
+        try FileManager.default.createDirectory(atPath: scene, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(atPath: scene) }
+
+        guard let box = Shape.box(width: 20, height: 20, depth: 20),
+              let src = box.translated(by: SIMD3(20, 0, 0)) else {
+            Issue.record("Failed to synthesise box")
+            return
+        }
+        try Exporter.writeBREP(shape: src, to: URL(fileURLWithPath: "\(scene)/src.brep"))
+        try ManifestStore(path: "\(scene)/manifest.json").write(ScriptManifest(
+            description: "provenance fallback test",
+            bodies: [BodyDescriptor(id: "src", file: "src.brep", color: [1, 0, 0, 1])]
+        ))
+
+        let harness = try Harness(binary: binary, extraEnv: ["OCCTMCP_OUTPUT_DIR": scene])
+        defer { harness.terminate() }
+        try harness.handshake()
+
+        // Mirror via the tool — this is what writes the provenance entry.
+        try harness.send(.init(
+            id: 110, method: "tools/call",
+            params: .object([
+                "name": .string("mirror_or_pattern"),
+                "arguments": .object([
+                    "bodyId": .string("src"),
+                    "kind": .string("mirror"),
+                    "params": .object([
+                        "planeOrigin": .array([.double(0), .double(0), .double(0)]),
+                        "planeNormal": .array([.double(1), .double(0), .double(0)]),
+                    ]),
+                ]),
+            ])
+        ))
+        _ = try harness.recv(timeout: 30)
+
+        // Pick a face on the source.
+        try harness.send(.init(
+            id: 111, method: "tools/call",
+            params: .object([
+                "name": .string("select_topology"),
+                "arguments": .object([
+                    "bodyId": .string("src"),
+                    "kind": .string("face"),
+                    "limit": .int(1),
+                ]),
+            ])
+        ))
+        let selResp = try harness.recv(timeout: 10)
+        guard case .object(let r1)? = selResp["result"],
+              case .array(let c1)? = r1["content"],
+              case .object(let f1)? = c1.first,
+              let t1 = f1["text"]?.stringValue,
+              let d1 = t1.data(using: .utf8),
+              let p1 = (try? JSONSerialization.jsonObject(with: d1)) as? [String: Any],
+              let sels = p1["selections"] as? [[String: Any]],
+              let firstSel = sels.first,
+              let selectionId = firstSel["selectionId"] as? String else {
+            Issue.record("select_topology response shape unexpected")
+            return
+        }
+
+        // No transform argument — should pick up the provenance record.
+        try harness.send(.init(
+            id: 112, method: "tools/call",
+            params: .object([
+                "name": .string("find_correspondences"),
+                "arguments": .object([
+                    "sourceSelectionIds": .array([.string(selectionId)]),
+                    "targetBodyId": .string("mirror-src"),
+                ]),
+            ])
+        ))
+        let resp = try harness.recv(timeout: 10)
+        guard case .object(let r2)? = resp["result"],
+              case .array(let c2)? = r2["content"],
+              case .object(let f2)? = c2.first,
+              let t2 = f2["text"]?.stringValue,
+              let d2 = t2.data(using: .utf8),
+              let parsed = (try? JSONSerialization.jsonObject(with: d2)) as? [String: Any],
+              let arr = parsed["correspondences"] as? [[String: Any]],
+              let entry = arr.first else {
+            Issue.record("find_correspondences response unexpected: \(resp)")
+            return
+        }
+        #expect(parsed["transformSource"] as? String == "provenance",
+                "transform should resolve from provenance.json, got transformSource=\(parsed["transformSource"] ?? "nil")")
+        #expect(entry["fate"] as? String == "matched",
+                "expected matched via provenance default, got \(entry)")
+    }
+
+    @Test("find_correspondences infers a translation from bbox alignment when no hint")
+    func findCorrespondencesBboxInference() async throws {
+        guard let binary = Self.binaryURL else {
+            Issue.record("Binary not built — run `swift build` first.")
+            return
+        }
+        let scene = NSTemporaryDirectory() + "occtmcp-it-corrbbox-\(UUID().uuidString)"
+        try FileManager.default.createDirectory(atPath: scene, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(atPath: scene) }
+
+        // Two boxes of the same size, translated by [30, 0, 0]. No
+        // mirror_or_pattern call → no provenance entry → tool falls
+        // through to bbox inference.
+        guard let box = Shape.box(width: 20, height: 20, depth: 20),
+              let tgt = box.translated(by: SIMD3(30, 0, 0)) else {
+            Issue.record("Failed to synthesise boxes")
+            return
+        }
+        try Exporter.writeBREP(shape: box, to: URL(fileURLWithPath: "\(scene)/src.brep"))
+        try Exporter.writeBREP(shape: tgt, to: URL(fileURLWithPath: "\(scene)/tgt.brep"))
+        try ManifestStore(path: "\(scene)/manifest.json").write(ScriptManifest(
+            description: "bbox inference test",
+            bodies: [
+                BodyDescriptor(id: "src", file: "src.brep", color: [1, 0, 0, 1]),
+                BodyDescriptor(id: "tgt", file: "tgt.brep", color: [0, 1, 0, 1]),
+            ]
+        ))
+
+        let harness = try Harness(binary: binary, extraEnv: ["OCCTMCP_OUTPUT_DIR": scene])
+        defer { harness.terminate() }
+        try harness.handshake()
+
+        try harness.send(.init(
+            id: 120, method: "tools/call",
+            params: .object([
+                "name": .string("select_topology"),
+                "arguments": .object([
+                    "bodyId": .string("src"),
+                    "kind": .string("face"),
+                    "limit": .int(1),
+                ]),
+            ])
+        ))
+        let selResp = try harness.recv(timeout: 10)
+        guard case .object(let r1)? = selResp["result"],
+              case .array(let c1)? = r1["content"],
+              case .object(let f1)? = c1.first,
+              let t1 = f1["text"]?.stringValue,
+              let d1 = t1.data(using: .utf8),
+              let p1 = (try? JSONSerialization.jsonObject(with: d1)) as? [String: Any],
+              let sels = p1["selections"] as? [[String: Any]],
+              let firstSel = sels.first,
+              let selectionId = firstSel["selectionId"] as? String else {
+            Issue.record("select_topology response shape unexpected")
+            return
+        }
+
+        try harness.send(.init(
+            id: 121, method: "tools/call",
+            params: .object([
+                "name": .string("find_correspondences"),
+                "arguments": .object([
+                    "sourceSelectionIds": .array([.string(selectionId)]),
+                    "targetBodyId": .string("tgt"),
+                ]),
+            ])
+        ))
+        let resp = try harness.recv(timeout: 10)
+        guard case .object(let r2)? = resp["result"],
+              case .array(let c2)? = r2["content"],
+              case .object(let f2)? = c2.first,
+              let t2 = f2["text"]?.stringValue,
+              let d2 = t2.data(using: .utf8),
+              let parsed = (try? JSONSerialization.jsonObject(with: d2)) as? [String: Any],
+              let arr = parsed["correspondences"] as? [[String: Any]],
+              let entry = arr.first else {
+            Issue.record("find_correspondences response unexpected: \(resp)")
+            return
+        }
+        #expect(parsed["transformSource"] as? String == "bbox-inference",
+                "transform should be inferred from bbox alignment, got transformSource=\(parsed["transformSource"] ?? "nil")")
+        #expect(entry["fate"] as? String == "matched",
+                "expected matched via bbox inference, got \(entry)")
+    }
+
     @Test("annotation tools round-trip via the sidecar")
     func annotationsRoundTrip() async throws {
         guard let binary = Self.binaryURL else {


### PR DESCRIPTION
Closes the three follow-ups listed inside [#24](https://github.com/gsdali/OCCTMCP/issues/24).

## Summary

### `TransformHint` — compound + Codable

- `indirect enum` with a new `compound(steps: [TransformHint])` case for chained transforms (`steps` applied in array order). LLMs that build a body via "translate then mirror" or "rotate twice" can now describe that with one transform argument.
- `Codable` conformance so the same JSON shape works for both tool args and on-disk persistence. Server.swift dispatch dropped its inline parser in favour of `JSONEncoder` → `JSONDecoder` round-trip — recurses through `compound` for free.

### `<output_dir>/provenance.json` sidecar

- New `Sources/OCCTMCPCore/Provenance.swift` — `ProvenanceRecord = { sourceBodyId, transform: TransformHint }`, keyed by body id, atomic writes.
- `mirror_or_pattern` writes a provenance record on success when `kind == .mirror`. (Linear / circular patterns produce N instances which don't fit `find_correspondences`'s single-target-per-source return shape; their provenance can be added when a multi-target return type lands.)

### `find_correspondences` — `transform` optional

Resolution order:

1. **caller-supplied hint** → `transformSource: "explicit"`
2. **`provenance.json[targetBodyId]`** → `transformSource: "provenance"`
3. **bbox-translation inference** (source / target bbox sizes match within 0.1% → translation is the centroid delta) → `transformSource: "bbox-inference"`
4. **zero-translate fallback** → `transformSource: "identity-fallback"`

`inferTranslation` only handles translation. Mirror / rotate / scale aren't recovered from bbox alone — provenance is the right path for those.

The response shape gains `transformSource: String` so callers can tell which path produced the answer.

## Test plan

- [x] `swift build` clean
- [x] `swift test` — 28/28 (was 25)
- [x] `findCorrespondencesCompoundTransform` — composes translate+mirror manually on the test side, asserts the server's compound transform matches the same target.
- [x] `findCorrespondencesProvenanceFallback` — `mirror_or_pattern` writes provenance, `find_correspondences` omits `transform`, asserts `transformSource == "provenance"` + `fate=matched`.
- [x] `findCorrespondencesBboxInference` — two equal-size boxes offset by +30X, no provenance, asserts `transformSource == "bbox-inference"` + `fate=matched`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)