### PR TITLE
fix(execute_script): pin OCCTSwiftScripts to 1.2.0 cohort (#42)

### DIFF
--- a/Sources/OCCTMCPCore/Tools/ExecuteScriptTool.swift
+++ b/Sources/OCCTMCPCore/Tools/ExecuteScriptTool.swift
@@ -20,9 +20,13 @@ public enum ExecuteScriptTool {
 
     public static let buildTimeoutSeconds: TimeInterval = 300
 
-    /// Pin floor for OCCTSwiftScripts (provides ScriptHarness). Bump as
-    /// new ScriptManifest fields land.
-    static let scriptsPin = "0.8.1"
+    /// Pin floor for OCCTSwiftScripts (provides ScriptHarness). MUST track
+    /// `Package.swift`'s OCCTSwiftScripts pin — they share the OCCTSwift
+    /// cohort transitively, so divergence makes execute_script compile
+    /// against a different (older) kernel than the server's own tools.
+    /// A `from: "0.x"` floor caps below 1.0.0 (SPM "up to next major"),
+    /// which stranded scripts on pre-GA OCCTSwift 0.171.0 (#42).
+    static let scriptsPin = "1.2.0"
 
     public static func execute(
         code: String,


### PR DESCRIPTION
Fixes #42.

## Problem

`execute_script` builds a throwaway SPM workspace to compile user scripts. Its dependency template pinned OCCTSwiftScripts `from: "0.8.1"`. On a 0.x version, SPM's "up to next major" means `>= 0.8.1, < 1.0.0`, so it resolved the newest *pre-1.0* OCCTSwiftScripts, which transitively dragged in the stale pre-GA **OCCTSwift 0.171.0**.

Meanwhile the server's own `Package.swift` pins OCCTSwiftScripts `from: "1.2.0"` (→ OCCTSwift 1.7.1). So `execute_script` compiled against a different, older kernel than every in-process tool — and could not compile any 1.x API (e.g. `ThreadForm.trapezoidal`, `threadedShaft(build:)`).

## Fix

- Bump `scriptsPin` `0.8.1` → `1.2.0` in `ExecuteScriptTool.swift` so the generated workspace resolves the same cohort as the server (OCCTSwift 1.7.x).
- Document that `scriptsPin` **must track** `Package.swift`'s OCCTSwiftScripts pin, with a note on why the `0.x` floor capped below 1.0.0.

`ensureWorkspace()` rewrites `Package.swift` when its content changes, and the new constraint invalidates any cached 0.x `Package.resolved`, so SPM re-resolves automatically on the next call — no manual cache wipe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)