### PR TITLE
feat(reconstruct): reconstruct_* tools — read/write the attributed graph (#33)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 MCP server that gives LLMs the ability to author, inspect, and iterate on 3D CAD models with OpenCASCADE via the OCCTSwift family. Two implementations live side-by-side:
 
-- **Swift** (`Sources/`, `Package.swift`) — the **primary**, in-process server. Uses the official Swift MCP SDK, calls OCCTSwift / OCCTSwiftMesh / OCCTSwiftTools / OCCTSwiftAIS / DrawingComposer directly. 50 typed tools. macOS 15+.
+- **Swift** (`Sources/`, `Package.swift`) — the **primary**, in-process server. Uses the official Swift MCP SDK, calls OCCTSwift / OCCTSwiftMesh / OCCTSwiftTools / OCCTSwiftAIS / DrawingComposer directly. 56 typed tools. macOS 15+.
 - **Node / TypeScript** (`src/`, `dist/`) — the original implementation. Shells out to the `occtkit` CLI via `OCCTSwiftScripts`. 36 tools (the pre-v0.4 surface; selection / remap / annotations are Swift-only).
 
 Both speak stdio MCP and read/write the same `manifest.json` + `annotations.json` files in the output directory. Pick whichever fits the host: the Swift binary eliminates JSONL marshalling and per-call subprocess spawn; the Node server runs anywhere a Node 18+ runtime exists, but needs `occtkit` on `$PATH`.
@@ -41,7 +41,7 @@ npm run test:integration  # node:test end-to-end chain through occtkit (slow; ~3
 
 `Sources/OCCTMCPCore/` (library) + `Sources/OCCTMCPServer/` (executable that connects stdio).
 
-- `Server.swift` — `createServer()` factory: registers all 50 tools with their JSON Schemas, returns an `MCP.Server` ready to bind to a transport. Tests import `createServer()` to introspect the registry without binding stdio. The `get_api_reference` tool's `mcp_tools` category dumps the live registry as JSON Schema for LLM auto-discovery.
+- `Server.swift` — `createServer()` factory: registers all 56 tools with their JSON Schemas, returns an `MCP.Server` ready to bind to a transport. Tests import `createServer()` to introspect the registry without binding stdio. The `get_api_reference` tool's `mcp_tools` category dumps the live registry as JSON Schema for LLM auto-discovery.
 - `Tools/` — one file per tool family:
   - `CoreTools.swift` — `get_scene`, `get_script`, `export_model`, `get_api_reference`
   - `ExecuteScriptTool.swift` — `execute_script` (writes Swift to tempfile, `occtkit run` via the resolved binary, parses manifest)
@@ -62,6 +62,8 @@ npm run test:integration  # node:test end-to-end chain through occtkit (slow; ~3
   - `GapFillerTools.swift` — `show_bounding_box`, `diff_overlay`, `select_by_feature`
   - `IntrospectionRegistryTools.swift` — `list_selections`, `clear_selections`, `list_annotations`
   - `AutoDimensionTool.swift` — `auto_dimension`
+  - `ReconstructTools.swift` — `reconstruct_get_graph`, `reconstruct_set_decision`, `reconstruct_force_fit`, `reconstruct_confirm_instances`, `reconstruct_export_session`, `reconstruct_import_session` (LLM read/write over the attributed reconstruction graph; #33)
+- `ReconstructRegistry.swift` — actor-backed `sessionId → TopologyGraph`. Holds the per-node attribute overlay (OCCTSwift 1.2.0 `NodeAttributeStore`) for a reconstruction session; all graph reads/writes are actor-isolated. `reconstruct.*` namespaced keys (`decidedBy`, `accepted`, `forcedSurfaceType`, `instanceCluster`, `instanceConfirmed`). Nodes addressed as `<kind>:<index>`. The reconstruction *engine* (fitting, congruence) lives in OCCTReconstruct — `force_fit` records an override, it does not re-fit. Persistence via `TopologyGraph.snapshot()` / `GraphSnapshot` round-trip.
 - `Manifest.swift` — `ScriptManifest` + `BodyDescriptor` Codable, plus `ManifestStore` (atomic JSON read/write)
 - `Annotations.swift` — `AnnotationsSidecar` (`<output_dir>/annotations.json`): `dimensions[]` + `primitives[]`, `AnyCodable` for per-kind primitive params
 - `AnnotationsRenderer.swift` — synthesises `ViewportBody` overlays from the sidecar (trihedron / workPlane / axis / pointCloud / boundingBox / diffMarker / 3D dimension leaders), and `ViewportMeasurement` entries (linear / angular / radial) for OffscreenRenderer's 2D label overlay. `pointCloud` routes through `OCCTSwiftTools.PointConverter.pointsToBody` (no per-point cap).
@@ -138,7 +140,7 @@ The Node server does not expose the v0.4+ tool surface (selection / remap / anno
 
 ### Swift implementation
 
-- **OCCTSwift** ≥ 1.1.0 — kernel wrapper around OpenCASCADE; full per-input history coverage for booleans + every `FeatureSpec` kind in `BuildResult.histories[id]`, plus `TopologyGraph.findDerivedOrSelf` / `hasHistoryRecord` for unambiguous untouched-vs-deleted resolution
+- **OCCTSwift** ≥ 1.2.0 — kernel wrapper around OpenCASCADE; full per-input history coverage for booleans + every `FeatureSpec` kind in `BuildResult.histories[id]`, plus `TopologyGraph.findDerivedOrSelf` / `hasHistoryRecord` for unambiguous untouched-vs-deleted resolution. v1.2.0 adds the `TopologyGraph` per-node attribute store (`attributes` / `setAttribute` / `attribute`, closed `AttrValue` enum) and Codable `GraphSnapshot` round-trip (`snapshot()` / `init(snapshot:)`) backing the `reconstruct_*` tool group (#33)
 - **OCCTSwiftMesh** ≥ 1.0.0 — mesh-domain algorithms (QEM decimation today; smoothing / repair / remeshing in roadmap)
 - **OCCTSwiftScripts** ≥ 1.0.2 — provides `occtkit` (only used by `execute_script` and `export_scene`); also ships `ScriptHarness` + `DrawingComposer` consumed in-process
 - **OCCTSwiftTools** ≥ 1.1.0 — Shape↔ViewportBody bridge; ships `PointConverter` and wires `pointRadius` / `vertexColors` through to `ViewportBody`
@@ -154,7 +156,7 @@ The Node server does not expose the v0.4+ tool surface (selection / remap / anno
 
 ## MCP Tools
 
-50 tools across both implementations (Swift); 36 in Node (no selection / remap / annotations / history). See README.md for the categorized table — that's the LLM-facing surface and stays canonical.
+56 tools in Swift; 36 in Node (no selection / remap / annotations / history / reconstruct). See README.md for the categorized table — that's the LLM-facing surface and stays canonical.
 
 ## Script Template
 

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "e1067c9af961ea600d3bfb6c5aead9c184003b4ab9985e95e807e5be8eb7e464",
+  "originHash" : "fd106e498eb0f75b0da3a758cfb28c2760bbe82c6a3d794d01a9f134d3b4a73c",
   "pins" : [
     {
       "identity" : "eventsource",
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/gsdali/OCCTSwift.git",
       "state" : {
-        "revision" : "2124f0c63ed5750886b9235838cd3b866d3367ee",
-        "version" : "1.1.0"
+        "revision" : "12b37d2a49e9c391f84cbc735ec512b228d7d4bc",
+        "version" : "1.2.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -39,11 +39,18 @@ let package = Package(
         // applyChamfer go through *WithFullHistory and populate
         // BuildResult.histories[id] for every FeatureSpec kind.
         //
+        // OCCTSwift 1.2.0 closes gsdali/OCCTSwift#168: TopologyGraph
+        // gains a per-node attribute store (`attributes` /
+        // `setAttribute` / `attribute`), a closed `AttrValue` enum, and
+        // a Codable `GraphSnapshot` round-trip (`snapshot()` /
+        // `init(snapshot:)`). Backs the `reconstruct_*` tool group
+        // (OCCTMCP #33) — LLM read/write over the attributed graph.
+        //
         // OCCTSwiftViewport 1.0.2 closes #28: Metal point-sprite
         // pipeline. Combined with OCCTSwiftTools 1.1.0 wiring
         // pointRadius / vertexColors through to ViewportBody, the
         // pointCloud annotation now actually renders.
-        .package(url: "https://github.com/gsdali/OCCTSwift.git", from: "1.1.0"),
+        .package(url: "https://github.com/gsdali/OCCTSwift.git", from: "1.2.0"),
         .package(url: "https://github.com/gsdali/OCCTSwiftMesh.git", from: "1.0.0"),
         .package(url: "https://github.com/gsdali/OCCTSwiftScripts.git", from: "1.0.3"),
         .package(url: "https://github.com/gsdali/OCCTSwiftTools.git", from: "1.1.1"),

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ MCP server that gives LLMs the ability to author, inspect, and iterate on 3D CAD
 
 Part of the [OCCTSwift ecosystem](https://github.com/gsdali/OCCTSwift/blob/main/docs/ecosystem.md) — see the ecosystem map for how this package sits on top of the kernel, viewport, bridge, and AIS layers. SemVer-stable from v1.0.0.
 
-The Swift implementation calls OCCT directly in-process — no subprocess, no JSONL marshalling — and exposes 50 typed MCP tools that cover authoring, scene reads, mutation, introspection, construction, analysis, I/O, mesh, drawing, selection / remap, and dimension overlays.
+The Swift implementation calls OCCT directly in-process — no subprocess, no JSONL marshalling — and exposes 56 typed MCP tools that cover authoring, scene reads, mutation, introspection, construction, analysis, I/O, mesh, drawing, selection / remap, and dimension overlays.
 
 ## How It Works
 
@@ -22,7 +22,7 @@ For novel geometry the typed tools don't cover, the LLM falls back to `execute_s
 
 ## Tools
 
-50 tools, organized below. Call `get_api_reference({ category: "mcp_tools" })` to dump every tool's JSON Schema in one shot — useful for LLM auto-discovery. Most flows can answer "what's the volume?", "make it red", "boolean-subtract these", "render a preview", "add a dimension between these two faces", "export to STEP", and "draw this" without ever touching `execute_script`.
+56 tools, organized below. Call `get_api_reference({ category: "mcp_tools" })` to dump every tool's JSON Schema in one shot — useful for LLM auto-discovery. Most flows can answer "what's the volume?", "make it red", "boolean-subtract these", "render a preview", "add a dimension between these two faces", "export to STEP", and "draw this" without ever touching `execute_script`.
 
 ### Authoring
 
@@ -128,11 +128,24 @@ For novel geometry the typed tools don't cover, the LLM falls back to `execute_s
 | `graph_ml` | Export topology + UV/edge samples as ML-friendly JSON |
 | `feature_recognize` | Pockets + holes (raw BREP path; `recognize_features` is the scene-aware wrapper) |
 
+### Reconstruction graph (read/write)
+
+LLM read/write over an attributed reconstruction graph — annotate per-node decisions and persist them. Backed by OCCTSwift 1.2.0's `NodeAttributeStore` + Codable `GraphSnapshot`. Nodes are addressed as `<kind>:<index>` (e.g. `face:3`). The reconstruction *engine* (surface fitting, congruence detection) lives in [OCCTReconstruct](https://github.com/gsdali/OCCTReconstruct); these tools are the annotate-and-persist layer — `reconstruct_force_fit` records an override for the engine to honour, it does not re-fit here.
+
+| Tool | Purpose |
+|------|---------|
+| `reconstruct_get_graph` | Export the attributed graph as JSON — topology counts, annotated nodes (with `reconstruct.*` attributes), instance clusters. Starts a session from a `bodyId` or reads an existing one by `sessionId` |
+| `reconstruct_set_decision` | Annotate a node's `decidedBy` (geometric / ml / human) and/or accept-reject a proposed fit |
+| `reconstruct_force_fit` | Override a node's fitted surface type (e.g. force `cylinder`) |
+| `reconstruct_confirm_instances` | Confirm / reject a congruence cluster ("these N nodes are one part definition") |
+| `reconstruct_export_session` | Write the session snapshot to disk (byte-stable JSON) |
+| `reconstruct_import_session` | Reload a snapshot file into a session |
+
 ## Implementations
 
 This repo ships two implementations side-by-side:
 
-- **Swift** (`Sources/`, `Package.swift`) — the **primary** server. In-process against OCCTSwift / OCCTSwiftMesh / OCCTSwiftTools / OCCTSwiftAIS / DrawingComposer using the [official Swift MCP SDK](https://swiftpackageindex.com/modelcontextprotocol/swift-sdk). 50 tools. macOS 15+ (the OCCT.xcframework arm64 platform).
+- **Swift** (`Sources/`, `Package.swift`) — the **primary** server. In-process against OCCTSwift / OCCTSwiftMesh / OCCTSwiftTools / OCCTSwiftAIS / DrawingComposer using the [official Swift MCP SDK](https://swiftpackageindex.com/modelcontextprotocol/swift-sdk). 56 tools. macOS 15+ (the OCCT.xcframework arm64 platform).
 - **Node / TypeScript** (`src/`, `dist/`) — the original implementation. Shells out to the `occtkit` CLI for everything Swift-side. 36 tools (the pre-v0.4 surface; selection / remap / annotations are Swift-only). Useful if you can't run a macOS binary.
 
 Both speak stdio MCP and read/write the same manifest format.

--- a/Sources/OCCTMCPCore/ReconstructRegistry.swift
+++ b/Sources/OCCTMCPCore/ReconstructRegistry.swift
@@ -1,0 +1,260 @@
+// ReconstructRegistry — actor-backed store of `sessionId → TopologyGraph`
+// for the `reconstruct_*` tool group (OCCTMCP #33).
+//
+// A "reconstruction session" is a live `TopologyGraph` plus its per-node
+// attribute overlay (OCCTSwift 1.2.0's `NodeAttributeStore`). The
+// reconstruction *engine* — surface fitting, congruence detection, the
+// math behind residuals/confidence — lives downstream in OCCTReconstruct.
+// OCCTMCP only reads and writes the attributed graph so an LLM-in-the-loop
+// can annotate decisions (`decidedBy`, accept/reject, forced surface type,
+// instance clusters) and have them persist via `GraphSnapshot`.
+//
+// All graph access is funnelled through the actor so the (`@unchecked
+// Sendable`) `TopologyGraph` reference type is never mutated concurrently:
+// the tool layer builds a graph (from a body's BREP or an imported
+// snapshot), hands it to `store(id:graph:)`, and never touches it again —
+// every subsequent read/write goes through an actor-isolated method.
+
+import Foundation
+import OCCTSwift
+
+/// Namespaced attribute keys this layer reads/writes. The store is generic;
+/// these are the keys the `reconstruct_*` tools own. Engine-written keys
+/// (e.g. `reconstruct.residualRMS`, `reconstruct.confidence`) round-trip
+/// through `get_graph` / `export_session` untouched.
+public enum ReconstructKeys {
+    public static let decidedBy = "reconstruct.decidedBy"
+    public static let accepted = "reconstruct.accepted"
+    public static let forcedSurfaceType = "reconstruct.forcedSurfaceType"
+    public static let instanceCluster = "reconstruct.instanceCluster"
+    public static let instanceConfirmed = "reconstruct.instanceConfirmed"
+}
+
+/// A Sendable, Encodable snapshot of a session's state for `get_graph` /
+/// `import_session` responses. Lists topology counts plus every annotated
+/// node (nodes carrying no attributes are omitted) and any instance
+/// clusters derived from `reconstruct.instanceCluster`.
+public struct ReconstructGraphState: Encodable, Sendable {
+    public struct TopologyCounts: Encodable, Sendable {
+        public let solids: Int
+        public let shells: Int
+        public let faces: Int
+        public let wires: Int
+        public let edges: Int
+        public let vertices: Int
+        public let compounds: Int
+        public let totalNodes: Int
+    }
+    public struct NodeAttrs: Encodable, Sendable {
+        public let node: String                       // "<kind>:<index>", e.g. "face:3"
+        public let attributes: [String: AnyCodable]
+    }
+    public struct InstanceCluster: Encodable, Sendable {
+        public let clusterId: String
+        public let members: [String]
+        public let confirmed: Bool
+    }
+
+    public let sessionId: String
+    public let topology: TopologyCounts
+    public let annotatedNodeCount: Int
+    public let nodes: [NodeAttrs]
+    public let instanceClusters: [InstanceCluster]
+}
+
+/// Outcome of a single-node write (`set_decision` / `force_fit`).
+public enum ReconstructWriteOutcome: Sendable {
+    case ok(node: String, attributes: [String: AnyCodable])
+    case noSession(String)
+    case badNode(String)
+}
+
+/// Outcome of a cluster write (`confirm_instances`).
+public enum ReconstructClusterOutcome: Sendable {
+    case ok(clusterId: String, members: [String], confirmed: Bool)
+    case noSession(String)
+    case badNodes([String])
+}
+
+public enum ReconstructError: Error, CustomStringConvertible, Sendable {
+    case noSession(String)
+    public var description: String {
+        switch self {
+        case .noSession(let id):
+            return "No reconstruction session '\(id)'. Run reconstruct_get_graph or reconstruct_import_session first."
+        }
+    }
+}
+
+public actor ReconstructRegistry {
+    public static let shared = ReconstructRegistry()
+
+    private var sessions: [String: TopologyGraph] = [:]
+
+    public init() {}
+
+    // MARK: lifecycle
+
+    public func hasSession(id: String) -> Bool { sessions[id] != nil }
+
+    /// Register (or replace) the graph backing a session.
+    public func store(id: String, graph: TopologyGraph) { sessions[id] = graph }
+
+    public func sessionIds() -> [String] { sessions.keys.sorted() }
+
+    public func clear() { sessions.removeAll() }
+
+    // MARK: read
+
+    public func state(id: String) -> ReconstructGraphState? {
+        guard let g = sessions[id] else { return nil }
+        let s = g.stats
+        let counts = ReconstructGraphState.TopologyCounts(
+            solids: s.solids, shells: s.shells, faces: s.faces, wires: s.wires,
+            edges: s.edges, vertices: s.vertices, compounds: s.compounds,
+            totalNodes: s.totalNodes
+        )
+        let storage = g.attributes.storage
+        let orderedRefs = storage.keys.sorted(by: Self.nodeOrder)
+
+        var nodes: [ReconstructGraphState.NodeAttrs] = []
+        var clusters: [String: (members: [String], confirmed: Bool)] = [:]
+        for ref in orderedRefs {
+            guard let attrs = storage[ref] else { continue }
+            var out: [String: AnyCodable] = [:]
+            for (k, v) in attrs { out[k] = Self.anyCodable(v) }
+            nodes.append(.init(node: Self.format(ref), attributes: out))
+
+            if let cid = attrs[ReconstructKeys.instanceCluster]?.stringValue {
+                let confirmed = attrs[ReconstructKeys.instanceConfirmed]?.boolValue ?? false
+                var entry = clusters[cid] ?? (members: [], confirmed: false)
+                entry.members.append(Self.format(ref))
+                entry.confirmed = entry.confirmed || confirmed
+                clusters[cid] = entry
+            }
+        }
+        let clusterList = clusters.keys.sorted().map { cid in
+            ReconstructGraphState.InstanceCluster(
+                clusterId: cid, members: clusters[cid]!.members, confirmed: clusters[cid]!.confirmed
+            )
+        }
+        return ReconstructGraphState(
+            sessionId: id, topology: counts,
+            annotatedNodeCount: g.attributes.annotatedNodeCount,
+            nodes: nodes, instanceClusters: clusterList
+        )
+    }
+
+    // MARK: write
+
+    public func setDecision(
+        id: String, nodeStr: String, decidedBy: String?, accepted: Bool?
+    ) -> ReconstructWriteOutcome {
+        guard let g = sessions[id] else { return .noSession(id) }
+        guard let node = Self.parse(nodeStr) else { return .badNode(nodeStr) }
+        if let d = decidedBy { g.setAttribute(ReconstructKeys.decidedBy, .string(d), for: node) }
+        if let a = accepted { g.setAttribute(ReconstructKeys.accepted, .bool(a), for: node) }
+        return .ok(node: nodeStr, attributes: Self.attrsOut(g, node))
+    }
+
+    public func forceFit(
+        id: String, nodeStr: String, surfaceType: String
+    ) -> ReconstructWriteOutcome {
+        guard let g = sessions[id] else { return .noSession(id) }
+        guard let node = Self.parse(nodeStr) else { return .badNode(nodeStr) }
+        g.setAttribute(ReconstructKeys.forcedSurfaceType, .string(surfaceType), for: node)
+        return .ok(node: nodeStr, attributes: Self.attrsOut(g, node))
+    }
+
+    public func confirmInstances(
+        id: String, clusterId: String, nodeStrs: [String], confirmed: Bool
+    ) -> ReconstructClusterOutcome {
+        guard let g = sessions[id] else { return .noSession(id) }
+        let parsed = nodeStrs.map { (raw: $0, ref: Self.parse($0)) }
+        let bad = parsed.filter { $0.ref == nil }.map { $0.raw }
+        guard bad.isEmpty else { return .badNodes(bad) }
+        for entry in parsed {
+            guard let ref = entry.ref else { continue }
+            g.setAttribute(ReconstructKeys.instanceCluster, .string(clusterId), for: ref)
+            g.setAttribute(ReconstructKeys.instanceConfirmed, .bool(confirmed), for: ref)
+        }
+        return .ok(clusterId: clusterId, members: nodeStrs, confirmed: confirmed)
+    }
+
+    // MARK: persistence
+
+    public func makeSnapshot(id: String) throws -> GraphSnapshot {
+        guard let g = sessions[id] else { throw ReconstructError.noSession(id) }
+        return try g.snapshot()
+    }
+
+    // MARK: helpers
+
+    private static func attrsOut(_ g: TopologyGraph, _ node: TopologyGraph.NodeRef) -> [String: AnyCodable] {
+        var out: [String: AnyCodable] = [:]
+        for (k, v) in g.attributes.storage[node] ?? [:] { out[k] = anyCodable(v) }
+        return out
+    }
+
+    private static func nodeOrder(_ a: TopologyGraph.NodeRef, _ b: TopologyGraph.NodeRef) -> Bool {
+        if a.kind.rawValue != b.kind.rawValue { return a.kind.rawValue < b.kind.rawValue }
+        return a.index < b.index
+    }
+
+    static func anyCodable(_ v: TopologyGraph.AttrValue) -> AnyCodable {
+        switch v {
+        case .bool(let b):    return .bool(b)
+        case .int(let i):     return .number(Double(i))
+        case .double(let d):  return .number(d)
+        case .string(let s):  return .string(s)
+        case .ints(let a):    return .array(a.map { .number(Double($0)) })
+        case .doubles(let a): return .array(a.map { .number($0) })
+        }
+    }
+
+    // Self-describing "<kind>:<index>" node addressing (parseable both ways).
+    static func kindName(_ k: TopologyGraph.NodeKind) -> String {
+        switch k {
+        case .solid:      return "solid"
+        case .shell:      return "shell"
+        case .face:       return "face"
+        case .wire:       return "wire"
+        case .edge:       return "edge"
+        case .vertex:     return "vertex"
+        case .compound:   return "compound"
+        case .compSolid:  return "compsolid"
+        case .coedge:     return "coedge"
+        case .product:    return "product"
+        case .occurrence: return "occurrence"
+        }
+    }
+
+    static func kind(from name: String) -> TopologyGraph.NodeKind? {
+        switch name.lowercased() {
+        case "solid":      return .solid
+        case "shell":      return .shell
+        case "face":       return .face
+        case "wire":       return .wire
+        case "edge":       return .edge
+        case "vertex":     return .vertex
+        case "compound":   return .compound
+        case "compsolid":  return .compSolid
+        case "coedge":     return .coedge
+        case "product":    return .product
+        case "occurrence": return .occurrence
+        default:           return nil
+        }
+    }
+
+    static func format(_ ref: TopologyGraph.NodeRef) -> String {
+        "\(kindName(ref.kind)):\(ref.index)"
+    }
+
+    static func parse(_ s: String) -> TopologyGraph.NodeRef? {
+        let parts = s.split(separator: ":", maxSplits: 1)
+        guard parts.count == 2,
+              let k = kind(from: String(parts[0])),
+              let idx = Int(parts[1]) else { return nil }
+        return TopologyGraph.NodeRef(kind: k, index: idx)
+    }
+}

--- a/Sources/OCCTMCPCore/Server.swift
+++ b/Sources/OCCTMCPCore/Server.swift
@@ -943,6 +943,96 @@ func catalogTools() -> [Tool] {
                 "additionalProperties": .bool(false),
             ])
         ),
+        // ── reconstruct_* — read/write the attributed reconstruction graph (#33)
+        Tool(
+            name: "reconstruct_get_graph",
+            description: "Export the attributed reconstruction graph as JSON: topology counts, every annotated node (with its reconstruct.* attributes), and instance clusters. Pass `sessionId` for an existing session, or `bodyId` to start one from a scene body. Nodes are addressed as `<kind>:<index>` (e.g. `face:3`).",
+            inputSchema: .object([
+                "type": .string("object"),
+                "properties": .object([
+                    "sessionId": .object(["type": .string("string"), "description": .string("Existing reconstruction session id.")]),
+                    "bodyId": .object(["type": .string("string"), "description": .string("Scene body to start a new session from (sessionId defaults to bodyId).")]),
+                ]),
+                "additionalProperties": .bool(false),
+            ])
+        ),
+        Tool(
+            name: "reconstruct_set_decision",
+            description: "Annotate a node's reconstruction decision: `decidedBy` (geometric | ml | human) and/or `accepted` (accept/reject a proposed fit). At least one must be supplied.",
+            inputSchema: .object([
+                "type": .string("object"),
+                "properties": .object([
+                    "sessionId": .object(["type": .string("string")]),
+                    "node": .object(["type": .string("string"), "description": .string("Target node as `<kind>:<index>`, e.g. `face:3`.")]),
+                    "decidedBy": .object([
+                        "type": .string("string"),
+                        "enum": .array([.string("geometric"), .string("ml"), .string("human")]),
+                    ]),
+                    "accepted": .object(["type": .string("boolean")]),
+                ]),
+                "required": .array([.string("sessionId"), .string("node")]),
+                "additionalProperties": .bool(false),
+            ])
+        ),
+        Tool(
+            name: "reconstruct_force_fit",
+            description: "Override a node's fitted surface type (e.g. force `cylinder`). Records the override as an attribute for the OCCTReconstruct engine to honour on its next pass; it does not re-fit here.",
+            inputSchema: .object([
+                "type": .string("object"),
+                "properties": .object([
+                    "sessionId": .object(["type": .string("string")]),
+                    "node": .object(["type": .string("string"), "description": .string("Target node as `<kind>:<index>`.")]),
+                    "surfaceType": .object(["type": .string("string"), "description": .string("Forced surface type, e.g. plane / cylinder / cone / sphere / torus.")]),
+                ]),
+                "required": .array([.string("sessionId"), .string("node"), .string("surfaceType")]),
+                "additionalProperties": .bool(false),
+            ])
+        ),
+        Tool(
+            name: "reconstruct_confirm_instances",
+            description: "Confirm or reject a congruence cluster (\"these N nodes are one part definition\"). Tags every listed node with `clusterId` and the `confirmed` flag.",
+            inputSchema: .object([
+                "type": .string("object"),
+                "properties": .object([
+                    "sessionId": .object(["type": .string("string")]),
+                    "clusterId": .object(["type": .string("string")]),
+                    "nodes": .object([
+                        "type": .string("array"),
+                        "items": .object(["type": .string("string")]),
+                        "description": .string("Cluster member nodes as `<kind>:<index>`."),
+                    ]),
+                    "confirmed": .object(["type": .string("boolean"), "description": .string("Default true.")]),
+                ]),
+                "required": .array([.string("sessionId"), .string("clusterId"), .string("nodes")]),
+                "additionalProperties": .bool(false),
+            ])
+        ),
+        Tool(
+            name: "reconstruct_export_session",
+            description: "Write the session's attributed graph snapshot to disk (byte-stable JSON). Defaults to <output_dir>/reconstruct/<sessionId>.session.json. Round-trips losslessly via reconstruct_import_session.",
+            inputSchema: .object([
+                "type": .string("object"),
+                "properties": .object([
+                    "sessionId": .object(["type": .string("string")]),
+                    "path": .object(["type": .string("string"), "description": .string("Optional output path.")]),
+                ]),
+                "required": .array([.string("sessionId")]),
+                "additionalProperties": .bool(false),
+            ])
+        ),
+        Tool(
+            name: "reconstruct_import_session",
+            description: "Reload a graph snapshot file into a session and return its state. `sessionId` defaults to the file's stem.",
+            inputSchema: .object([
+                "type": .string("object"),
+                "properties": .object([
+                    "path": .object(["type": .string("string")]),
+                    "sessionId": .object(["type": .string("string")]),
+                ]),
+                "required": .array([.string("path")]),
+                "additionalProperties": .bool(false),
+            ])
+        ),
     ]
 }
 
@@ -1529,6 +1619,63 @@ func dispatch(callName: String, arguments: [String: Value]) async -> CallTool.Re
     case "compare_versions":
         let since = arguments["since"]?.intValue ?? 1
         return await SceneTools.compareVersions(since: since).asCallToolResult()
+
+    case "reconstruct_get_graph":
+        return await ReconstructTools.getGraph(
+            sessionId: arguments["sessionId"]?.stringValue,
+            bodyId: arguments["bodyId"]?.stringValue
+        ).asCallToolResult()
+
+    case "reconstruct_set_decision":
+        guard let sessionId = arguments["sessionId"]?.stringValue,
+              let node = arguments["node"]?.stringValue else {
+            return ToolText("reconstruct_set_decision requires `sessionId` and `node`.", isError: true).asCallToolResult()
+        }
+        return await ReconstructTools.setDecision(
+            sessionId: sessionId,
+            node: node,
+            decidedBy: arguments["decidedBy"]?.stringValue,
+            accepted: arguments["accepted"]?.boolValue
+        ).asCallToolResult()
+
+    case "reconstruct_force_fit":
+        guard let sessionId = arguments["sessionId"]?.stringValue,
+              let node = arguments["node"]?.stringValue,
+              let surfaceType = arguments["surfaceType"]?.stringValue else {
+            return ToolText("reconstruct_force_fit requires `sessionId`, `node`, and `surfaceType`.", isError: true).asCallToolResult()
+        }
+        return await ReconstructTools.forceFit(
+            sessionId: sessionId, node: node, surfaceType: surfaceType
+        ).asCallToolResult()
+
+    case "reconstruct_confirm_instances":
+        guard let sessionId = arguments["sessionId"]?.stringValue,
+              let clusterId = arguments["clusterId"]?.stringValue,
+              let nodes = arguments["nodes"]?.arrayValue?.compactMap({ $0.stringValue }), !nodes.isEmpty else {
+            return ToolText("reconstruct_confirm_instances requires `sessionId`, `clusterId`, and a non-empty `nodes` array.", isError: true).asCallToolResult()
+        }
+        return await ReconstructTools.confirmInstances(
+            sessionId: sessionId,
+            clusterId: clusterId,
+            nodes: nodes,
+            confirmed: arguments["confirmed"]?.boolValue ?? true
+        ).asCallToolResult()
+
+    case "reconstruct_export_session":
+        guard let sessionId = arguments["sessionId"]?.stringValue else {
+            return ToolText("reconstruct_export_session requires `sessionId`.", isError: true).asCallToolResult()
+        }
+        return await ReconstructTools.exportSession(
+            sessionId: sessionId, path: arguments["path"]?.stringValue
+        ).asCallToolResult()
+
+    case "reconstruct_import_session":
+        guard let path = arguments["path"]?.stringValue else {
+            return ToolText("reconstruct_import_session requires `path`.", isError: true).asCallToolResult()
+        }
+        return await ReconstructTools.importSession(
+            path: path, sessionId: arguments["sessionId"]?.stringValue
+        ).asCallToolResult()
 
     default:
         return ToolText("Unknown tool: \(callName)", isError: true).asCallToolResult()

--- a/Sources/OCCTMCPCore/Tools/ReconstructTools.swift
+++ b/Sources/OCCTMCPCore/Tools/ReconstructTools.swift
@@ -1,0 +1,246 @@
+// ReconstructTools — the `reconstruct_*` MCP tool group (OCCTMCP #33).
+//
+// Read and write an attributed reconstruction graph from an LLM. Backed by
+// OCCTSwift 1.2.0's `NodeAttributeStore` + Codable `GraphSnapshot`, held in
+// the actor-backed `ReconstructRegistry` keyed by sessionId.
+//
+//   reconstruct_get_graph        read   export the attributed graph as JSON
+//   reconstruct_set_decision     write  annotate decidedBy + accept/reject a node
+//   reconstruct_force_fit        write  override a node's fitted surface type
+//   reconstruct_confirm_instances write confirm/reject a congruence cluster
+//   reconstruct_export_session   read   round-trip the graph snapshot to a file
+//   reconstruct_import_session   write  reload a snapshot from a file
+//
+// Scope boundary: OCCTMCP is the read/write layer only. The reconstruction
+// engine (surface fitting, congruence detection, the math behind residuals
+// and confidence) lives in OCCTReconstruct. `force_fit` records the
+// override for the engine to honour on its next pass — it does not re-fit
+// here. Nodes are addressed by the self-describing string `<kind>:<index>`
+// (e.g. `face:3`), parseable in both directions.
+
+import Foundation
+import OCCTSwift
+import ScriptHarness
+
+public enum ReconstructTools {
+
+    // ── reconstruct_get_graph ───────────────────────────────────────────
+    // Resolves the session: an existing one by `sessionId`, or a fresh one
+    // built from a body's BREP when `bodyId` is supplied (sessionId defaults
+    // to the bodyId). Returns topology counts + every annotated node + any
+    // instance clusters.
+
+    public static func getGraph(
+        sessionId: String? = nil,
+        bodyId: String? = nil,
+        store: ManifestStore = ManifestStore(),
+        registry: ReconstructRegistry = .shared
+    ) async -> ToolText {
+        guard let sid = sessionId ?? bodyId else {
+            return .init("reconstruct_get_graph requires `sessionId` or `bodyId`.", isError: true)
+        }
+        if await registry.hasSession(id: sid) == false {
+            guard let bodyId else {
+                return .init(
+                    "No session '\(sid)'. Provide `bodyId` to start a new reconstruction session from a scene body.",
+                    isError: true
+                )
+            }
+            do {
+                let loaded = try IntrospectionTools.loadShape(bodyId: bodyId, store: store)
+                guard let graph = TopologyGraph(shape: loaded.shape) else {
+                    return .init("Failed to build a topology graph for body '\(bodyId)'.", isError: true)
+                }
+                await registry.store(id: sid, graph: graph)
+            } catch {
+                return .init("\(error)", isError: true)
+            }
+        }
+        guard let state = await registry.state(id: sid) else {
+            return .init("No session '\(sid)'.", isError: true)
+        }
+        return IntrospectionTools.encode(state)
+    }
+
+    // ── reconstruct_set_decision ────────────────────────────────────────
+
+    public static func setDecision(
+        sessionId: String,
+        node: String,
+        decidedBy: String? = nil,
+        accepted: Bool? = nil,
+        registry: ReconstructRegistry = .shared
+    ) async -> ToolText {
+        if decidedBy == nil && accepted == nil {
+            return .init(
+                "reconstruct_set_decision requires at least one of `decidedBy` or `accepted`.",
+                isError: true
+            )
+        }
+        if let d = decidedBy, !["geometric", "ml", "human"].contains(d) {
+            return .init("`decidedBy` must be one of: geometric, ml, human.", isError: true)
+        }
+        let outcome = await registry.setDecision(
+            id: sessionId, nodeStr: node, decidedBy: decidedBy, accepted: accepted
+        )
+        return encodeWrite(outcome, sessionId: sessionId, tool: "reconstruct_set_decision")
+    }
+
+    // ── reconstruct_force_fit ───────────────────────────────────────────
+    // Records the forced surface type as an attribute. The actual re-fit is
+    // performed by the OCCTReconstruct engine on its next pass — out of
+    // scope for this read/write layer.
+
+    public static func forceFit(
+        sessionId: String,
+        node: String,
+        surfaceType: String,
+        registry: ReconstructRegistry = .shared
+    ) async -> ToolText {
+        if surfaceType.trimmingCharacters(in: .whitespaces).isEmpty {
+            return .init("reconstruct_force_fit requires a non-empty `surfaceType`.", isError: true)
+        }
+        let outcome = await registry.forceFit(
+            id: sessionId, nodeStr: node, surfaceType: surfaceType
+        )
+        return encodeWrite(outcome, sessionId: sessionId, tool: "reconstruct_force_fit")
+    }
+
+    // ── reconstruct_confirm_instances ───────────────────────────────────
+
+    public static func confirmInstances(
+        sessionId: String,
+        clusterId: String,
+        nodes: [String],
+        confirmed: Bool = true,
+        registry: ReconstructRegistry = .shared
+    ) async -> ToolText {
+        if nodes.isEmpty {
+            return .init("reconstruct_confirm_instances requires a non-empty `nodes` array.", isError: true)
+        }
+        let outcome = await registry.confirmInstances(
+            id: sessionId, clusterId: clusterId, nodeStrs: nodes, confirmed: confirmed
+        )
+        switch outcome {
+        case .noSession(let id):
+            return .init(ReconstructError.noSession(id).description, isError: true)
+        case .badNodes(let ns):
+            return .init(
+                "reconstruct_confirm_instances: could not parse nodes: \(ns.joined(separator: ", ")). Use `<kind>:<index>`, e.g. `face:3`.",
+                isError: true
+            )
+        case .ok(let cid, let members, let conf):
+            struct Result: Encodable {
+                let sessionId: String
+                let clusterId: String
+                let confirmed: Bool
+                let members: [String]
+            }
+            return IntrospectionTools.encode(
+                Result(sessionId: sessionId, clusterId: cid, confirmed: conf, members: members)
+            )
+        }
+    }
+
+    // ── reconstruct_export_session ──────────────────────────────────────
+    // Byte-stable (canonicalEncoder) snapshot to disk. Default path is
+    // <output_dir>/reconstruct/<sessionId>.session.json.
+
+    public static func exportSession(
+        sessionId: String,
+        path: String? = nil,
+        registry: ReconstructRegistry = .shared
+    ) async -> ToolText {
+        let snapshot: GraphSnapshot
+        do {
+            snapshot = try await registry.makeSnapshot(id: sessionId)
+        } catch let e as ReconstructError {
+            return .init(e.description, isError: true)
+        } catch {
+            return .init("reconstruct_export_session failed: \(error)", isError: true)
+        }
+        let outPath = path ?? "\(OCCTMCPPaths.outputDir())/reconstruct/\(sessionId).session.json"
+        do {
+            let data = try GraphSnapshot.canonicalEncoder().encode(snapshot)
+            let url = URL(fileURLWithPath: outPath)
+            try FileManager.default.createDirectory(
+                at: url.deletingLastPathComponent(), withIntermediateDirectories: true
+            )
+            try data.write(to: url, options: .atomic)
+        } catch {
+            return .init("reconstruct_export_session: write failed: \(error)", isError: true)
+        }
+        struct Result: Encodable {
+            let sessionId: String
+            let path: String
+            let annotatedNodeCount: Int
+            let formatVersion: Int
+        }
+        return IntrospectionTools.encode(Result(
+            sessionId: sessionId,
+            path: outPath,
+            annotatedNodeCount: snapshot.attributes.annotatedNodeCount,
+            formatVersion: snapshot.formatVersion
+        ))
+    }
+
+    // ── reconstruct_import_session ──────────────────────────────────────
+    // Reload a snapshot file into a session and return its state. sessionId
+    // defaults to the file's stem (sans .session.json / .json).
+
+    public static func importSession(
+        path: String,
+        sessionId: String? = nil,
+        registry: ReconstructRegistry = .shared
+    ) async -> ToolText {
+        guard FileManager.default.fileExists(atPath: path) else {
+            return .init("reconstruct_import_session: file not found: \(path)", isError: true)
+        }
+        let snapshot: GraphSnapshot
+        do {
+            let data = try Data(contentsOf: URL(fileURLWithPath: path))
+            snapshot = try JSONDecoder().decode(GraphSnapshot.self, from: data)
+        } catch {
+            return .init("reconstruct_import_session: decode failed: \(error)", isError: true)
+        }
+        let graph: TopologyGraph
+        do {
+            graph = try TopologyGraph(snapshot: snapshot)
+        } catch {
+            return .init("reconstruct_import_session: rebuild failed: \(error)", isError: true)
+        }
+        let sid = sessionId ?? (path as NSString).lastPathComponent
+            .replacingOccurrences(of: ".session.json", with: "")
+            .replacingOccurrences(of: ".json", with: "")
+        await registry.store(id: sid, graph: graph)
+        guard let state = await registry.state(id: sid) else {
+            return .init("reconstruct_import_session: session unavailable after import.", isError: true)
+        }
+        return IntrospectionTools.encode(state)
+    }
+
+    // ── shared single-node write encoder ────────────────────────────────
+
+    private static func encodeWrite(
+        _ outcome: ReconstructWriteOutcome, sessionId: String, tool: String
+    ) -> ToolText {
+        switch outcome {
+        case .noSession(let id):
+            return .init(ReconstructError.noSession(id).description, isError: true)
+        case .badNode(let n):
+            return .init(
+                "\(tool): could not parse node '\(n)'. Use `<kind>:<index>`, e.g. `face:3`.",
+                isError: true
+            )
+        case .ok(let node, let attributes):
+            struct Result: Encodable {
+                let sessionId: String
+                let node: String
+                let attributes: [String: AnyCodable]
+            }
+            return IntrospectionTools.encode(
+                Result(sessionId: sessionId, node: node, attributes: attributes)
+            )
+        }
+    }
+}

--- a/SwiftTests/OCCTMCPCoreTests/ReconstructToolsTests.swift
+++ b/SwiftTests/OCCTMCPCoreTests/ReconstructToolsTests.swift
@@ -1,0 +1,148 @@
+// Unit tests for the reconstruct_* tool group (OCCTMCP #33): per-node
+// attribute writes over OCCTSwift 1.2.0's NodeAttributeStore, and the
+// GraphSnapshot export/import round-trip that must preserve every
+// annotation. Runs fully in-process — no occtkit, no manifest — by
+// building a box graph directly and driving the ReconstructRegistry.
+
+import Foundation
+import Testing
+import OCCTSwift
+import ScriptHarness
+@testable import OCCTMCPCore
+
+private extension AnyCodable {
+    /// Test-side unwrap for the string payload (the get_graph attributes map
+    /// carries reconstruct.* values as AnyCodable).
+    var asString: String? { if case let .string(s) = self { return s } else { return nil } }
+}
+
+@Suite("reconstruct_* graph read/write", .serialized)
+struct ReconstructToolsTests {
+
+    /// Fresh registry + a box-backed graph stored under `id`.
+    private func makeSession(id: String) async throws -> ReconstructRegistry {
+        let box = try #require(Shape.box(width: 10, height: 20, depth: 30))
+        let graph = try #require(TopologyGraph(shape: box))
+        let registry = ReconstructRegistry()
+        await registry.store(id: id, graph: graph)
+        return registry
+    }
+
+    @Test("node addressing round-trips through parse/format")
+    func nodeAddressing() {
+        for kindName in ["face", "edge", "vertex", "solid", "shell", "wire", "compound"] {
+            let s = "\(kindName):7"
+            let ref = ReconstructRegistry.parse(s)
+            #expect(ref != nil)
+            #expect(ReconstructRegistry.format(ref!) == s)
+        }
+        #expect(ReconstructRegistry.parse("bogus:1") == nil)
+        #expect(ReconstructRegistry.parse("face") == nil)
+        #expect(ReconstructRegistry.parse("face:notanint") == nil)
+    }
+
+    @Test("set_decision writes decidedBy + accepted onto a node")
+    func setDecisionWrites() async throws {
+        let registry = try await makeSession(id: "s1")
+        let outcome = await registry.setDecision(
+            id: "s1", nodeStr: "face:0", decidedBy: "human", accepted: true
+        )
+        guard case let .ok(node, attrs) = outcome else {
+            Issue.record("expected .ok, got \(outcome)")
+            return
+        }
+        #expect(node == "face:0")
+        #expect(attrs[ReconstructKeys.decidedBy]?.asString == "human")
+        if case .bool(let b)? = attrs[ReconstructKeys.accepted] { #expect(b) } else { Issue.record("accepted not a bool") }
+    }
+
+    @Test("set_decision on unknown session reports noSession")
+    func setDecisionNoSession() async {
+        let registry = ReconstructRegistry()
+        let outcome = await registry.setDecision(id: "ghost", nodeStr: "face:0", decidedBy: "ml", accepted: nil)
+        guard case .noSession = outcome else {
+            Issue.record("expected .noSession, got \(outcome)")
+            return
+        }
+    }
+
+    @Test("confirm_instances tags every member and surfaces as a cluster")
+    func confirmInstancesClusters() async throws {
+        let registry = try await makeSession(id: "s2")
+        let outcome = await registry.confirmInstances(
+            id: "s2", clusterId: "wheel", nodeStrs: ["face:0", "face:1", "face:2"], confirmed: true
+        )
+        guard case .ok = outcome else {
+            Issue.record("expected .ok, got \(outcome)")
+            return
+        }
+        let state = try #require(await registry.state(id: "s2"))
+        let cluster = try #require(state.instanceClusters.first { $0.clusterId == "wheel" })
+        #expect(cluster.members.count == 3)
+        #expect(cluster.confirmed)
+    }
+
+    @Test("export → import round-trip preserves all annotations")
+    func snapshotRoundTrip() async throws {
+        let registry = try await makeSession(id: "src")
+        _ = await registry.setDecision(id: "src", nodeStr: "face:0", decidedBy: "geometric", accepted: false)
+        _ = await registry.forceFit(id: "src", nodeStr: "face:1", surfaceType: "cylinder")
+        _ = await registry.confirmInstances(id: "src", clusterId: "c1", nodeStrs: ["face:2", "face:3"], confirmed: true)
+
+        // Export → JSON bytes → decode → rebuild into a brand-new registry.
+        let snapshot = try await registry.makeSnapshot(id: "src")
+        let data = try GraphSnapshot.canonicalEncoder().encode(snapshot)
+        let decoded = try JSONDecoder().decode(GraphSnapshot.self, from: data)
+        let rebuilt = try TopologyGraph(snapshot: decoded)
+        let registry2 = ReconstructRegistry()
+        await registry2.store(id: "dst", graph: rebuilt)
+
+        let state = try #require(await registry2.state(id: "dst"))
+        // Annotated nodes: face:0, face:1, face:2, face:3 → 4.
+        #expect(state.annotatedNodeCount == 4)
+
+        let face0 = try #require(state.nodes.first { $0.node == "face:0" })
+        #expect(face0.attributes[ReconstructKeys.decidedBy]?.asString == "geometric")
+
+        let face1 = try #require(state.nodes.first { $0.node == "face:1" })
+        #expect(face1.attributes[ReconstructKeys.forcedSurfaceType]?.asString == "cylinder")
+
+        let cluster = try #require(state.instanceClusters.first { $0.clusterId == "c1" })
+        #expect(cluster.members.sorted() == ["face:2", "face:3"])
+        #expect(cluster.confirmed)
+
+        // Byte-stable: re-encoding the rebuilt snapshot reproduces the bytes.
+        let snapshot2 = try await registry2.makeSnapshot(id: "dst")
+        let data2 = try GraphSnapshot.canonicalEncoder().encode(snapshot2)
+        #expect(data == data2)
+    }
+
+    @Test("getGraph builds a fresh session from a manifest body id")
+    func getGraphFromBody() async throws {
+        // Drive the tool layer end to end against a tempdir manifest so the
+        // bodyId → BREP → graph path is covered, not just the registry.
+        let tmp = FileManager.default.temporaryDirectory
+            .appendingPathComponent("occtmcp-recon-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: tmp, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tmp) }
+
+        let box = try #require(Shape.box(width: 5, height: 5, depth: 5))
+        let brepPath = tmp.appendingPathComponent("part.brep")
+        try box.writeBREP(to: brepPath)
+
+        let manifest = ScriptManifest(
+            description: "test",
+            bodies: [BodyDescriptor(id: "part", file: "part.brep", format: "brep")]
+        )
+        let store = ManifestStore(path: tmp.appendingPathComponent("manifest.json").path)
+        try store.write(manifest)
+
+        let registry = ReconstructRegistry()
+        let result = await ReconstructTools.getGraph(
+            sessionId: nil, bodyId: "part", store: store, registry: registry
+        )
+        #expect(!result.isError)
+        #expect(result.text.contains("\"faces\""))
+        #expect(await registry.hasSession(id: "part"))
+    }
+}


### PR DESCRIPTION
## What

Adds the **`reconstruct_*` MCP tool group** — six tools that let an LLM **read and write** an attributed reconstruction graph, the missing piece for driving the [OCCTReconstruct](https://github.com/gsdali/OCCTReconstruct) mesh-to-solid use case from a model. Closes #33.

Backed by **OCCTSwift 1.2.0**'s new `TopologyGraph` per-node attribute store + Codable `GraphSnapshot` (upstream #168, which landed today). Pin bumped `1.1.0 → 1.2.0`.

| Tool | Direction | Purpose |
|---|---|---|
| `reconstruct_get_graph` | read | Topology counts + annotated nodes (with `reconstruct.*` attrs) + instance clusters |
| `reconstruct_set_decision` | write | `decidedBy` (geometric/ml/human) + accept/reject |
| `reconstruct_force_fit` | write | Record a forced surface-type override |
| `reconstruct_confirm_instances` | write | Confirm/reject a congruence cluster |
| `reconstruct_export_session` | read | Byte-stable `GraphSnapshot` to disk |
| `reconstruct_import_session` | write | Reload a snapshot into a session |

## Design

- **`ReconstructRegistry`** (new actor) — `sessionId → TopologyGraph`, mirroring `SelectionRegistry`/`HistoryRegistry`. All graph access is actor-isolated so the `@unchecked Sendable` graph is never mutated concurrently.
- Nodes addressed by the self-describing `<kind>:<index>` string (e.g. `face:3`), parseable both ways.
- `reconstruct.*` namespaced attribute keys. Engine-written keys (residual/confidence/etc.) round-trip through `get_graph`/`export_session` untouched.
- **Scope:** the reconstruction *engine* (surface fitting, congruence detection) lives in OCCTReconstruct. The issue listed `force_fit` as "override **and re-fit**", which conflicts with its own out-of-scope note — resolved toward out-of-scope: `force_fit` **records the override** for the engine to honour, it does not re-fit here. Documented in the tool description, README, and code.
- Swift-only, consistent with selection/remap/annotations/history (Node remains the portable 36-tool subset).

## Acceptance (from #33)

- [x] `reconstruct_get_graph` returns attributed JSON (attrs + provenance + instances)
- [x] each write tool mutates the graph and the change survives an export/import round-trip
- [x] `export_session` → `import_session` reproduces all annotations
- [x] tools registered in the canonical (Swift) manifest

## Verification

`swift build` clean; **all 34 tests pass** (was 28). New `ReconstructToolsTests.swift` covers node addressing, each write path, the export→import round-trip, and byte-stability of the canonical snapshot. Tool count **50 → 56**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
