### PR TITLE
fix(deps): floor + lock the crash-fixed Viewport cohort

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "969e2f70cb7bb0cbf305a32151fd0510df411c71a67ff6dbe40c4b168df79cf2",
+  "originHash" : "e1067c9af961ea600d3bfb6c5aead9c184003b4ab9985e95e807e5be8eb7e464",
   "pins" : [
     {
       "identity" : "eventsource",
@@ -24,8 +24,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/gsdali/OCCTSwiftAIS.git",
       "state" : {
-        "revision" : "550f7897aa59b8cf358993f1f19485651143528f",
-        "version" : "1.0.1"
+        "revision" : "dcb814b6332706d40717f66c6f327698283b59cf",
+        "version" : "1.0.2"
       }
     },
     {
@@ -51,8 +51,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/gsdali/OCCTSwiftScripts.git",
       "state" : {
-        "revision" : "be3c89d651e6dcdfe0f0f52c08e4c520b90f3134",
-        "version" : "1.0.2"
+        "revision" : "6d790b270d517cf4fc672db0c1b2251bd505d901",
+        "version" : "1.0.3"
       }
     },
     {
@@ -60,8 +60,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/gsdali/OCCTSwiftTools.git",
       "state" : {
-        "revision" : "5f00acaf8164f5de68234741cb2b193ed4e9a9dd",
-        "version" : "1.1.0"
+        "revision" : "d71764d0468069369e71ee18e52c95e26a7aae0a",
+        "version" : "1.1.1"
       }
     },
     {
@@ -69,8 +69,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/gsdali/OCCTSwiftViewport.git",
       "state" : {
-        "revision" : "b6c0e7c14c30332f9aa9df11243595ad7e3a61a8",
-        "version" : "1.0.2"
+        "revision" : "6c8e95e62e2b25666ba9160af24bce22c7ccb08c",
+        "version" : "1.0.4"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -45,10 +45,13 @@ let package = Package(
         // pointCloud annotation now actually renders.
         .package(url: "https://github.com/gsdali/OCCTSwift.git", from: "1.1.0"),
         .package(url: "https://github.com/gsdali/OCCTSwiftMesh.git", from: "1.0.0"),
-        .package(url: "https://github.com/gsdali/OCCTSwiftScripts.git", from: "1.0.2"),
-        .package(url: "https://github.com/gsdali/OCCTSwiftTools.git", from: "1.1.0"),
-        .package(url: "https://github.com/gsdali/OCCTSwiftViewport.git", from: "1.0.2"),
-        .package(url: "https://github.com/gsdali/OCCTSwiftAIS.git", from: "1.0.1"),
+        .package(url: "https://github.com/gsdali/OCCTSwiftScripts.git", from: "1.0.3"),
+        .package(url: "https://github.com/gsdali/OCCTSwiftTools.git", from: "1.1.1"),
+        // Viewport floored at 1.0.4: 1.0.3 fixes an uncatchable quantize()
+        // crash on body load (Viewport #30) that would trap the MCP server
+        // during render-preview; 1.0.4 makes the package dependency-free.
+        .package(url: "https://github.com/gsdali/OCCTSwiftViewport.git", from: "1.0.4"),
+        .package(url: "https://github.com/gsdali/OCCTSwiftAIS.git", from: "1.0.2"),
     ],
     targets: [
         .target(


### PR DESCRIPTION
OCCTMCP was locked to `OCCTSwiftViewport` **1.0.2** — the version with the uncatchable `NormalSmoothing.quantize()` crash on body load ([Viewport #30](https://github.com/gsdali/OCCTSwiftViewport/issues/30)). Since render-preview rasterizes through Viewport, the server could trap on large/ill-bounded models.

Floors + lock raised to the crash-fixed cohort: Viewport `1.0.2 → 1.0.4`, Tools `1.1.0 → 1.1.1`, AIS `1.0.1 → 1.0.2`, Scripts `1.0.2 → 1.0.3`. Build clean; 28 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
