### PR TITLE
feat(compute_metrics): add boundingBoxOptimal metric (#44)

### DIFF
--- a/Sources/OCCTMCPCore/Server.swift
+++ b/Sources/OCCTMCPCore/Server.swift
@@ -744,7 +744,7 @@ func catalogTools() -> [Tool] {
         ),
         Tool(
             name: "compute_metrics",
-            description: "Compute volume / surface area / center of mass / bounding box / principal axes for a scene body. Direct OCCTSwift call, no occtkit subprocess.",
+            description: "Compute volume / surface area / center of mass / bounding box / principal axes for a scene body. Direct OCCTSwift call, no occtkit subprocess. `boundingBox` is the default Bnd_Box (control-point hull — over-reports curved B-spline geometry); request `boundingBoxOptimal` for a tight BRepBndLib::AddOptimal extent that matches the exact surface / mesh.",
             inputSchema: .object([
                 "type": .string("object"),
                 "properties": .object([
@@ -752,7 +752,7 @@ func catalogTools() -> [Tool] {
                     "metrics": .object([
                         "type": .string("array"),
                         "items": .object(["type": .string("string")]),
-                        "description": .string("Subset to compute. Default: all. Items: volume, surfaceArea, centerOfMass, boundingBox, principalAxes."),
+                        "description": .string("Subset to compute. Default: all except boundingBoxOptimal. Items: volume, surfaceArea, centerOfMass, boundingBox, boundingBoxOptimal, principalAxes. boundingBoxOptimal (tight AddOptimal extent) is opt-in — list it explicitly."),
                     ]),
                 ]),
                 "required": .array([.string("bodyId")]),

--- a/Sources/OCCTMCPCore/Tools/IntrospectionTools.swift
+++ b/Sources/OCCTMCPCore/Tools/IntrospectionTools.swift
@@ -55,6 +55,7 @@ public enum IntrospectionTools {
         public var surfaceArea: Double?
         public var centerOfMass: [Double]?
         public var boundingBox: BBox?
+        public var boundingBoxOptimal: BBox?
         public var principalAxes: PrincipalAxes?
 
         public struct BBox: Encodable {
@@ -94,10 +95,25 @@ public enum IntrospectionTools {
             report.centerOfMass = [i.centerOfMass.x, i.centerOfMass.y, i.centerOfMass.z]
         }
         if wants("boundingBox") {
+            // Default Bnd_Box: for B-spline / curved faces this is the
+            // control-point hull and over-reports the true extent
+            // (OCCTSwift #232 / #213). Use boundingBoxOptimal for a tight box.
             let b = shape.bounds
             report.boundingBox = .init(
                 min: [b.min.x, b.min.y, b.min.z],
                 max: [b.max.x, b.max.y, b.max.z]
+            )
+        }
+        // Opt-in only (not part of default-all): AddOptimal is costlier than
+        // the Bnd_Box, and most callers want the cheap footprint.
+        if metrics?.contains("boundingBoxOptimal") == true, let o = shape.boundingBoxOptimal() {
+            // BRepBndLib::AddOptimal — tight extent that matches the exact
+            // surface (and the mesh) for curved geometry; equal to the
+            // Bnd_Box for planar bodies. Needed for extent-vs-mesh
+            // reconstruction verification (#44).
+            report.boundingBoxOptimal = .init(
+                min: [o.min.x, o.min.y, o.min.z],
+                max: [o.max.x, o.max.y, o.max.z]
             )
         }
         if wants("principalAxes"), let i = inertia {


### PR DESCRIPTION
Fixes #44.

## Problem

`compute_metrics`'s `boundingBox` comes from OCCT's default `Bnd_Box`. For B-spline / curved faces that box is the **control-point hull**, which over-reports the true extent (OCCTSwift #232 / #213). On curved STEP geometry (threads, helicoids, revolves, lofts) this produces a false over-extension in the extent-vs-mesh reconstruction check — a correct curved part reads as oversized.

## Fix

Add an opt-in `boundingBoxOptimal` metric backed by `Shape.boundingBoxOptimal()` (`BRepBndLib::AddOptimal`):

- **Tight** for curved surfaces — matches the exact surface and the source mesh.
- **Equal** to the `Bnd_Box` for planar bodies.
- **Opt-in** (request `metrics: ["boundingBoxOptimal"]`) — kept out of the default-all set because `AddOptimal` is costlier and most callers want the cheap footprint.
- `boundingBox` is **unchanged**, so existing consumers are unaffected.

## Verification

Trapezoidal threaded shaft, both boxes measured through the running server:

| extent | x | y | z |
|---|---|---|---|
| `boundingBox` (Bnd_Box) | 12.03 | 12.08 | 61.90 |
| `boundingBoxOptimal` (AddOptimal) | 12.00 | 12.00 | 60.00 |

Optimal equals the nominal extent; the Bnd_Box over-reports (control-hull / runout-pole artifact). Build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)