### PR TITLE
feat(node): measure_deviation + compute_metrics boundingBoxOptimal (Swift parity)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 MCP server that gives LLMs the ability to author, inspect, and iterate on 3D CAD models with OpenCASCADE via the OCCTSwift family. Two implementations live side-by-side:
 
 - **Swift** (`Sources/`, `Package.swift`) — the **primary**, in-process server. Uses the official Swift MCP SDK, calls OCCTSwift / OCCTSwiftMesh / OCCTSwiftTools / OCCTSwiftAIS / DrawingComposer directly. 59 typed tools. macOS 15+.
-- **Node / TypeScript** (`src/`, `dist/`) — the original implementation. Shells out to the `occtkit` CLI via `OCCTSwiftScripts`. 36 tools (the pre-v0.4 surface; selection / remap / annotations are Swift-only).
+- **Node / TypeScript** (`src/`, `dist/`) — the original implementation. Shells out to the `occtkit` CLI via `OCCTSwiftScripts`. 37 tools (the pre-v0.4 surface; selection / remap / annotations are Swift-only).
 
 Both speak stdio MCP and read/write the same `manifest.json` + `annotations.json` files in the output directory. Pick whichever fits the host: the Swift binary eliminates JSONL marshalling and per-call subprocess spawn; the Node server runs anywhere a Node 18+ runtime exists, but needs `occtkit` on `$PATH`.
 
@@ -151,13 +151,13 @@ The Node server does not expose the v0.4+ tool surface (selection / remap / anno
 
 ### Node implementation
 
-- **OCCTSwiftScripts** — provides `occtkit` on `$PATH` (`make install` from the OCCTSwiftScripts repo) or via sibling clone at `~/Projects/OCCTSwiftScripts` so `swift run -c release occtkit` works as the fallback
+- **OCCTSwiftScripts** ≥ 1.3.0 — provides `occtkit` on `$PATH` (`make install` from the OCCTSwiftScripts repo) or via sibling clone at `~/Projects/OCCTSwiftScripts` so `swift run -c release occtkit` works as the fallback. v1.3.0 adds the `measure-deviation` verb and the `metrics` `boundingBoxOptimal` field that the Node `measure_deviation` / `compute_metrics` tools wrap
 - **OCCTSwift** — required at `~/Projects/OCCTSwift/` only when regenerating `src/api-reference.ts` via `scripts/generate-api-reference.mjs` (runs as `npm run prebuild`)
 - **OCCTSwiftViewport** — Metal viewport that watches the output directory via `ScriptWatcher` and auto-reloads. Optional but expected if you want the live preview
 
 ## MCP Tools
 
-59 tools in Swift; 36 in Node (no selection / remap / annotations / history / reconstruct). See README.md for the categorized table — that's the LLM-facing surface and stays canonical.
+59 tools in Swift; 37 in Node (no selection / remap / annotations / history / reconstruct). See README.md for the categorized table — that's the LLM-facing surface and stays canonical.
 
 ## Script Template
 

--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ LLM read/write over an attributed reconstruction graph — annotate per-node dec
 This repo ships two implementations side-by-side:
 
 - **Swift** (`Sources/`, `Package.swift`) — the **primary** server. In-process against OCCTSwift / OCCTSwiftMesh / OCCTSwiftTools / OCCTSwiftAIS / DrawingComposer using the [official Swift MCP SDK](https://swiftpackageindex.com/modelcontextprotocol/swift-sdk). 59 tools. macOS 15+ (the OCCT.xcframework arm64 platform).
-- **Node / TypeScript** (`src/`, `dist/`) — the original implementation. Shells out to the `occtkit` CLI for everything Swift-side. 36 tools (the pre-v0.4 surface; selection / remap / annotations are Swift-only). Useful if you can't run a macOS binary.
+- **Node / TypeScript** (`src/`, `dist/`) — the original implementation. Shells out to the `occtkit` CLI for everything Swift-side. 37 tools (the pre-v0.4 surface; selection / remap / annotations are Swift-only). Useful if you can't run a macOS binary.
 
 Both speak stdio MCP and read/write the same manifest format.
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,6 +29,7 @@ import {
   computeMetrics,
   queryTopology,
   measureDistance,
+  measureDeviation,
   checkThickness,
   analyzeClearance,
   generateMesh,
@@ -457,15 +458,26 @@ server.tool(
 server.tool(
   "compute_metrics",
   "Compute volume / surface area / center of mass / bounding box / principal " +
-    "axes for a scene body. Wraps occtkit metrics.",
+    "axes for a scene body. Wraps occtkit metrics. `boundingBox` is the default " +
+    "Bnd_Box (control-point hull — over-reports curved B-spline geometry); " +
+    "request `boundingBoxOptimal` for a tight BRepBndLib::AddOptimal extent.",
   {
     bodyId: z.string().describe("Body to compute metrics for."),
     metrics: z
       .array(
-        z.enum(["volume", "surfaceArea", "centerOfMass", "boundingBox", "principalAxes"])
+        z.enum([
+          "volume",
+          "surfaceArea",
+          "centerOfMass",
+          "boundingBox",
+          "boundingBoxOptimal",
+          "principalAxes",
+        ])
       )
       .optional()
-      .describe("Subset to compute. Default: all."),
+      .describe(
+        "Subset to compute. Default: all except boundingBoxOptimal (opt-in — list it explicitly)."
+      ),
   },
   async ({ bodyId, metrics }) => computeMetrics(bodyId, metrics)
 );
@@ -509,6 +521,37 @@ server.tool(
   },
   async ({ fromBodyId, toBodyId, fromRef, toRef, computeContacts }) =>
     measureDistance(fromBodyId, toBodyId, fromRef, toRef, computeContacts)
+);
+
+// ── measure_deviation ───────────────────────────────────────────────────────
+server.tool(
+  "measure_deviation",
+  "Directed + symmetric surface deviation (Hausdorff) between two scene bodies " +
+    "— the metric for certifying a reconstruction against its source mesh. " +
+    "Unlike measure_distance (minimum gap, ~0 for overlapping bodies), this " +
+    "samples each body's tessellated surface and reports the worst / RMS / mean " +
+    "distance to the other in BOTH directions: fromToTo (over-extension) and " +
+    "toToFrom (under-coverage), each with a worstPoint, plus symmetricHausdorff. " +
+    "Wraps occtkit measure-deviation.",
+  {
+    fromBodyId: z.string(),
+    toBodyId: z.string(),
+    deflection: z
+      .number()
+      .positive()
+      .optional()
+      .describe(
+        "Mesh linear deflection (model units). Smaller = finer = tighter bound. Default: 0.5% of the from-body bbox diagonal."
+      ),
+    maxSamples: z
+      .number()
+      .int()
+      .positive()
+      .optional()
+      .describe("Max source surface samples per direction (stride-subsampled). Default 20000."),
+  },
+  async ({ fromBodyId, toBodyId, deflection, maxSamples }) =>
+    measureDeviation(fromBodyId, toBodyId, deflection, maxSamples)
 );
 
 // ── check_thickness ───────────────────────────────────────────────────────

--- a/src/verb-tools.ts
+++ b/src/verb-tools.ts
@@ -168,6 +168,36 @@ export async function measureDistance(
   return passthroughResult("measure-distance", await runVerbJSON("measure-distance", req));
 }
 
+// ── measure_deviation ────────────────────────────────────────────────────────
+
+export async function measureDeviation(
+  fromBodyId: string,
+  toBodyId: string,
+  deflection?: number,
+  maxSamples?: number
+): Promise<ToolResult> {
+  const m = await readManifest();
+  if (!m) return text("No scene loaded. Run execute_script first.");
+  const a = findBody(m, fromBodyId);
+  const b = findBody(m, toBodyId);
+  if (!a) return text(`Body not found: ${fromBodyId}`);
+  if (!b) return text(`Body not found: ${toBodyId}`);
+
+  const req: Record<string, unknown> = { a: bodyPath(a), b: bodyPath(b) };
+  if (deflection !== undefined) req.deflection = deflection;
+  if (maxSamples !== undefined) req.maxSamples = maxSamples;
+  const r = await runVerbJSON("measure-deviation", req);
+  if (!r.ok) return text(`occtkit measure-deviation failed.\n\n${r.error}\n${r.stderr}`);
+  // occtkit reports on BREP paths, not body ids — re-attach the ids so the Node
+  // response matches the Swift server's measure_deviation shape.
+  try {
+    const parsed = JSON.parse(r.stdout) as Record<string, unknown>;
+    return text(JSON.stringify({ from: fromBodyId, to: toBodyId, ...parsed }, null, 2));
+  } catch {
+    return text(r.stdout);
+  }
+}
+
 // ── check_thickness ────────────────────────────────────────────────────────
 
 export async function checkThickness(


### PR DESCRIPTION
Brings the **Node** server to parity with the Swift server's new measurement surface, wrapping the occtkit verbs released in [OCCTSwiftScripts v1.3.0](https://github.com/gsdali/OCCTSwiftScripts/releases/tag/v1.3.0).

## Changes

- **`measure_deviation(fromBodyId, toBodyId, deflection?, maxSamples?)`** — wraps the new occtkit `measure-deviation` verb. Parses its JSON and re-attaches `from`/`to` body ids so the Node response matches the Swift server's `measure_deviation` shape (occtkit reports on BREP paths, not ids).
- **`compute_metrics`** — adds `boundingBoxOptimal` to the metrics enum + description. The request array was already forwarded to the `metrics` verb, which now emits the opt-in tight box.

## Requirements

OCCTSwiftScripts **≥ 1.3.0** on `$PATH` (`make install`) or the sibling clone. Node tool count 36 → 37.

## Verification

End-to-end over stdio against a fresh server: two coaxial cylinders Δr=0.5 → `symmetricHausdorff` ≈ 0.524, identical to the Swift server and the direct occtkit verb. Node unit tests green (23).

🤖 Generated with [Claude Code](https://claude.com/claude-code)