### PR TITLE
feat(measure): pick_surface_point + repin viewport 1.1.20

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "fd106e498eb0f75b0da3a758cfb28c2760bbe82c6a3d794d01a9f134d3b4a73c",
+  "originHash" : "0c243d6dde36727749fa1af1a24439b0b23232f0a206b5125c34f1064a67b24a",
   "pins" : [
     {
       "identity" : "eventsource",
@@ -69,8 +69,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/gsdali/OCCTSwiftViewport.git",
       "state" : {
-        "revision" : "6c8e95e62e2b25666ba9160af24bce22c7ccb08c",
-        "version" : "1.0.4"
+        "revision" : "069d894a9c3f9c366e4387eff2cda796703faf99",
+        "version" : "1.1.20"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -54,10 +54,13 @@ let package = Package(
         .package(url: "https://github.com/gsdali/OCCTSwiftMesh.git", from: "1.0.0"),
         .package(url: "https://github.com/gsdali/OCCTSwiftScripts.git", from: "1.0.3"),
         .package(url: "https://github.com/gsdali/OCCTSwiftTools.git", from: "1.1.1"),
-        // Viewport floored at 1.0.4: 1.0.3 fixes an uncatchable quantize()
+        // Viewport floored at 1.1.20: 1.0.3 fixes an uncatchable quantize()
         // crash on body load (Viewport #30) that would trap the MCP server
-        // during render-preview; 1.0.4 makes the package dependency-free.
-        .package(url: "https://github.com/gsdali/OCCTSwiftViewport.git", from: "1.0.4"),
+        // during render-preview; 1.0.4 makes the package dependency-free;
+        // 1.1.20 adds tap-to-measure (Viewport #68) and
+        // ViewportBody.worldHitPoint(ray:triangleIndex:) — ray → world
+        // surface-point reconstruction that respects the body transform.
+        .package(url: "https://github.com/gsdali/OCCTSwiftViewport.git", from: "1.1.20"),
         .package(url: "https://github.com/gsdali/OCCTSwiftAIS.git", from: "1.0.2"),
     ],
     targets: [

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ MCP server that gives LLMs the ability to author, inspect, and iterate on 3D CAD
 
 Part of the [OCCTSwift ecosystem](https://github.com/gsdali/OCCTSwift/blob/main/docs/ecosystem.md) — see the ecosystem map for how this package sits on top of the kernel, viewport, bridge, and AIS layers. SemVer-stable from v1.0.0.
 
-The Swift implementation calls OCCT directly in-process — no subprocess, no JSONL marshalling — and exposes 56 typed MCP tools that cover authoring, scene reads, mutation, introspection, construction, analysis, I/O, mesh, drawing, selection / remap, and dimension overlays.
+The Swift implementation calls OCCT directly in-process — no subprocess, no JSONL marshalling — and exposes 57 typed MCP tools that cover authoring, scene reads, mutation, introspection, construction, analysis, I/O, mesh, drawing, selection / remap, and dimension overlays.
 
 ## How It Works
 
@@ -22,7 +22,7 @@ For novel geometry the typed tools don't cover, the LLM falls back to `execute_s
 
 ## Tools
 
-56 tools, organized below. Call `get_api_reference({ category: "mcp_tools" })` to dump every tool's JSON Schema in one shot — useful for LLM auto-discovery. Most flows can answer "what's the volume?", "make it red", "boolean-subtract these", "render a preview", "add a dimension between these two faces", "export to STEP", and "draw this" without ever touching `execute_script`.
+57 tools, organized below. Call `get_api_reference({ category: "mcp_tools" })` to dump every tool's JSON Schema in one shot — useful for LLM auto-discovery. Most flows can answer "what's the volume?", "make it red", "boolean-subtract these", "render a preview", "add a dimension between these two faces", "export to STEP", and "draw this" without ever touching `execute_script`.
 
 ### Authoring
 
@@ -116,6 +116,7 @@ For novel geometry the typed tools don't cover, the LLM falls back to `execute_s
 | `generate_mesh` | Tessellate to triangles + quality metrics |
 | `simplify_mesh` | QEM mesh decimation to .stl/.obj — wraps OCCTSwiftMesh's `Mesh.simplified` (vendored meshoptimizer) |
 | `render_preview` | One-shot PNG render with measurement labels and primitive overlays |
+| `pick_surface_point` | Cast a render_preview-framed ray through a pixel → world surface point + selectionId (usable as an `add_dimension` anchor) |
 | `generate_drawing` | Multi-view ISO 128-30 DXF technical drawing |
 
 ### Topology graph (low-level)
@@ -145,7 +146,7 @@ LLM read/write over an attributed reconstruction graph — annotate per-node dec
 
 This repo ships two implementations side-by-side:
 
-- **Swift** (`Sources/`, `Package.swift`) — the **primary** server. In-process against OCCTSwift / OCCTSwiftMesh / OCCTSwiftTools / OCCTSwiftAIS / DrawingComposer using the [official Swift MCP SDK](https://swiftpackageindex.com/modelcontextprotocol/swift-sdk). 56 tools. macOS 15+ (the OCCT.xcframework arm64 platform).
+- **Swift** (`Sources/`, `Package.swift`) — the **primary** server. In-process against OCCTSwift / OCCTSwiftMesh / OCCTSwiftTools / OCCTSwiftAIS / DrawingComposer using the [official Swift MCP SDK](https://swiftpackageindex.com/modelcontextprotocol/swift-sdk). 57 tools. macOS 15+ (the OCCT.xcframework arm64 platform).
 - **Node / TypeScript** (`src/`, `dist/`) — the original implementation. Shells out to the `occtkit` CLI for everything Swift-side. 36 tools (the pre-v0.4 surface; selection / remap / annotations are Swift-only). Useful if you can't run a macOS binary.
 
 Both speak stdio MCP and read/write the same manifest format.

--- a/Sources/OCCTMCPCore/SelectionRegistry.swift
+++ b/Sources/OCCTMCPCore/SelectionRegistry.swift
@@ -146,6 +146,15 @@ public actor SelectionRegistry {
         snapshots[id] = snapshot
     }
 
+    /// Record a snapshot under an arbitrary selectionId that isn't a
+    /// topology sub-shape — e.g. a `pick:<bodyId>#N` surface point from
+    /// `pick_surface_point`. There's no `TopologyAnchor` for a free point,
+    /// so only the snapshot is stored; `add_dimension` resolves anchors via
+    /// `snapshot(for:)`, so the picked point composes as a dimension anchor.
+    public func recordPointSnapshot(selectionId: String, snapshot: AnchorSnapshot) {
+        snapshots[selectionId] = snapshot
+    }
+
     public func anchor(for selectionId: String) -> TopologyAnchor? {
         if let cached = anchors[selectionId] { return cached }
         // Fall back to parsing — selectionId is self-describing so a

--- a/Sources/OCCTMCPCore/Server.swift
+++ b/Sources/OCCTMCPCore/Server.swift
@@ -375,6 +375,24 @@ func catalogTools() -> [Tool] {
             ])
         ),
         Tool(
+            name: "pick_surface_point",
+            description: "Cast a ray through pixel (screenX, screenY) of a render_preview-framed view and return the nearest world-space surface point [x,y,z] on a body, plus the bodyId and a selectionId. Pass the SAME options (camera / width / height) you rendered the preview with so the pixel maps to the same ray. The returned selectionId is a valid add_dimension anchor, so you can pick two points and dimension between them — measure to an arbitrary point on a face, not just a topology centroid.",
+            inputSchema: .object([
+                "type": .string("object"),
+                "properties": .object([
+                    "screenX": .object(["type": .string("number"), "description": .string("Pixel X (top-left origin) in the options.width×height image.")]),
+                    "screenY": .object(["type": .string("number"), "description": .string("Pixel Y (top-left origin) in the options.width×height image.")]),
+                    "id": .object(["type": .string("string"), "description": .string("Optional explicit selectionId for the picked point.")]),
+                    "options": .object([
+                        "type": .string("object"),
+                        "description": .string("Camera / framing — same shape as render_preview.options (camera, cameraPosition/Target/Up, width, height)."),
+                    ]),
+                ]),
+                "required": .array([.string("screenX"), .string("screenY")]),
+                "additionalProperties": .bool(false),
+            ])
+        ),
+        Tool(
             name: "remap_selection",
             description: "Remap selectionIds across a scene mutation using a position-matching heuristic (closest-centroid within a body-bbox-relative tolerance). Returns each input mapped to zero or more new selectionIds plus a `fate` ('preserved' | 'approximate' | 'lost'). High-confidence for transforms / in-place edits; approximate for fillets / chamfers / boolean splits.",
             inputSchema: .object([
@@ -1287,6 +1305,20 @@ func dispatch(callName: String, arguments: [String: Value]) async -> CallTool.Re
         let opts = parseRenderOptions(arguments["options"])
         return await RenderPreviewTool.render(
             outputPath: outputPath, bodyIds: ids, options: opts
+        ).asCallToolResult()
+
+    case "pick_surface_point":
+        // numberValue (not doubleValue): an integer pixel like 200 round-trips
+        // through JSON to Value.int, and doubleValue returns nil for .int.
+        guard let sx = arguments["screenX"]?.numberValue,
+              let sy = arguments["screenY"]?.numberValue else {
+            return ToolText("pick_surface_point requires `screenX` and `screenY`.", isError: true).asCallToolResult()
+        }
+        return await RayPickTool.pickSurfacePoint(
+            screenX: sx,
+            screenY: sy,
+            options: parseRenderOptions(arguments["options"]),
+            id: arguments["id"]?.stringValue
         ).asCallToolResult()
 
     case "execute_script":

--- a/Sources/OCCTMCPCore/Tools/RayPickTool.swift
+++ b/Sources/OCCTMCPCore/Tools/RayPickTool.swift
@@ -1,0 +1,119 @@
+// RayPickTool — pick_surface_point. Resolves a screen coordinate (in the
+// same camera/framing as render_preview) to a world-space point on the
+// nearest body surface, by casting a camera ray into the scene.
+//
+// This surfaces the viewport's pick math headlessly: the interactive client
+// gained tap-to-measure in OCCTSwiftViewport 1.1.20 (#68, including
+// ViewportBody.worldHitPoint ray→surface reconstruction); here an LLM that
+// is looking at a render_preview PNG can name a pixel and get back the
+// measurable world point under it. The returned selectionId is a valid
+// add_dimension anchor, so pick → measure composes with the existing
+// dimensioning pipeline.
+
+import Foundation
+import simd
+import OCCTSwift
+import OCCTSwiftTools
+import OCCTSwiftViewport
+import ScriptHarness
+
+public enum RayPickTool {
+
+    public struct PickReport: Encodable {
+        public let hit: Bool
+        public let bodyId: String?
+        /// World-space surface point [x, y, z] (mm).
+        public let point: [Double]?
+        /// Distance from the camera/ray origin to the hit (mm).
+        public let distance: Double?
+        /// Stable id for the picked point, usable directly as an
+        /// `add_dimension` anchor (e.g. anchors.from = this id).
+        public let selectionId: String?
+        /// Human note when nothing was under the coordinate.
+        public let note: String?
+    }
+
+    /// Cast a ray through pixel (`screenX`, `screenY`) of a `width`×`height`
+    /// view framed exactly like `render_preview` with the same `options`, and
+    /// return the nearest surface point.
+    ///
+    /// - Parameters:
+    ///   - screenX/screenY: pixel coordinates, top-left origin, in the
+    ///     `options.width`×`options.height` image space (matching the preview).
+    ///   - id: optional explicit selectionId for the picked point.
+    @MainActor
+    public static func pickSurfacePoint(
+        screenX: Double,
+        screenY: Double,
+        options: RenderPreviewTool.Options = .init(),
+        id: String? = nil,
+        store: ManifestStore = ManifestStore(),
+        registry: SelectionRegistry = .shared
+    ) async -> ToolText {
+        guard let manifest = try? store.read() else {
+            return .init("No scene loaded. Run execute_script first.")
+        }
+        let outputDir = (store.path as NSString).deletingLastPathComponent
+
+        var bodies: [ViewportBody] = []
+        for body in manifest.bodies {
+            let path = "\(outputDir)/\(body.file)"
+            do {
+                let shape = try Shape.loadBREP(fromPath: path)
+                let color = RenderPreviewTool.bodyColor(body)
+                let bid = body.id ?? UUID().uuidString
+                let (vb, _) = CADFileLoader.shapeToBodyAndMetadata(shape, id: bid, color: color)
+                if let vb = vb { bodies.append(vb) }
+            } catch {
+                return .init(
+                    "Failed to load body \(body.id ?? body.file): \(error.localizedDescription)",
+                    isError: true
+                )
+            }
+        }
+        if bodies.isEmpty {
+            return .init("No bodies in scene to pick.")
+        }
+
+        // Same camera + framing as render_preview, so a pixel the LLM reads
+        // off a preview maps to the same ray.
+        let state = RenderPreviewTool.makeCameraState(options: options, bodies: bodies)
+        let width = max(options.width, 1)
+        let height = max(options.height, 1)
+        let aspect = Float(width) / Float(height)
+
+        // Pixel (top-left origin) → NDC (centre origin, y up), matching
+        // MetalViewportView.handlePickAt.
+        let ndcX = Float(screenX / Double(width)) * 2 - 1
+        let ndcY = Float(1 - screenY / Double(height)) * 2 - 1
+        let ray = Ray.fromCamera(ndc: SIMD2(ndcX, ndcY), cameraState: state, aspectRatio: aspect)
+
+        var bbCache: [String: BoundingBox] = [:]
+        for body in bodies where body.boundingBox != nil {
+            bbCache[body.id] = body.boundingBox
+        }
+
+        guard let hit = SceneRaycast.cast(ray: ray, bodies: bodies, boundingBoxCache: bbCache) else {
+            return IntrospectionTools.encode(PickReport(
+                hit: false, bodyId: nil, point: nil, distance: nil, selectionId: nil,
+                note: "No surface under (\(Int(screenX)), \(Int(screenY))) in this view."
+            ))
+        }
+
+        let p = hit.point
+        let pickId = id ?? "pick:\(hit.bodyID)#\(UUID().uuidString.prefix(8))"
+        await registry.recordPointSnapshot(
+            selectionId: pickId,
+            snapshot: AnchorSnapshot(center: [Double(p.x), Double(p.y), Double(p.z)])
+        )
+
+        return IntrospectionTools.encode(PickReport(
+            hit: true,
+            bodyId: hit.bodyID,
+            point: [Double(p.x), Double(p.y), Double(p.z)],
+            distance: Double(hit.distance),
+            selectionId: pickId,
+            note: nil
+        ))
+    }
+}

--- a/SwiftTests/OCCTMCPCoreTests/IntegrationTests.swift
+++ b/SwiftTests/OCCTMCPCoreTests/IntegrationTests.swift
@@ -81,6 +81,7 @@ struct IntegrationTests {
         }
         for expected in [
             "ping", "get_scene", "execute_script", "render_preview",
+            "pick_surface_point",
             "compute_metrics", "boolean_op", "set_assembly_metadata",
             "check_thickness",
         ] {
@@ -298,6 +299,105 @@ struct IntegrationTests {
         // PNG with a body + dimension overlay should comfortably exceed
         // ~2 KB. A blank 400×300 RGBA PNG is ~700 bytes.
         #expect(size > 2_000, "rendered PNG was \(size) bytes — overlay may not have been drawn")
+    }
+
+    @Test("pick_surface_point hits a body and composes into add_dimension")
+    func pickSurfacePointMeasures() async throws {
+        guard let binary = Self.binaryURL else {
+            Issue.record("Binary not built — run `swift build` first.")
+            return
+        }
+        let scene = NSTemporaryDirectory() + "occtmcp-it-pick-\(UUID().uuidString)"
+        try FileManager.default.createDirectory(atPath: scene, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(atPath: scene) }
+
+        // A box: its 8 pick-vertices give an interior centroid, so the
+        // centre-pixel ray (which the framing aims at the centroid) crosses two
+        // faces and reliably hits. A cylinder's sparse seam vertices would put
+        // the framing pivot on the lateral surface → grazing ray.
+        guard let box = Shape.box(width: 20, height: 20, depth: 20) else {
+            Issue.record("Failed to synthesise box fixture")
+            return
+        }
+        try Exporter.writeBREP(shape: box, to: URL(fileURLWithPath: "\(scene)/box.brep"))
+        let store = ManifestStore(path: "\(scene)/manifest.json")
+        try store.write(ScriptManifest(
+            description: "pick_surface_point test scene",
+            bodies: [BodyDescriptor(id: "box", file: "box.brep", color: [0.8, 0.7, 0.3, 1])]
+        ))
+
+        let harness = try Harness(binary: binary, extraEnv: ["OCCTMCP_OUTPUT_DIR": scene])
+        defer { harness.terminate() }
+        try harness.handshake()
+
+        // The centre pixel ray passes through the framing pivot (bbox centre),
+        // which is interior to the solid, so it must hit a boundary face. Two
+        // different camera presets give two distinct surface points.
+        func pick(id: Int, camera: String) throws -> String {
+            try harness.send(.init(
+                id: id, method: "tools/call",
+                params: .object([
+                    "name": .string("pick_surface_point"),
+                    "arguments": .object([
+                        "screenX": .double(200),
+                        "screenY": .double(150),
+                        "options": .object([
+                            "camera": .string(camera),
+                            "width": .int(400),
+                            "height": .int(300),
+                        ]),
+                    ]),
+                ])
+            ))
+            let resp = try harness.recv(timeout: 30)
+            guard case .object(let result)? = resp["result"],
+                  case .array(let content)? = result["content"],
+                  case .object(let first)? = content.first,
+                  let text = first["text"]?.stringValue,
+                  let data = text.data(using: .utf8) else {
+                throw Harness.HarnessError.unexpectedShape("pick_surface_point response envelope")
+            }
+            guard let parsed = (try? JSONSerialization.jsonObject(with: data)) as? [String: Any] else {
+                Issue.record("pick_surface_point (\(camera)) returned non-JSON: \(text)")
+                throw Harness.HarnessError.unexpectedShape("pick_surface_point body not JSON")
+            }
+            #expect(parsed["hit"] as? Bool == true, "centre-pixel pick missed the solid (\(camera))")
+            #expect(parsed["bodyId"] as? String == "box")
+            guard let sel = parsed["selectionId"] as? String else {
+                throw Harness.HarnessError.unexpectedShape("pick_surface_point returned no selectionId")
+            }
+            return sel
+        }
+
+        let front = try pick(id: 50, camera: "front")
+        let top = try pick(id: 51, camera: "top")
+
+        // The picked points must be usable directly as add_dimension anchors.
+        try harness.send(.init(
+            id: 52, method: "tools/call",
+            params: .object([
+                "name": .string("add_dimension"),
+                "arguments": .object([
+                    "kind": .string("linear"),
+                    "id": .string("pick_span"),
+                    "anchors": .object(["from": .string(front), "to": .string(top)]),
+                ]),
+            ])
+        ))
+        let dimResp = try harness.recv(timeout: 10)
+        #expect(dimResp["error"] == nil)
+        guard case .object(let dimResult)? = dimResp["result"],
+              case .array(let dimContent)? = dimResult["content"],
+              case .object(let dimFirst)? = dimContent.first,
+              let dimText = dimFirst["text"]?.stringValue,
+              let dimData = dimText.data(using: .utf8),
+              let dimParsed = try JSONSerialization.jsonObject(with: dimData) as? [String: Any] else {
+            Issue.record("add_dimension response shape unexpected")
+            return
+        }
+        // A non-zero span between two distinct surface points.
+        let value = (dimParsed["value"] as? Double) ?? 0
+        #expect(value > 0, "dimension between two picked points was \(value)")
     }
 
     @Test("history-based remap survives boolean_op via per-input history")
@@ -1255,7 +1355,7 @@ final class Harness {
             if let line = nextLine() {
                 let parsed = try JSONDecoder().decode(Value.self, from: line)
                 guard case .object(let dict) = parsed else {
-                    throw HarnessError.unexpectedShape("top-level not an object")
+                    throw Harness.HarnessError.unexpectedShape("top-level not an object")
                 }
                 return dict
             }


### PR DESCRIPTION
## Summary
Repins `OCCTSwiftViewport` `1.0.4 → 1.1.20` (tap-to-measure, gsdali/OCCTSwiftViewport#68) and adds **`pick_surface_point`**, a new MCP tool that surfaces the viewport's ray→surface-point pick math in a headless server.

OCCTMCP already exposes measurement *rendering* fully (`add_dimension`, `auto_dimension`, `measure_distance` → `annotations.json` → `ViewportMeasurement` overlay). The new viewport work is interaction-only, but it unlocks one genuinely-new headless capability: resolving a screen coordinate to a world surface point on a face.

## `pick_surface_point`
Casts a ray through pixel `(screenX, screenY)` of a `render_preview`-framed view (same `options` you render with, so the pixel maps to the same ray) and returns:
- `hit`, `bodyId`, `point` `[x,y,z]`, `distance`
- a `selectionId` registered in the `SelectionRegistry` — **usable directly as an `add_dimension` anchor**

So you can pick two arbitrary surface points and dimension between them — not just topology centroids. Implemented with `Ray.fromCamera` + `SceneRaycast.cast` over the scene bodies.

## Changes
- `Package.swift` / `Package.resolved`: viewport floor `1.1.20`.
- `RayPickTool.swift`: the tool.
- `SelectionRegistry.recordPointSnapshot`: stores a snapshot under a free-point `pick:<bodyId>#<n>` id (no `TopologyAnchor` for a free point; `add_dimension` resolves anchors via `snapshot(for:)`).
- `Server.swift`: `catalogTools()` + `dispatch()` wiring. Uses `numberValue` (not `doubleValue`) so an integer pixel like `200` survives the JSON int/double round-trip.
- `IntegrationTests.pickSurfacePointMeasures`: pick ×2 (front + top) → `add_dimension` → non-zero span. **35 tests pass.**
- README: 57 tools.

## Notes
- The incremental build initially hit a stale-artifact link error (`OCCTSwiftAIS 1.0.2` cached against the pre-`isPickable` `ViewportBody.init`); a clean build recompiles AIS against 1.1.20 and links cleanly — AIS 1.0.2 is source-compatible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)