### PR TITLE
fix(deps): drop swift-sdk fork branch for official tagged release

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "e0b7a2f3ec455ed401f83f59070c829b14888ac3852815897476c4eacce31acc",
+  "originHash" : "969e2f70cb7bb0cbf305a32151fd0510df411c71a67ff6dbe40c4b168df79cf2",
   "pins" : [
     {
       "identity" : "eventsource",
@@ -87,8 +87,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-collections.git",
       "state" : {
-        "revision" : "03cc312c2c933ed87abace34044a5dff7a3117c1",
-        "version" : "1.5.0"
+        "revision" : "fea17c02d767f46b23070fdfdacc28a03a39232a",
+        "version" : "1.5.1"
       }
     },
     {
@@ -96,8 +96,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-log.git",
       "state" : {
-        "revision" : "5073617dac96330a486245e4c0179cb0a6fd2256",
-        "version" : "1.12.0"
+        "revision" : "a012e0ad8a8a72de92b0e008c81a9b793f70e73a",
+        "version" : "1.12.1"
       }
     },
     {
@@ -105,17 +105,17 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio.git",
       "state" : {
-        "revision" : "f71c8d2a5e74a2c6d11a0fbe324774b5d6084237",
-        "version" : "2.99.0"
+        "revision" : "57c0a08a331aaea9f5d7a932ad94ef43be942a95",
+        "version" : "2.100.0"
       }
     },
     {
       "identity" : "swift-sdk",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/gsdali/swift-sdk.git",
+      "location" : "https://github.com/modelcontextprotocol/swift-sdk.git",
       "state" : {
-        "branch" : "add-value-numbervalue",
-        "revision" : "62ac56f107f02728f63764d38176a7cf20e47785"
+        "revision" : "a0ae212ebf6eab5f754c3129608bc5557637e605",
+        "version" : "0.12.1"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -21,13 +21,12 @@ let package = Package(
         .executable(name: "occtmcp-server", targets: ["OCCTMCPServer"]),
     ],
     dependencies: [
-        // Temporary pin against gsdali's swift-sdk fork while
-        // modelcontextprotocol/swift-sdk#226 is in review. Upstream
-        // tag floor goes back to `from: "0.11.0"` once the PR merges.
-        // The branch ships `Value.numberValue` (proposed in upstream
-        // #225) — Server.swift consumes it directly so we delete our
-        // own back-port the moment upstream lands.
-        .package(url: "https://github.com/gsdali/swift-sdk.git", branch: "add-value-numbervalue"),
+        // Official MCP Swift SDK. `Value.numberValue` (proposed upstream
+        // in modelcontextprotocol/swift-sdk#225, PR #226) is not yet in a
+        // tagged release, so we back-port it locally in
+        // Sources/OCCTMCPCore/Value+NumberValue.swift. Delete that file
+        // and nothing else changes once the SDK ships the property.
+        .package(url: "https://github.com/modelcontextprotocol/swift-sdk.git", from: "0.11.0"),
         // OCCT 8.0.0 GA cohort.
         //
         // OCCTSwift 1.1.0 closes gsdali/OCCTSwift#167: TopologyGraph

--- a/Sources/OCCTMCPCore/Value+NumberValue.swift
+++ b/Sources/OCCTMCPCore/Value+NumberValue.swift
@@ -1,0 +1,24 @@
+import MCP
+
+extension Value {
+    /// Back-port of the upstream `Value.numberValue` proposed in
+    /// modelcontextprotocol/swift-sdk#225 (PR #226), pending a tagged
+    /// release of the official SDK.
+    ///
+    /// JSON has a single `number` type with no integer/float distinction,
+    /// and `Value.init(from:)` tries `Int` first — so `Value.double(0)`
+    /// round-trips through JSON to `Value.int(0)` and `doubleValue` returns
+    /// `nil`. This accessor coerces both `.int` and `.double` to `Double`,
+    /// which is what tool-argument readers want for coordinates, dimensions,
+    /// tolerances, and angles. Returns `nil` for any non-numeric case.
+    ///
+    /// Remove this file once the SDK ships `numberValue` upstream; no other
+    /// code changes are required.
+    var numberValue: Double? {
+        switch self {
+        case .int(let value):    return Double(value)
+        case .double(let value): return value
+        default:                 return nil
+        }
+    }
+}


### PR DESCRIPTION
## Problem

OCCTMCP — a tagged, released package (currently v1.4.0) — depended on the **`gsdali/swift-sdk` fork branch `add-value-numbervalue`**:

```swift
.package(url: "https://github.com/gsdali/swift-sdk.git", branch: "add-value-numbervalue"),
```

A branch reference is a moving, non-reproducible pin: consumers and CI get whatever is on the branch at resolve time, and it breaks if the fork branch is ever rebased or deleted. The branch's **only** delta from upstream `main` is a single `Value.numberValue` computed property (proposed upstream in modelcontextprotocol/swift-sdk#225, [PR #226](https://github.com/modelcontextprotocol/swift-sdk/pull/226) — still open).

## Fix

- Depend on the **official** `modelcontextprotocol/swift-sdk` (`from: "0.11.0"`, resolves to **0.12.1**). The package identity stays `swift-sdk`, so all `.product(name: "MCP", package: "swift-sdk")` references are unchanged.
- Back-port `Value.numberValue` locally in `Sources/OCCTMCPCore/Value+NumberValue.swift` — a verbatim copy of the proposed accessor (coerces `.int`/`.double` → `Double`). `Server.swift` consumes it in ~12 places (coordinates, tolerances, material params).
- Delete that one file once the SDK ships the property upstream; nothing else changes.

## Verification

`Package.resolved` now pins `swift-sdk` at version **0.12.1** (revision-locked) instead of a branch. `swift build` clean (0 errors); **all 28 tests pass**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
