### PR TITLE
feat(drawing): general-arrangement / assembly drawings via DrawingComposer 1.0.4

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "0c243d6dde36727749fa1af1a24439b0b23232f0a206b5125c34f1064a67b24a",
+  "originHash" : "ccb76d2d1034dbb5bbdce4fb8956687d881647caf512aab71966932f29ae4a68",
   "pins" : [
     {
       "identity" : "eventsource",
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/gsdali/OCCTSwift.git",
       "state" : {
-        "revision" : "12b37d2a49e9c391f84cbc735ec512b228d7d4bc",
-        "version" : "1.2.0"
+        "revision" : "c32f4943616c3683c16454cec0042d46e82b376a",
+        "version" : "1.4.0"
       }
     },
     {
@@ -51,8 +51,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/gsdali/OCCTSwiftScripts.git",
       "state" : {
-        "revision" : "6d790b270d517cf4fc672db0c1b2251bd505d901",
-        "version" : "1.0.3"
+        "revision" : "2c3f8130b219db77ad5faa37506ae6ba808f46e7",
+        "version" : "1.0.4"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -50,9 +50,17 @@ let package = Package(
         // pipeline. Combined with OCCTSwiftTools 1.1.0 wiring
         // pointRadius / vertexColors through to ViewportBody, the
         // pointCloud annotation now actually renders.
-        .package(url: "https://github.com/gsdali/OCCTSwift.git", from: "1.2.0"),
+        //
+        // Floored at 1.3.1 because OCCTSwiftScripts 1.0.4 (GA / assembly
+        // drawings, #50) raised its own OCCTSwift floor to 1.3.1; resolves
+        // to 1.4.0 (OCCT.xcframework 1.3.2) in the current cohort.
+        .package(url: "https://github.com/gsdali/OCCTSwift.git", from: "1.3.1"),
         .package(url: "https://github.com/gsdali/OCCTSwiftMesh.git", from: "1.0.0"),
-        .package(url: "https://github.com/gsdali/OCCTSwiftScripts.git", from: "1.0.3"),
+        // 1.0.4 adds DrawingComposer GA / assembly drawings (OCCTSwiftScripts#50):
+        // Composer.render(spec:components:) / render(spec:document:) — multi-body
+        // drawings with a parts list + balloons. Surfaced via generate_drawing's
+        // bodyIds.
+        .package(url: "https://github.com/gsdali/OCCTSwiftScripts.git", from: "1.0.4"),
         .package(url: "https://github.com/gsdali/OCCTSwiftTools.git", from: "1.1.1"),
         // Viewport floored at 1.1.20: 1.0.3 fixes an uncatchable quantize()
         // crash on body load (Viewport #30) that would trap the MCP server

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ For novel geometry the typed tools don't cover, the LLM falls back to `execute_s
 | `simplify_mesh` | QEM mesh decimation to .stl/.obj — wraps OCCTSwiftMesh's `Mesh.simplified` (vendored meshoptimizer) |
 | `render_preview` | One-shot PNG render with measurement labels and primitive overlays |
 | `pick_surface_point` | Cast a render_preview-framed ray through a pixel → world surface point + selectionId (usable as an `add_dimension` anchor) |
-| `generate_drawing` | Multi-view ISO 128-30 DXF technical drawing |
+| `generate_drawing` | Multi-view ISO 128-30 DXF technical drawing — `bodyId` for a single part, or `bodyIds` (2+) for a general-arrangement assembly sheet with a parts list + balloons |
 
 ### Topology graph (low-level)
 

--- a/Sources/OCCTMCPCore/Server.swift
+++ b/Sources/OCCTMCPCore/Server.swift
@@ -229,18 +229,23 @@ func catalogTools() -> [Tool] {
         ),
         Tool(
             name: "generate_drawing",
-            description: "Render a multi-view ISO 128-30 DXF technical drawing for a scene body. Pass a DrawingSpec object (sheet, title, views, sections, dimensions, ...). The tool injects shape + output into the spec.",
+            description: "Render a multi-view ISO 128-30 DXF technical drawing. Pass `bodyId` for a single-part drawing (sections / dimensions honoured), or `bodyIds` (2+) for a general-arrangement / assembly sheet — shared views with a parts list and a numbered balloon per body. Pass a DrawingSpec object (sheet, title, views, sections, dimensions, ...).",
             inputSchema: .object([
                 "type": .string("object"),
                 "properties": .object([
-                    "bodyId": .object(["type": .string("string")]),
+                    "bodyId": .object(["type": .string("string"), "description": .string("Single body — standard part drawing.")]),
+                    "bodyIds": .object([
+                        "type": .string("array"),
+                        "items": .object(["type": .string("string")]),
+                        "description": .string("Two or more bodies — general-arrangement assembly sheet with a parts list. Takes precedence over `bodyId`."),
+                    ]),
                     "outputPath": .object(["type": .string("string")]),
                     "spec": .object([
                         "type": .string("object"),
-                        "description": .string("DrawingSpec object: { sheet, title?, views, sections?, dimensions?, ... }. See OCCTSwiftScripts/Sources/DrawingComposer/Spec.swift."),
+                        "description": .string("DrawingSpec object: { sheet, title?, views, sections?, dimensions?, ... }. See OCCTSwiftScripts/Sources/DrawingComposer/Spec.swift. For a general-arrangement sheet, per-view sections/dimensions are not applied."),
                     ]),
                 ]),
-                "required": .array([.string("bodyId"), .string("outputPath"), .string("spec")]),
+                "required": .array([.string("outputPath"), .string("spec")]),
                 "additionalProperties": .bool(false),
             ])
         ),
@@ -1349,13 +1354,18 @@ func dispatch(callName: String, arguments: [String: Value]) async -> CallTool.Re
         ).asCallToolResult()
 
     case "generate_drawing":
-        guard let bodyId = arguments["bodyId"]?.stringValue,
-              let outputPath = arguments["outputPath"]?.stringValue,
+        guard let outputPath = arguments["outputPath"]?.stringValue,
               let spec = arguments["spec"] else {
-            return ToolText("generate_drawing requires `bodyId`, `outputPath`, `spec`.", isError: true).asCallToolResult()
+            return ToolText("generate_drawing requires `outputPath` and `spec`.", isError: true).asCallToolResult()
+        }
+        // Accept either a single `bodyId` or a `bodyIds` array (general-arrangement).
+        let ids = arguments["bodyIds"]?.arrayValue?.compactMap { $0.stringValue }
+            ?? arguments["bodyId"]?.stringValue.map { [$0] }
+        guard let bodyIds = ids, !bodyIds.isEmpty else {
+            return ToolText("generate_drawing requires `bodyId` or a non-empty `bodyIds`.", isError: true).asCallToolResult()
         }
         return await DrawingTools.generateDrawing(
-            bodyId: bodyId, outputPath: outputPath, spec: spec
+            bodyIds: bodyIds, outputPath: outputPath, spec: spec
         ).asCallToolResult()
 
     case "get_api_reference":

--- a/Sources/OCCTMCPCore/Tools/DrawingTools.swift
+++ b/Sources/OCCTMCPCore/Tools/DrawingTools.swift
@@ -17,10 +17,19 @@ public enum DrawingTools {
         public let detailCount: Int
         public let scaleLabel: String
         public let fileSize: Int
+        /// Number of bodies laid out (1 for a single-part drawing; N for a
+        /// general-arrangement / assembly sheet).
+        public let componentCount: Int
+        /// Number of parts-list rows on the sheet (0 for a single-part drawing).
+        public let partCount: Int
     }
 
+    /// Render a drawing for one or more scene bodies. A single body produces a
+    /// standard multi-view part drawing (sections / dimensions honoured); several
+    /// bodies produce a general-arrangement sheet — shared views, a parts list,
+    /// and a numbered balloon per body (OCCTSwiftScripts#50).
     public static func generateDrawing(
-        bodyId: String,
+        bodyIds: [String],
         outputPath: String,
         spec: Value,
         store: ManifestStore = ManifestStore()
@@ -28,47 +37,52 @@ public enum DrawingTools {
         guard let manifest = try? store.read() else {
             return .init("No scene loaded. Run execute_script first.")
         }
-        guard let body = manifest.body(withId: bodyId) else {
-            return .init("Body not found: \(bodyId)")
+        guard !bodyIds.isEmpty else {
+            return .init("generate_drawing requires `bodyId` or a non-empty `bodyIds`.")
         }
         let outputDir = (store.path as NSString).deletingLastPathComponent
-        let inputPath = "\(outputDir)/\(body.file)"
-        guard FileManager.default.fileExists(atPath: inputPath) else {
-            return .init("BREP file missing: \(inputPath)")
+
+        // Resolve + load every requested body.
+        var loaded: [(id: String, name: String, shape: Shape)] = []
+        for id in bodyIds {
+            guard let body = manifest.body(withId: id) else {
+                return .init("Body not found: \(id)")
+            }
+            let inputPath = "\(outputDir)/\(body.file)"
+            guard FileManager.default.fileExists(atPath: inputPath) else {
+                return .init("BREP file missing: \(inputPath)")
+            }
+            do {
+                let shape = try Shape.loadBREP(fromPath: inputPath)
+                loaded.append((id, body.name ?? id, shape))
+            } catch {
+                return .init("Failed to load BREP \(id): \(error.localizedDescription)", isError: true)
+            }
         }
 
-        // Inject shape + output into the spec so callers don't have to.
-        var enriched: Value = spec
-        if case .object(var dict) = enriched {
-            dict["shape"] = .string(inputPath)
-            dict["output"] = .string(outputPath)
-            enriched = .object(dict)
-        } else {
+        guard case .object = spec else {
             return .init("`spec` must be a JSON object.")
-        }
-
-        let specData: Data
-        do {
-            specData = try JSONEncoder().encode(enriched)
-        } catch {
-            return .init("Failed to encode spec: \(error.localizedDescription)", isError: true)
         }
         let drawingSpec: DrawingSpec
         do {
+            let specData = try JSONEncoder().encode(spec)
             drawingSpec = try JSONDecoder().decode(DrawingSpec.self, from: specData)
         } catch {
             return .init("Invalid DrawingSpec: \(error.localizedDescription)")
         }
 
-        let shape: Shape
-        do {
-            shape = try Shape.loadBREP(fromPath: inputPath)
-        } catch {
-            return .init("Failed to load BREP: \(error.localizedDescription)", isError: true)
-        }
         let result: DrawingComposerResult
         do {
-            result = try Composer.render(spec: drawingSpec, shape: shape)
+            if loaded.count == 1 {
+                // Single body → standard part drawing (keeps section / dimension support).
+                result = try Composer.render(spec: drawingSpec, shape: loaded[0].shape)
+            } else {
+                // Multiple bodies → general-arrangement sheet with a parts list.
+                let components = loaded.map {
+                    Composer.DrawingComponent(shape: $0.shape, name: $0.name, partNumber: $0.id)
+                }
+                result = try Composer.render(spec: drawingSpec, components: components)
+            }
         } catch {
             return .init("Composer.render failed: \(error.localizedDescription)", isError: true)
         }
@@ -89,7 +103,9 @@ public enum DrawingTools {
             sectionCount: result.sectionCount,
             detailCount: result.detailCount,
             scaleLabel: result.scaleLabel,
-            fileSize: size
+            fileSize: size,
+            componentCount: result.componentCount,
+            partCount: result.partsList.count
         ))
     }
 }

--- a/SwiftTests/OCCTMCPCoreTests/IntegrationTests.swift
+++ b/SwiftTests/OCCTMCPCoreTests/IntegrationTests.swift
@@ -301,6 +301,75 @@ struct IntegrationTests {
         #expect(size > 2_000, "rendered PNG was \(size) bytes — overlay may not have been drawn")
     }
 
+    @Test("generate_drawing lays out multiple bodies as a general-arrangement sheet")
+    func generateDrawingAssembly() async throws {
+        guard let binary = Self.binaryURL else {
+            Issue.record("Binary not built — run `swift build` first.")
+            return
+        }
+        let scene = NSTemporaryDirectory() + "occtmcp-it-ga-\(UUID().uuidString)"
+        try FileManager.default.createDirectory(atPath: scene, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(atPath: scene) }
+
+        // Two distinct parts in the scene.
+        let plate = try #require(Shape.box(width: 40, height: 30, depth: 8))
+        let pin = try #require(Shape.cylinder(radius: 5, height: 25))
+        try Exporter.writeBREP(shape: plate, to: URL(fileURLWithPath: "\(scene)/plate.brep"))
+        try Exporter.writeBREP(shape: pin, to: URL(fileURLWithPath: "\(scene)/pin.brep"))
+        let store = ManifestStore(path: "\(scene)/manifest.json")
+        try store.write(ScriptManifest(
+            description: "GA drawing test scene",
+            bodies: [
+                BodyDescriptor(id: "plate", file: "plate.brep", name: "Base Plate", color: [0.7, 0.7, 0.7, 1]),
+                BodyDescriptor(id: "pin", file: "pin.brep", name: "Dowel Pin", color: [0.6, 0.6, 0.6, 1]),
+            ]
+        ))
+
+        let harness = try Harness(binary: binary, extraEnv: ["OCCTMCP_OUTPUT_DIR": scene])
+        defer { harness.terminate() }
+        try harness.handshake()
+
+        let dxfPath = "\(scene)/ga.dxf"
+        try harness.send(.init(
+            id: 60, method: "tools/call",
+            params: .object([
+                "name": .string("generate_drawing"),
+                "arguments": .object([
+                    "bodyIds": .array([.string("plate"), .string("pin")]),
+                    "outputPath": .string(dxfPath),
+                    "spec": .object([
+                        "sheet": .object([
+                            "size": .string("a3"),
+                            "orientation": .string("landscape"),
+                            "projection": .string("third"),
+                            "scale": .string("auto"),
+                        ]),
+                        "views": .array([
+                            .object(["name": .string("front")]),
+                            .object(["name": .string("top")]),
+                            .object(["name": .string("right")]),
+                        ]),
+                    ]),
+                ]),
+            ])
+        ))
+        let resp = try harness.recv(timeout: 30)
+        #expect(resp["error"] == nil)
+        guard case .object(let result)? = resp["result"],
+              case .array(let content)? = result["content"],
+              case .object(let first)? = content.first,
+              let text = first["text"]?.stringValue,
+              let data = text.data(using: .utf8),
+              let parsed = try JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            Issue.record("generate_drawing response shape unexpected")
+            return
+        }
+        #expect(parsed["componentCount"] as? Int == 2)   // two bodies laid out
+        #expect(parsed["partCount"] as? Int == 2)         // two parts-list rows
+        let fileSize = (parsed["fileSize"] as? Int) ?? 0
+        #expect(fileSize > 4_000, "GA DXF was \(fileSize) bytes — views may not have rendered")
+    }
+
     @Test("pick_surface_point hits a body and composes into add_dimension")
     func pickSurfacePointMeasures() async throws {
         guard let binary = Self.binaryURL else {


### PR DESCRIPTION
Bumps `OCCTSwiftScripts` `1.0.3 → 1.0.4` to pull in the new DrawingComposer general-arrangement overloads ([OCCTSwiftScripts#50](https://github.com/gsdali/OCCTSwiftScripts/issues/50)) and surfaces them through `generate_drawing`.

## What changed
- **`generate_drawing` now accepts a `bodyIds` array (2+):** renders a **general-arrangement assembly sheet** — shared views, a parts list, and a numbered balloon per body — via `Composer.render(spec:components:)`. A single `bodyId` still produces a standard part drawing (sections / dimensions honoured). `bodyId` is now optional; `outputPath` + `spec` remain required; `bodyIds` takes precedence.
- `DrawingReport` gains `componentCount` + `partCount`.
- New integration test: two-body scene → GA sheet (`componentCount`/`partCount` == 2, non-trivial DXF).
- README: `generate_drawing` row updated.

## ⚠️ Transitive OCCTSwift bump (unavoidable)
OCCTSwiftScripts 1.0.4 raised **its own** OCCTSwift floor to `from: 1.3.1`, so pulling in the new DrawingComposer **forces OCCTSwift `1.2.0 → 1.4.0`** (OCCT.xcframework 1.3.2) across the whole cohort (AIS/Tools/Mesh/Viewport all ride OCCTSwift). This is inherent to the bump, not optional — SPM rejects pinning OCCTSwift back to 1.2.0. The declared OCCTSwift floor is bumped to `1.3.1` to document it.

Verified with a **clean build** against OCCTSwift 1.4.0 (no API breakage in OCCTMCP) — **36 tests green**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)