### PR TITLE
feat(measure): add measure_deviation — surface Hausdorff between two bodies (#41)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 MCP server that gives LLMs the ability to author, inspect, and iterate on 3D CAD models with OpenCASCADE via the OCCTSwift family. Two implementations live side-by-side:
 
-- **Swift** (`Sources/`, `Package.swift`) — the **primary**, in-process server. Uses the official Swift MCP SDK, calls OCCTSwift / OCCTSwiftMesh / OCCTSwiftTools / OCCTSwiftAIS / DrawingComposer directly. 57 typed tools. macOS 15+.
+- **Swift** (`Sources/`, `Package.swift`) — the **primary**, in-process server. Uses the official Swift MCP SDK, calls OCCTSwift / OCCTSwiftMesh / OCCTSwiftTools / OCCTSwiftAIS / DrawingComposer directly. 59 typed tools. macOS 15+.
 - **Node / TypeScript** (`src/`, `dist/`) — the original implementation. Shells out to the `occtkit` CLI via `OCCTSwiftScripts`. 36 tools (the pre-v0.4 surface; selection / remap / annotations are Swift-only).
 
 Both speak stdio MCP and read/write the same `manifest.json` + `annotations.json` files in the output directory. Pick whichever fits the host: the Swift binary eliminates JSONL marshalling and per-call subprocess spawn; the Node server runs anywhere a Node 18+ runtime exists, but needs `occtkit` on `$PATH`.
@@ -20,7 +20,7 @@ The Swift port reached **v1.0.0** on 2026-05-09 and is published on the [Swift P
 ```bash
 swift build -c release         # debug build is `swift build`
 swift run occtmcp-server       # stdio transport
-swift test                     # 22 swift-testing cases under SwiftTests/OCCTMCPCoreTests
+swift test                     # 39 swift-testing cases under SwiftTests/OCCTMCPCoreTests
 ```
 
 `swift test` runs unit + integration tests against a tempdir. Integration tests spawn the built `occtmcp-server` binary and drive it over stdio (so a `swift build` must precede them; the harness itself does this).
@@ -41,12 +41,13 @@ npm run test:integration  # node:test end-to-end chain through occtkit (slow; ~3
 
 `Sources/OCCTMCPCore/` (library) + `Sources/OCCTMCPServer/` (executable that connects stdio).
 
-- `Server.swift` — `createServer()` factory: registers all 57 tools with their JSON Schemas, returns an `MCP.Server` ready to bind to a transport. Tests import `createServer()` to introspect the registry without binding stdio. The `get_api_reference` tool's `mcp_tools` category dumps the live registry as JSON Schema for LLM auto-discovery.
+- `Server.swift` — `createServer()` factory: registers all 59 tools with their JSON Schemas, returns an `MCP.Server` ready to bind to a transport. Tests import `createServer()` to introspect the registry without binding stdio. The `get_api_reference` tool's `mcp_tools` category dumps the live registry as JSON Schema for LLM auto-discovery.
 - `Tools/` — one file per tool family:
   - `CoreTools.swift` — `get_scene`, `get_script`, `export_model`, `get_api_reference`
   - `ExecuteScriptTool.swift` — `execute_script` (writes Swift to tempfile, `occtkit run` via the resolved binary, parses manifest)
   - `SceneTools.swift` — `remove_body`, `clear_scene`, `rename_body`, `set_appearance`, `compare_versions`, `export_scene` (pure manifest manipulation; `export_scene` runs a templated script via occtkit)
   - `IntrospectionTools.swift` — `validate_geometry`, `compute_metrics`, `query_topology`, `measure_distance` (in-process via OCCTSwift)
+  - `DeviationTools.swift` — `measure_deviation` (directed + symmetric surface Hausdorff between two bodies; meshes both, KD-tree nearest-vertex → exact point-to-triangle distance, both directions. The certify-a-reconstruction metric `measure_distance` can't give since it's min-only — #41)
   - `FeatureTools.swift` — `recognize_features`, `apply_feature`
   - `ConstructionTools.swift` — `transform_body`, `boolean_op`, `mirror_or_pattern` (record history into `HistoryRegistry`)
   - `EngineeringTools.swift` — `check_thickness`, `analyze_clearance`
@@ -156,7 +157,7 @@ The Node server does not expose the v0.4+ tool surface (selection / remap / anno
 
 ## MCP Tools
 
-57 tools in Swift; 36 in Node (no selection / remap / annotations / history / reconstruct). See README.md for the categorized table — that's the LLM-facing surface and stays canonical.
+59 tools in Swift; 36 in Node (no selection / remap / annotations / history / reconstruct). See README.md for the categorized table — that's the LLM-facing surface and stays canonical.
 
 ## Script Template
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ MCP server that gives LLMs the ability to author, inspect, and iterate on 3D CAD
 
 Part of the [OCCTSwift ecosystem](https://github.com/gsdali/OCCTSwift/blob/main/docs/ecosystem.md) — see the ecosystem map for how this package sits on top of the kernel, viewport, bridge, and AIS layers. SemVer-stable from v1.0.0.
 
-The Swift implementation calls OCCT directly in-process — no subprocess, no JSONL marshalling — and exposes 58 typed MCP tools that cover authoring, scene reads, mutation, introspection, construction, analysis, I/O, mesh, drawing, selection / remap, and dimension overlays.
+The Swift implementation calls OCCT directly in-process — no subprocess, no JSONL marshalling — and exposes 59 typed MCP tools that cover authoring, scene reads, mutation, introspection, construction, analysis, I/O, mesh, drawing, selection / remap, and dimension overlays.
 
 ## How It Works
 
@@ -22,7 +22,7 @@ For novel geometry the typed tools don't cover, the LLM falls back to `execute_s
 
 ## Tools
 
-58 tools, organized below. Call `get_api_reference({ category: "mcp_tools" })` to dump every tool's JSON Schema in one shot — useful for LLM auto-discovery. Most flows can answer "what's the volume?", "make it red", "boolean-subtract these", "render a preview", "add a dimension between these two faces", "export to STEP", and "draw this" without ever touching `execute_script`.
+59 tools, organized below. Call `get_api_reference({ category: "mcp_tools" })` to dump every tool's JSON Schema in one shot — useful for LLM auto-discovery. Most flows can answer "what's the volume?", "make it red", "boolean-subtract these", "render a preview", "add a dimension between these two faces", "export to STEP", and "draw this" without ever touching `execute_script`.
 
 ### Authoring
 
@@ -57,6 +57,7 @@ For novel geometry the typed tools don't cover, the LLM falls back to `execute_s
 | `compute_metrics` | Volume, area, centroid, bounding box, principal axes |
 | `query_topology` | Find faces / edges / vertices matching criteria, return stable IDs |
 | `measure_distance` | Min distance + contacts between two bodies |
+| `measure_deviation` | Directed + symmetric surface deviation (Hausdorff) between two bodies — worst / RMS / mean each way + worstPoint. The certify-a-reconstruction metric (`measure_distance` is min-only) |
 | `recognize_features` | Pockets and holes via AAG heuristics |
 | `inspect_assembly` | Walk an XCAF assembly tree (STEP / IGES / XBF) |
 
@@ -147,7 +148,7 @@ LLM read/write over an attributed reconstruction graph — annotate per-node dec
 
 This repo ships two implementations side-by-side:
 
-- **Swift** (`Sources/`, `Package.swift`) — the **primary** server. In-process against OCCTSwift / OCCTSwiftMesh / OCCTSwiftTools / OCCTSwiftAIS / DrawingComposer using the [official Swift MCP SDK](https://swiftpackageindex.com/modelcontextprotocol/swift-sdk). 58 tools. macOS 15+ (the OCCT.xcframework arm64 platform).
+- **Swift** (`Sources/`, `Package.swift`) — the **primary** server. In-process against OCCTSwift / OCCTSwiftMesh / OCCTSwiftTools / OCCTSwiftAIS / DrawingComposer using the [official Swift MCP SDK](https://swiftpackageindex.com/modelcontextprotocol/swift-sdk). 59 tools. macOS 15+ (the OCCT.xcframework arm64 platform).
 - **Node / TypeScript** (`src/`, `dist/`) — the original implementation. Shells out to the `occtkit` CLI for everything Swift-side. 36 tools (the pre-v0.4 surface; selection / remap / annotations are Swift-only). Useful if you can't run a macOS binary.
 
 Both speak stdio MCP and read/write the same manifest format.

--- a/Sources/OCCTMCPCore/Server.swift
+++ b/Sources/OCCTMCPCore/Server.swift
@@ -795,6 +795,27 @@ func catalogTools() -> [Tool] {
             ])
         ),
         Tool(
+            name: "measure_deviation",
+            description: "Surface deviation (one-sided + symmetric Hausdorff) between two scene bodies — the metric for certifying a reconstruction against its source mesh. Unlike measure_distance (minimum gap, ≈0 for overlapping bodies), this samples each body's tessellated surface and reports the worst / RMS / mean distance to the other in BOTH directions: `fromToTo` (from's surface vs to — over-extension) and `toToFrom` (under-coverage), each with a worstPoint, plus `symmetricHausdorff`. Mesh-based; fidelity scales with `deflection` (default 0.5% of the from-body bbox diagonal). `maxSamples` (default 20000) stride-subsamples the source surface per direction.",
+            inputSchema: .object([
+                "type": .string("object"),
+                "properties": .object([
+                    "fromBodyId": .object(["type": .string("string")]),
+                    "toBodyId": .object(["type": .string("string")]),
+                    "deflection": .object([
+                        "type": .string("number"),
+                        "description": .string("Mesh linear deflection (model units). Smaller = finer = tighter bound. Default: 0.5% of the from-body bbox diagonal."),
+                    ]),
+                    "maxSamples": .object([
+                        "type": .string("integer"),
+                        "description": .string("Max source surface samples per direction (stride-subsampled). Default 20000."),
+                    ]),
+                ]),
+                "required": .array([.string("fromBodyId"), .string("toBodyId")]),
+                "additionalProperties": .bool(false),
+            ])
+        ),
+        Tool(
             name: "transform_body",
             description: "Apply translate / rotate / uniform-scale to a scene body. Without outputBodyId, replaces in place; with outputBodyId, adds a new body.",
             inputSchema: .object([
@@ -1547,6 +1568,17 @@ func dispatch(callName: String, arguments: [String: Value]) async -> CallTool.Re
         let computeContacts = arguments["computeContacts"]?.boolValue ?? false
         return await IntrospectionTools.measureDistance(
             fromBodyId: fromId, toBodyId: toId, computeContacts: computeContacts
+        ).asCallToolResult()
+
+    case "measure_deviation":
+        guard let fromId = arguments["fromBodyId"]?.stringValue,
+              let toId = arguments["toBodyId"]?.stringValue else {
+            return ToolText("measure_deviation requires `fromBodyId` and `toBodyId`.", isError: true).asCallToolResult()
+        }
+        let deflection = arguments["deflection"]?.doubleValue
+        let maxSamples = arguments["maxSamples"]?.intValue ?? 20_000
+        return await DeviationTools.measureDeviation(
+            fromBodyId: fromId, toBodyId: toId, deflection: deflection, maxSamples: maxSamples
         ).asCallToolResult()
 
     case "transform_body":

--- a/Sources/OCCTMCPCore/Tools/DeviationTools.swift
+++ b/Sources/OCCTMCPCore/Tools/DeviationTools.swift
@@ -1,0 +1,257 @@
+// DeviationTools — surface-deviation (one-sided / symmetric Hausdorff) between
+// two scene bodies. Where `measure_distance` returns the *minimum* gap (≈0 for
+// an overlapping reconstruction-vs-source pair, hence useless as a fidelity
+// figure), this samples one body's tessellated surface and projects each sample
+// onto the other body's triangles to report the *worst* and RMS deviation in
+// each direction. This is the metric a mesh→analytic reconstruction check needs
+// (OCCTMCP #41): fromToTo surfaces departing from `to` (over-extension), and
+// toToFrom (missing material / under-coverage).
+//
+// Mesh-based by design: both bodies are typically meshes (an STL source vs a
+// STEP reconstruction), and meshing once + a KD-tree is far cheaper than N
+// per-point BRep extrema. Fidelity scales with `deflection` — a finer mesh
+// tightens the bound. The per-sample distance is exact point-to-triangle, so
+// the only approximation is the tessellation itself, not nearest-vertex.
+
+import Foundation
+import OCCTSwift
+import simd
+
+public enum DeviationTools {
+
+    public struct DirectionStat: Encodable {
+        public let max: Double
+        public let rms: Double
+        public let mean: Double
+        public let worstPoint: [Double]
+        public let samples: Int
+    }
+
+    public struct DeviationReport: Encodable {
+        public let from: String
+        public let to: String
+        public let deflection: Double
+        /// Deviation of `from`'s surface measured against `to` (over-extension).
+        public let fromToTo: DirectionStat
+        /// Deviation of `to`'s surface measured against `from` (under-coverage).
+        public let toToFrom: DirectionStat
+        /// max(fromToTo.max, toToFrom.max) — the symmetric Hausdorff distance.
+        public let symmetricHausdorff: Double
+    }
+
+    public static func measureDeviation(
+        fromBodyId: String,
+        toBodyId: String,
+        deflection: Double? = nil,
+        maxSamples: Int = 20_000,
+        store: ManifestStore = ManifestStore()
+    ) async -> ToolText {
+        let fromShape: Shape, toShape: Shape
+        do {
+            fromShape = try IntrospectionTools.loadShape(bodyId: fromBodyId, store: store).shape
+            toShape = try IntrospectionTools.loadShape(bodyId: toBodyId, store: store).shape
+        } catch {
+            return .init("\(error)")
+        }
+
+        // Default deflection scales with the model so the bound is meaningful
+        // regardless of units/size: 0.5% of the `from` bbox diagonal, floored.
+        let defl = deflection ?? defaultDeflection(for: fromShape)
+        guard defl > 0 else {
+            return .init("deflection must be positive.", isError: true)
+        }
+
+        guard let fromTris = TriMesh(shape: fromShape, deflection: defl) else {
+            return .init("Failed to tessellate '\(fromBodyId)' for deviation.", isError: true)
+        }
+        guard let toTris = TriMesh(shape: toShape, deflection: defl) else {
+            return .init("Failed to tessellate '\(toBodyId)' for deviation.", isError: true)
+        }
+
+        guard let fwd = directedDeviation(source: fromTris, target: toTris, maxSamples: maxSamples) else {
+            return .init("Deviation computation failed (empty tessellation).", isError: true)
+        }
+        guard let rev = directedDeviation(source: toTris, target: fromTris, maxSamples: maxSamples) else {
+            return .init("Deviation computation failed (empty tessellation).", isError: true)
+        }
+
+        let report = DeviationReport(
+            from: fromBodyId,
+            to: toBodyId,
+            deflection: defl,
+            fromToTo: fwd,
+            toToFrom: rev,
+            symmetricHausdorff: Swift.max(fwd.max, rev.max)
+        )
+        return IntrospectionTools.encode(report)
+    }
+
+    // ── tessellation snapshot ───────────────────────────────────────────
+
+    /// Double-precision triangle soup + a KD-tree over vertices, with a
+    /// vertex→incident-triangle adjacency for exact point-to-triangle queries.
+    struct TriMesh {
+        let vertices: [SIMD3<Double>]
+        let triangles: [(UInt32, UInt32, UInt32)]
+        let kd: KDTree
+        let incident: [[Int]]   // vertexIndex → triangle indices
+
+        init?(shape: Shape, deflection: Double) {
+            var params = MeshParameters.default
+            params.deflection = deflection
+            params.internalVertices = true
+            params.inParallel = true
+            // Re-meshing keeps an existing finer/coarser triangulation unless we
+            // allow it to be replaced, so the requested deflection actually takes
+            // effect on an already-tessellated import (OCCTSwift #211).
+            params.allowQualityDecrease = true
+            guard let mesh = shape.mesh(parameters: params) else { return nil }
+
+            let verts = mesh.vertices.map { SIMD3<Double>(Double($0.x), Double($0.y), Double($0.z)) }
+            let idx = mesh.indices
+            guard !verts.isEmpty, idx.count >= 3, let kd = KDTree(points: verts) else { return nil }
+
+            var tris: [(UInt32, UInt32, UInt32)] = []
+            tris.reserveCapacity(idx.count / 3)
+            var adj = [[Int]](repeating: [], count: verts.count)
+            var t = 0
+            while t + 2 < idx.count {
+                let a = idx[t], b = idx[t + 1], c = idx[t + 2]
+                let ti = tris.count
+                tris.append((a, b, c))
+                adj[Int(a)].append(ti)
+                adj[Int(b)].append(ti)
+                adj[Int(c)].append(ti)
+                t += 3
+            }
+            self.vertices = verts
+            self.triangles = tris
+            self.kd = kd
+            self.incident = adj
+        }
+    }
+
+    // ── directed deviation: source samples → nearest point on target ─────
+
+    static func directedDeviation(source: TriMesh, target: TriMesh, maxSamples: Int) -> DirectionStat? {
+        let n = source.vertices.count
+        guard n > 0 else { return nil }
+        // Stride-subsample the source vertices to honour the sample cap.
+        let stride = maxSamples > 0 ? Swift.max(1, (n + maxSamples - 1) / maxSamples) : 1
+        let k = 6                      // candidate target vertices per query
+
+        var maxD = 0.0
+        var sumSq = 0.0
+        var sum = 0.0
+        var count = 0
+        var worst = SIMD3<Double>(0, 0, 0)
+        // Reused stamp array dedups incident triangles across the k candidates.
+        var stamp = [Int](repeating: -1, count: target.triangles.count)
+
+        var i = 0
+        while i < n {
+            let p = source.vertices[i]
+            var best = Double.greatestFiniteMagnitude
+
+            let neighbours = target.kd.kNearest(to: p, k: k)
+            if neighbours.isEmpty {
+                // Degenerate target KD result — fall back to nearest vertex.
+                if let nv = target.kd.nearest(to: p) { best = nv.distance }
+            } else {
+                for (vi, _) in neighbours {
+                    for ti in target.incident[vi] where stamp[ti] != i {
+                        stamp[ti] = i
+                        let (a, b, c) = target.triangles[ti]
+                        let d = pointTriangleDistance(
+                            p,
+                            target.vertices[Int(a)],
+                            target.vertices[Int(b)],
+                            target.vertices[Int(c)]
+                        )
+                        if d < best { best = d }
+                    }
+                }
+                // A nearest vertex with no incident triangles (isolated) — guard.
+                if best == .greatestFiniteMagnitude, let nv = target.kd.nearest(to: p) {
+                    best = nv.distance
+                }
+            }
+
+            if best != .greatestFiniteMagnitude {
+                if best > maxD { maxD = best; worst = p }
+                sumSq += best * best
+                sum += best
+                count += 1
+            }
+            i += stride
+        }
+
+        guard count > 0 else { return nil }
+        return DirectionStat(
+            max: maxD,
+            rms: (sumSq / Double(count)).squareRoot(),
+            mean: sum / Double(count),
+            worstPoint: [worst.x, worst.y, worst.z],
+            samples: count
+        )
+    }
+
+    // ── geometry helpers ────────────────────────────────────────────────
+
+    static func defaultDeflection(for shape: Shape) -> Double {
+        let b = shape.bounds
+        let diag = simd_length(b.max - b.min)
+        // 0.5% of the diagonal, with a 1µm floor for degenerate/tiny shapes.
+        return Swift.max(diag * 0.005, 1e-6)
+    }
+
+    /// Exact distance from point `p` to triangle (a,b,c).
+    /// Closest-point-on-triangle, Ericson "Real-Time Collision Detection" §5.1.5.
+    static func pointTriangleDistance(
+        _ p: SIMD3<Double>,
+        _ a: SIMD3<Double>,
+        _ b: SIMD3<Double>,
+        _ c: SIMD3<Double>
+    ) -> Double {
+        let ab = b - a
+        let ac = c - a
+        let ap = p - a
+        let d1 = simd_dot(ab, ap)
+        let d2 = simd_dot(ac, ap)
+        if d1 <= 0 && d2 <= 0 { return simd_length(ap) }                 // vertex A
+
+        let bp = p - b
+        let d3 = simd_dot(ab, bp)
+        let d4 = simd_dot(ac, bp)
+        if d3 >= 0 && d4 <= d3 { return simd_length(bp) }                // vertex B
+
+        let vc = d1 * d4 - d3 * d2
+        if vc <= 0 && d1 >= 0 && d3 <= 0 {                                // edge AB
+            let v = d1 / (d1 - d3)
+            return simd_length(p - (a + v * ab))
+        }
+
+        let cp = p - c
+        let d5 = simd_dot(ab, cp)
+        let d6 = simd_dot(ac, cp)
+        if d6 >= 0 && d5 <= d6 { return simd_length(cp) }                // vertex C
+
+        let vb = d5 * d2 - d1 * d6
+        if vb <= 0 && d2 >= 0 && d6 <= 0 {                                // edge AC
+            let w = d2 / (d2 - d6)
+            return simd_length(p - (a + w * ac))
+        }
+
+        let va = d3 * d6 - d5 * d4
+        if va <= 0 && (d4 - d3) >= 0 && (d5 - d6) >= 0 {                  // edge BC
+            let w = (d4 - d3) / ((d4 - d3) + (d5 - d6))
+            return simd_length(p - (b + w * (c - b)))
+        }
+
+        // Interior — barycentric projection onto the triangle plane.
+        let denom = 1.0 / (va + vb + vc)
+        let v = vb * denom
+        let w = vc * denom
+        return simd_length(p - (a + ab * v + ac * w))
+    }
+}

--- a/SwiftTests/OCCTMCPCoreTests/DeviationToolsTests.swift
+++ b/SwiftTests/OCCTMCPCoreTests/DeviationToolsTests.swift
@@ -1,0 +1,77 @@
+// Unit tests for measure_deviation (surface Hausdorff between two bodies).
+
+import Foundation
+import Testing
+import OCCTSwift
+import ScriptHarness
+@testable import OCCTMCPCore
+
+@Suite("measure_deviation")
+struct DeviationToolsTests {
+
+    /// Seed a tempdir scene with two real BREP bodies, return its ManifestStore.
+    func scene(_ bodies: [(id: String, shape: Shape)]) throws -> ManifestStore {
+        let dir = NSTemporaryDirectory() + "occtmcp-dev-\(UUID().uuidString)"
+        try FileManager.default.createDirectory(atPath: dir, withIntermediateDirectories: true)
+        let descriptors = bodies.map { BodyDescriptor(id: $0.id, file: "\($0.id).brep", color: [1, 1, 1, 1]) }
+        let manifest = ScriptManifest(version: 1, timestamp: Date(), description: "dev", bodies: descriptors)
+        let store = ManifestStore(path: "\(dir)/manifest.json")
+        try store.write(manifest)
+        for b in bodies {
+            try Exporter.writeBREP(shape: b.shape, to: URL(fileURLWithPath: "\(dir)/\(b.id).brep"))
+        }
+        return store
+    }
+
+    func dirOf(_ store: ManifestStore) -> String { (store.path as NSString).deletingLastPathComponent }
+
+    // Decodable mirror of the encode-only report.
+    struct DeviationReport: Decodable {
+        struct Dir: Decodable { let max: Double; let rms: Double; let mean: Double; let worstPoint: [Double]; let samples: Int }
+        let from: String; let to: String; let deflection: Double
+        let fromToTo: Dir; let toToFrom: Dir; let symmetricHausdorff: Double
+    }
+
+    @Test("identical bodies → ~zero deviation")
+    func identical() async throws {
+        let a = Shape.box(width: 10, height: 10, depth: 10)!
+        let b = Shape.box(width: 10, height: 10, depth: 10)!
+        let store = try scene([("a", a), ("b", b)])
+        defer { try? FileManager.default.removeItem(atPath: dirOf(store)) }
+
+        let result = await DeviationTools.measureDeviation(fromBodyId: "a", toBodyId: "b", store: store)
+        #expect(!result.isError, "unexpected error: \(result.text)")
+        let r = try JSONDecoder().decode(DeviationReport.self, from: Data(result.text.utf8))
+        #expect(r.symmetricHausdorff < 1e-6)
+        #expect(r.fromToTo.samples > 0)
+        #expect(r.toToFrom.samples > 0)
+    }
+
+    @Test("coaxial cylinders → deviation ≈ radius delta")
+    func radialOffset() async throws {
+        // Same axis/height, radius differs by 0.5 — the worst surface gap
+        // (radial) must be ≈ 0.5, well above any tessellation noise.
+        let inner = Shape.cylinder(radius: 5.0, height: 20)!
+        let outer = Shape.cylinder(radius: 5.5, height: 20)!
+        let store = try scene([("inner", inner), ("outer", outer)])
+        defer { try? FileManager.default.removeItem(atPath: dirOf(store)) }
+
+        let result = await DeviationTools.measureDeviation(
+            fromBodyId: "inner", toBodyId: "outer", deflection: 0.05, store: store)
+        #expect(!result.isError, "unexpected error: \(result.text)")
+        let r = try JSONDecoder().decode(DeviationReport.self, from: Data(result.text.utf8))
+        // Lateral surface gap is 0.5; allow tessellation slack.
+        #expect(r.symmetricHausdorff > 0.4)
+        #expect(r.symmetricHausdorff < 0.65)
+    }
+
+    @Test("missing body errors cleanly")
+    func missingBody() async throws {
+        let a = Shape.box(width: 1, height: 1, depth: 1)!
+        let store = try scene([("a", a)])
+        defer { try? FileManager.default.removeItem(atPath: dirOf(store)) }
+
+        let result = await DeviationTools.measureDeviation(fromBodyId: "a", toBodyId: "nope", store: store)
+        #expect(result.text.contains("nope"))
+    }
+}

--- a/SwiftTests/OCCTMCPCoreTests/IntegrationTests.swift
+++ b/SwiftTests/OCCTMCPCoreTests/IntegrationTests.swift
@@ -82,7 +82,7 @@ struct IntegrationTests {
         for expected in [
             "ping", "get_scene", "execute_script", "render_preview",
             "pick_surface_point",
-            "compute_metrics", "boolean_op", "set_assembly_metadata",
+            "compute_metrics", "measure_deviation", "boolean_op", "set_assembly_metadata",
             "check_thickness",
         ] {
             #expect(names.contains(expected), "missing tool: \(expected)")


### PR DESCRIPTION
Addresses Gap 1 of #41 (and the deviation aside in #44).

## Problem

`measure_distance` returns the **minimum** distance between two bodies. For a reconstruction overlapping its source mesh that is ≈0 — useless as a fidelity figure. Certifying a mesh→analytic reconstruction needs the **directed/symmetric surface deviation**: how far each body's surface departs from the other, worst and RMS, with the worst-point location.

## Tool

`measure_deviation(fromBodyId, toBodyId, deflection?, maxSamples?)` →

```jsonc
{
  "from": "...", "to": "...", "deflection": 0.12,
  "fromToTo":  { "max": ..., "rms": ..., "mean": ..., "worstPoint": [x,y,z], "samples": ... }, // over-extension
  "toToFrom":  { "max": ..., "rms": ..., "mean": ..., "worstPoint": [x,y,z], "samples": ... }, // under-coverage
  "symmetricHausdorff": ...
}
```

## Approach

- Mesh both bodies. `deflection` defaults to **0.5% of the from-body bbox diagonal** so the bound scales with the model; override for a tighter bound.
- For each sampled vertex of one body, find the **exact closest point on the other's triangles**: KD-tree nearest vertices → incident triangles → point-to-triangle distance (Ericson, *Real-Time Collision Detection* §5.1.5). Both directions.
- `maxSamples` (default 20000) stride-subsamples the source surface per direction.
- The only approximation is the tessellation itself (not nearest-vertex), tunable via `deflection`. Mesh-based by design — both bodies are typically meshes (STL source vs STEP reconstruction), and meshing once + a KD-tree is far cheaper than N per-point BRep extrema.

## Verification

3 unit tests (`DeviationToolsTests`), driving real BREP geometry:
- identical boxes → symmetric Hausdorff `< 1e-6`
- coaxial cylinders Δr = 0.5 → symmetric Hausdorff ≈ 0.5 (the true radial gap)
- missing body → clean error

Full suite green (39 tests, `--no-parallel`). Tool count 58 → 59; README + CLAUDE.md updated.

## Not in scope (still open under #41)

Gap 2 — `import_file` / `read_brep` hard-gate on validity, so an in-progress loose-face reconstruction can't be loaded to be measured. That's a separate change; this PR delivers the deviation metric itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)