### PR TITLE
feat(io): allowInvalid on read_brep / import_file (#41 Gap 2)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -141,9 +141,9 @@ The Node server does not expose the v0.4+ tool surface (selection / remap / anno
 
 ### Swift implementation
 
-- **OCCTSwift** ≥ 1.2.0 — kernel wrapper around OpenCASCADE; full per-input history coverage for booleans + every `FeatureSpec` kind in `BuildResult.histories[id]`, plus `TopologyGraph.findDerivedOrSelf` / `hasHistoryRecord` for unambiguous untouched-vs-deleted resolution. v1.2.0 adds the `TopologyGraph` per-node attribute store (`attributes` / `setAttribute` / `attribute`, closed `AttrValue` enum) and Codable `GraphSnapshot` round-trip (`snapshot()` / `init(snapshot:)`) backing the `reconstruct_*` tool group (#33)
+- **OCCTSwift** ≥ 1.8.0 — kernel wrapper around OpenCASCADE; full per-input history coverage for booleans + every `FeatureSpec` kind in `BuildResult.histories[id]`, plus `TopologyGraph.findDerivedOrSelf` / `hasHistoryRecord` for unambiguous untouched-vs-deleted resolution. v1.2.0 adds the `TopologyGraph` per-node attribute store (`attributes` / `setAttribute` / `attribute`, closed `AttrValue` enum) and Codable `GraphSnapshot` round-trip (`snapshot()` / `init(snapshot:)`) backing the `reconstruct_*` tool group (#33). v1.8.0 adds `Exporter.writeBREP(allowInvalid:)` backing `read_brep` / `import_file`'s `allowInvalid` (#41)
 - **OCCTSwiftMesh** ≥ 1.0.0 — mesh-domain algorithms (QEM decimation today; smoothing / repair / remeshing in roadmap)
-- **OCCTSwiftScripts** ≥ 1.0.2 — provides `occtkit` (only used by `execute_script` and `export_scene`); also ships `ScriptHarness` + `DrawingComposer` consumed in-process
+- **OCCTSwiftScripts** ≥ 1.4.0 — provides `occtkit` (only used by `execute_script` and `export_scene`); also ships `ScriptHarness` + `DrawingComposer` consumed in-process. `ExecuteScriptTool.scriptsPin` must track this pin (#42)
 - **OCCTSwiftTools** ≥ 1.1.0 — Shape↔ViewportBody bridge; ships `PointConverter` and wires `pointRadius` / `vertexColors` through to `ViewportBody`
 - **OCCTSwiftViewport** ≥ 1.0.2 — Metal viewport + offscreen renderer; v1.0.2 added the point-sprite pipeline that makes `pointCloud` overlays actually render
 - **OCCTSwiftAIS** ≥ 1.0.1 — selection, manipulators, dimensions
@@ -151,7 +151,7 @@ The Node server does not expose the v0.4+ tool surface (selection / remap / anno
 
 ### Node implementation
 
-- **OCCTSwiftScripts** ≥ 1.3.0 — provides `occtkit` on `$PATH` (`make install` from the OCCTSwiftScripts repo) or via sibling clone at `~/Projects/OCCTSwiftScripts` so `swift run -c release occtkit` works as the fallback. v1.3.0 adds the `measure-deviation` verb and the `metrics` `boundingBoxOptimal` field that the Node `measure_deviation` / `compute_metrics` tools wrap
+- **OCCTSwiftScripts** ≥ 1.4.0 — provides `occtkit` on `$PATH` (`make install` from the OCCTSwiftScripts repo) or via sibling clone at `~/Projects/OCCTSwiftScripts` so `swift run -c release occtkit` works as the fallback. v1.3.0 adds the `measure-deviation` verb and the `metrics` `boundingBoxOptimal` field (Node `measure_deviation` / `compute_metrics`); v1.4.0 adds `load-brep` / `import` `--allow-invalid` (Node `read_brep` / `import_file` `allowInvalid`, #41)
 - **OCCTSwift** — required at `~/Projects/OCCTSwift/` only when regenerating `src/api-reference.ts` via `scripts/generate-api-reference.mjs` (runs as `npm run prebuild`)
 - **OCCTSwiftViewport** — Metal viewport that watches the output directory via `ScriptWatcher` and auto-reloads. Optional but expected if you want the live preview
 

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "0f4bd9521d36effae1f2e0b9c37ed03a4ece0c5633137c7656963f59f395faab",
+  "originHash" : "00ddb1821dd91c45c30db82470401666599849e9924c1b8d2cc70803757964cc",
   "pins" : [
     {
       "identity" : "eventsource",
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/gsdali/OCCTSwift.git",
       "state" : {
-        "revision" : "6e3f99603ed14790816cb4857a6df20848bd11ca",
-        "version" : "1.7.1"
+        "revision" : "94eea64c25c265f268ecd6da6fef36b05a60ce9b",
+        "version" : "1.8.0"
       }
     },
     {
@@ -51,8 +51,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/gsdali/OCCTSwiftScripts.git",
       "state" : {
-        "revision" : "d95999b9cbea02a2aed0db5b5299c7bcc7a4e498",
-        "version" : "1.2.0"
+        "revision" : "4859b273fee198e27f48225b6e13ebd98601c52d",
+        "version" : "1.4.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -53,8 +53,9 @@ let package = Package(
         //
         // Floored at 1.7.1 for OCCT 8.0.0p1 — the redesigned BRepGraph/
         // TopologyGraph model. All sibling deps below are re-pinned to the
-        // matching p1 cohort.
-        .package(url: "https://github.com/gsdali/OCCTSwift.git", from: "1.7.1"),
+        // matching p1 cohort. 1.8.0 adds Exporter.writeBREP(allowInvalid:) for
+        // read_brep / import_file `allowInvalid` (#41).
+        .package(url: "https://github.com/gsdali/OCCTSwift.git", from: "1.8.0"),
         .package(url: "https://github.com/gsdali/OCCTSwiftMesh.git", from: "1.1.1"),
         // 1.0.4 adds DrawingComposer GA / assembly drawings (OCCTSwiftScripts#50):
         // Composer.render(spec:components:) / render(spec:document:) — multi-body
@@ -62,7 +63,9 @@ let package = Package(
         // bodyIds.
         // v1.2.0 = OCCTSwift 1.7.1 floor (OCCT 8.0.0p1) + the graph-select verb /
         // convexity-attributed faceAdjacency (OCCTSwiftScripts #54/#55).
-        .package(url: "https://github.com/gsdali/OCCTSwiftScripts.git", from: "1.2.0"),
+        // v1.4.0 = measure-deviation verb + metrics boundingBoxOptimal (#44) +
+        // load-brep/import --allow-invalid (#41), used by the Node server.
+        .package(url: "https://github.com/gsdali/OCCTSwiftScripts.git", from: "1.4.0"),
         .package(url: "https://github.com/gsdali/OCCTSwiftTools.git", from: "1.1.2"),
         // Viewport floored at 1.1.20: 1.0.3 fixes an uncatchable quantize()
         // crash on body load (Viewport #30) that would trap the MCP server

--- a/README.md
+++ b/README.md
@@ -105,8 +105,8 @@ For novel geometry the typed tools don't cover, the LLM falls back to `execute_s
 
 | Tool | Purpose |
 |------|---------|
-| `read_brep` | Load a `.brep` from disk into the scene |
-| `import_file` | Multi-format import (STEP / IGES / STL / OBJ); optional XCAF assembly |
+| `read_brep` | Load a `.brep` from disk into the scene (`allowInvalid` loads a loose-face / invalid shape for measurement) |
+| `import_file` | Multi-format import (STEP / IGES / STL / OBJ); optional XCAF assembly; `allowInvalid` for in-progress reconstructions |
 | `export_scene` | Export to STEP / IGES / BREP / STL / OBJ / glTF / GLB |
 | `set_assembly_metadata` | Modify XCAF document or per-component metadata |
 

--- a/Sources/OCCTMCPCore/Server.swift
+++ b/Sources/OCCTMCPCore/Server.swift
@@ -947,6 +947,10 @@ func catalogTools() -> [Tool] {
                         "type": .string("array"),
                         "items": .object(["type": .string("number")]),
                     ]),
+                    "allowInvalid": .object([
+                        "type": .string("boolean"),
+                        "description": .string("Load a topologically invalid / loose-face shape as-is (skip the validity write-gate) so compute_metrics / measure_deviation / validate_geometry can run on an in-progress reconstruction. Default false."),
+                    ]),
                 ]),
                 "required": .array([.string("inputPath")]),
                 "additionalProperties": .bool(false),
@@ -964,6 +968,10 @@ func catalogTools() -> [Tool] {
                         "enum": .array([.string("auto"), .string("step"), .string("iges"), .string("obj"), .string("brep")]),
                     ]),
                     "idPrefix": .object(["type": .string("string")]),
+                    "allowInvalid": .object([
+                        "type": .string("boolean"),
+                        "description": .string("Import a topologically invalid / loose-face shape as-is (skip the validity write-gate) so the analysis tools can measure an in-progress reconstruction. Default false."),
+                    ]),
                 ]),
                 "required": .array([.string("inputPath")]),
                 "additionalProperties": .bool(false),
@@ -1701,7 +1709,8 @@ func dispatch(callName: String, arguments: [String: Value]) async -> CallTool.Re
         return await IOTools.readBrep(
             inputPath: inputPath,
             bodyId: arguments["bodyId"]?.stringValue,
-            color: color
+            color: color,
+            allowInvalid: arguments["allowInvalid"]?.boolValue ?? false
         ).asCallToolResult()
 
     case "import_file":
@@ -1712,7 +1721,8 @@ func dispatch(callName: String, arguments: [String: Value]) async -> CallTool.Re
         return await IOTools.importFile(
             inputPath: inputPath,
             format: format,
-            idPrefix: arguments["idPrefix"]?.stringValue ?? "imported"
+            idPrefix: arguments["idPrefix"]?.stringValue ?? "imported",
+            allowInvalid: arguments["allowInvalid"]?.boolValue ?? false
         ).asCallToolResult()
 
     case "export_scene":

--- a/Sources/OCCTMCPCore/Tools/ExecuteScriptTool.swift
+++ b/Sources/OCCTMCPCore/Tools/ExecuteScriptTool.swift
@@ -26,7 +26,7 @@ public enum ExecuteScriptTool {
     /// against a different (older) kernel than the server's own tools.
     /// A `from: "0.x"` floor caps below 1.0.0 (SPM "up to next major"),
     /// which stranded scripts on pre-GA OCCTSwift 0.171.0 (#42).
-    static let scriptsPin = "1.2.0"
+    static let scriptsPin = "1.4.0"
 
     public static func execute(
         code: String,

--- a/Sources/OCCTMCPCore/Tools/IOTools.swift
+++ b/Sources/OCCTMCPCore/Tools/IOTools.swift
@@ -25,6 +25,7 @@ public enum IOTools {
         inputPath: String,
         bodyId: String? = nil,
         color: [Float]? = nil,
+        allowInvalid: Bool = false,
         store: ManifestStore = ManifestStore(),
         history: SceneHistory = .shared
     ) async -> ToolText {
@@ -53,7 +54,7 @@ public enum IOTools {
         let outFile = "\(resolvedId).brep"
         let outPath = "\(outputDir)/\(outFile)"
         do {
-            try Exporter.writeBREP(shape: shape, to: URL(fileURLWithPath: outPath))
+            try Exporter.writeBREP(shape: shape, to: URL(fileURLWithPath: outPath), allowInvalid: allowInvalid)
         } catch {
             return .init("Failed to copy BREP: \(error.localizedDescription)", isError: true)
         }
@@ -118,6 +119,7 @@ public enum IOTools {
         inputPath: String,
         format: ImportFormat = .auto,
         idPrefix: String = "imported",
+        allowInvalid: Bool = false,
         store: ManifestStore = ManifestStore(),
         history: SceneHistory = .shared
     ) async -> ToolText {
@@ -158,7 +160,7 @@ public enum IOTools {
         let outFile = "\(id).brep"
         let outPath = "\(outputDir)/\(outFile)"
         do {
-            try Exporter.writeBREP(shape: shape, to: URL(fileURLWithPath: outPath))
+            try Exporter.writeBREP(shape: shape, to: URL(fileURLWithPath: outPath), allowInvalid: allowInvalid)
         } catch {
             return .init("Failed to write BREP: \(error.localizedDescription)", isError: true)
         }

--- a/SwiftTests/OCCTMCPCoreTests/IOToolsTests.swift
+++ b/SwiftTests/OCCTMCPCoreTests/IOToolsTests.swift
@@ -1,0 +1,53 @@
+// Unit tests for the IO tools' allowInvalid path (#41 Gap 2).
+
+import Foundation
+import Testing
+import OCCTSwift
+import ScriptHarness
+@testable import OCCTMCPCore
+
+@Suite("read_brep allowInvalid")
+struct IOToolsTests {
+
+    /// Fresh tempdir scene + the path to an on-disk BREP of a deterministically
+    /// invalid shape (a bowtie self-intersecting face).
+    func freshSceneWithInvalidBrep() throws -> (store: ManifestStore, brep: String, dir: String) {
+        let dir = NSTemporaryDirectory() + "occtmcp-io-\(UUID().uuidString)"
+        try FileManager.default.createDirectory(atPath: dir, withIntermediateDirectories: true)
+        let store = ManifestStore(path: "\(dir)/manifest.json")
+        try store.write(ScriptManifest(description: "io", bodies: []))
+
+        let bowtie = Wire.polygon([SIMD2(0, 0), SIMD2(1, 1), SIMD2(1, 0), SIMD2(0, 1)], closed: true)!
+        let invalid = Shape.face(from: bowtie)!
+        #expect(!invalid.isValid)
+        let brep = "\(dir)/invalid.brep"
+        try Exporter.writeBREP(shape: invalid, to: URL(fileURLWithPath: brep), allowInvalid: true)
+        return (store, brep, dir)
+    }
+
+    @Test("read_brep rejects an invalid shape by default")
+    func rejectsInvalidByDefault() async throws {
+        let (store, brep, dir) = try freshSceneWithInvalidBrep()
+        defer { try? FileManager.default.removeItem(atPath: dir) }
+
+        let result = await IOTools.readBrep(
+            inputPath: brep, bodyId: "x", allowInvalid: false,
+            store: store, history: SceneHistory())
+        #expect(result.isError)
+        #expect((try? store.read())?.bodies.isEmpty == true)
+    }
+
+    @Test("read_brep allowInvalid loads an invalid shape into the scene")
+    func loadsInvalidWhenAllowed() async throws {
+        let (store, brep, dir) = try freshSceneWithInvalidBrep()
+        defer { try? FileManager.default.removeItem(atPath: dir) }
+
+        let result = await IOTools.readBrep(
+            inputPath: brep, bodyId: "x", allowInvalid: true,
+            store: store, history: SceneHistory())
+        #expect(!result.isError, "unexpected error: \(result.text)")
+        let bodies = (try store.read())?.bodies ?? []
+        #expect(bodies.contains { $0.id == "x" })
+        #expect(FileManager.default.fileExists(atPath: "\(dir)/x.brep"))
+    }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -713,8 +713,15 @@ server.tool(
     inputPath: z.string(),
     bodyId: z.string().optional(),
     color: z.string().optional().describe("'#rrggbb' or '#rrggbbaa'."),
+    allowInvalid: z
+      .boolean()
+      .optional()
+      .describe(
+        "Load a topologically invalid / loose-face shape as-is (skip the validity write-gate) so compute_metrics / measure_deviation / validate_geometry can run on an in-progress reconstruction. Default false."
+      ),
   },
-  async ({ inputPath, bodyId, color }) => readBrep(inputPath, bodyId, color)
+  async ({ inputPath, bodyId, color, allowInvalid }) =>
+    readBrep(inputPath, bodyId, color, allowInvalid)
 );
 
 // ── import_file ───────────────────────────────────────────────────────────
@@ -731,9 +738,15 @@ server.tool(
       .optional()
       .describe("STEP only: walk XCAF and emit one body per leaf node."),
     healOnImport: z.boolean().optional(),
+    allowInvalid: z
+      .boolean()
+      .optional()
+      .describe(
+        "Import a topologically invalid / loose-face shape as-is (skip the validity write-gate) so the analysis tools can measure an in-progress reconstruction. Default false."
+      ),
   },
-  async ({ inputPath, format, idPrefix, preserveAssembly, healOnImport }) =>
-    importFile(inputPath, format, idPrefix, preserveAssembly, healOnImport)
+  async ({ inputPath, format, idPrefix, preserveAssembly, healOnImport, allowInvalid }) =>
+    importFile(inputPath, format, idPrefix, preserveAssembly, healOnImport, allowInvalid)
 );
 
 // ── render_preview ────────────────────────────────────────────────────────

--- a/src/verb-tools.ts
+++ b/src/verb-tools.ts
@@ -623,12 +623,14 @@ async function mergeStagedImport(
 export async function readBrep(
   inputPath: string,
   bodyId?: string,
-  color?: string
+  color?: string,
+  allowInvalid?: boolean
 ): Promise<ToolResult> {
   if (!existsSync(inputPath)) return text(`BREP file not found: ${inputPath}`);
   const req: Record<string, unknown> = { inputBrep: inputPath };
   if (bodyId !== undefined) req.id = bodyId;
   if (color !== undefined) req.color = color;
+  if (allowInvalid !== undefined) req.allowInvalid = allowInvalid;
   return mergeStagedImport("load-brep", req, 60_000);
 }
 
@@ -639,7 +641,8 @@ export async function importFile(
   format?: "auto" | "step" | "iges" | "stl" | "obj",
   idPrefix?: string,
   preserveAssembly?: boolean,
-  healOnImport?: boolean
+  healOnImport?: boolean,
+  allowInvalid?: boolean
 ): Promise<ToolResult> {
   if (!existsSync(inputPath)) return text(`File not found: ${inputPath}`);
   const req: Record<string, unknown> = { inputPath };
@@ -647,6 +650,7 @@ export async function importFile(
   if (idPrefix !== undefined) req.idPrefix = idPrefix;
   if (preserveAssembly !== undefined) req.preserveAssembly = preserveAssembly;
   if (healOnImport !== undefined) req.healOnImport = healOnImport;
+  if (allowInvalid !== undefined) req.allowInvalid = allowInvalid;
   return mergeStagedImport("import", req, 240_000);
 }
 


### PR DESCRIPTION
Closes the second half of #41. (Gap 1 — `measure_deviation` — already shipped.)

## Problem

An in-progress reconstruction — a compound of loose analytic faces, possibly with a few invalid faces — couldn't be loaded into the scene: the BREP write gated on `shape.isValid`. Yet every analysis tool (`compute_metrics`, `measure_deviation`, `validate_geometry`) loads via the non-gating `Shape.loadBREP` and works fine on invalid shapes. So the imperfect output that verification exists to measure was unmeasurable.

## Change

`allowInvalid` (default `false`) on `read_brep` and `import_file`, both servers:
- **Swift** → OCCTSwift 1.8.0 `Exporter.writeBREP(allowInvalid:)` (skips the `isValid` gate).
- **Node** → occtkit `load-brep` / `import --allow-invalid` (OCCTSwiftScripts 1.4.0).

Once loaded, the analysis tools run on it unchanged.

## Cohort

OCCTSwift 1.7.1 → 1.8.0, OCCTSwiftScripts 1.2.0 → 1.4.0; `execute_script` `scriptsPin` tracks at 1.4.0 (#42 invariant).

## Tests

A deterministically-invalid bowtie (self-intersecting) face is rejected by default and loaded into the scene with `allowInvalid: true` (new `IOToolsTests`). Full suites green — Swift 41, Node 23.

## Dependency chain (all merged + released)

- OCCTSwift [v1.8.0](https://github.com/gsdali/OCCTSwift/releases/tag/v1.8.0) — `Exporter.writeBREP(allowInvalid:)` (#248)
- OCCTSwiftScripts [v1.4.0](https://github.com/gsdali/OCCTSwiftScripts/releases/tag/v1.4.0) — `--allow-invalid` verbs (#60)

🤖 Generated with [Claude Code](https://claude.com/claude-code)