### PR TITLE
Refresh Package.resolved → SecondMouseAU (#53)

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "00ddb1821dd91c45c30db82470401666599849e9924c1b8d2cc70803757964cc",
+  "originHash" : "22d8466ec79caa5aa66b8436a48d536372b499d772e357ea261ff7c1e1063ad2",
   "pins" : [
     {
       "identity" : "eventsource",
@@ -13,16 +13,16 @@
     {
       "identity" : "occtswift",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/gsdali/OCCTSwift.git",
+      "location" : "https://github.com/SecondMouseAU/OCCTSwift.git",
       "state" : {
-        "revision" : "94eea64c25c265f268ecd6da6fef36b05a60ce9b",
-        "version" : "1.8.0"
+        "revision" : "240ad38b8d877a351f38a7f0eac8c0360ae353dd",
+        "version" : "1.8.2"
       }
     },
     {
       "identity" : "occtswiftais",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/gsdali/OCCTSwiftAIS.git",
+      "location" : "https://github.com/SecondMouseAU/OCCTSwiftAIS.git",
       "state" : {
         "revision" : "d531a505a079450462569007ec6272b40ed94768",
         "version" : "1.0.3"
@@ -31,7 +31,7 @@
     {
       "identity" : "occtswiftio",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/gsdali/OCCTSwiftIO.git",
+      "location" : "https://github.com/SecondMouseAU/OCCTSwiftIO.git",
       "state" : {
         "revision" : "05881da56a557873d3bd8a1a3b48f997eef504a6",
         "version" : "1.0.1"
@@ -40,7 +40,7 @@
     {
       "identity" : "occtswiftmesh",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/gsdali/OCCTSwiftMesh.git",
+      "location" : "https://github.com/SecondMouseAU/OCCTSwiftMesh.git",
       "state" : {
         "revision" : "70a0bdad8377d928710a22b92d8bc93aeca45470",
         "version" : "1.1.1"
@@ -49,28 +49,28 @@
     {
       "identity" : "occtswiftscripts",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/gsdali/OCCTSwiftScripts.git",
+      "location" : "https://github.com/SecondMouseAU/OCCTSwiftScripts.git",
       "state" : {
-        "revision" : "4859b273fee198e27f48225b6e13ebd98601c52d",
-        "version" : "1.4.0"
+        "revision" : "9ada338939ae66767884d6b76e26fd1d03a18079",
+        "version" : "1.4.1"
       }
     },
     {
       "identity" : "occtswifttools",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/gsdali/OCCTSwiftTools.git",
+      "location" : "https://github.com/SecondMouseAU/OCCTSwiftTools.git",
       "state" : {
-        "revision" : "a80581273e9299aa72b2f0e6d1ac786208c50950",
-        "version" : "1.1.2"
+        "revision" : "ec34b6c9a828c5752c4ac68b269e3c1947cf56ef",
+        "version" : "1.2.1"
       }
     },
     {
       "identity" : "occtswiftviewport",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/gsdali/OCCTSwiftViewport.git",
+      "location" : "https://github.com/SecondMouseAU/OCCTSwiftViewport.git",
       "state" : {
-        "revision" : "069d894a9c3f9c366e4387eff2cda796703faf99",
-        "version" : "1.1.20"
+        "revision" : "250a500e950efd7d8824b179b7c124ea8e84347c",
+        "version" : "1.1.22"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -24,6 +24,17 @@ func occtDep(_ name: String, from version: String) -> Package.Dependency {
     return .package(url: "https://github.com/SecondMouseAU/\(name).git", from: Version(version)!)
 }
 
+// As occtDep, but pins to the package's minor line (`.upToNextMinor`) instead of
+// the major. Used to cap a transitive dependency whose newer minors pull deps we
+// don't want in the graph — see the OCCTSwiftIO note in `dependencies` below.
+func occtDepUpToNextMinor(_ name: String, from version: String) -> Package.Dependency {
+    let manifestDir = URL(fileURLWithPath: #filePath).deletingLastPathComponent().path
+    if FileManager.default.fileExists(atPath: manifestDir + "/../\(name)/Package.swift") {
+        return .package(path: "../\(name)")
+    }
+    return .package(url: "https://github.com/SecondMouseAU/\(name).git", .upToNextMinor(from: Version(version)!))
+}
+
 let package = Package(
     name: "OCCTMCP",
     platforms: [
@@ -78,8 +89,11 @@ let package = Package(
         // convexity-attributed faceAdjacency (OCCTSwiftScripts #54/#55).
         // v1.4.0 = measure-deviation verb + metrics boundingBoxOptimal (#44) +
         // load-brep/import --allow-invalid (#41), used by the Node server.
-        occtDep("OCCTSwiftScripts", from: "1.4.0"),
-        occtDep("OCCTSwiftTools", from: "1.1.2"),
+        // v1.4.1 / Tools v1.2.1 = SecondMouseAU org migration: their manifests now
+        // declare OCCTSwiftIO at SecondMouseAU, so the transitive pin re-homes
+        // without a root-level OCCTSwiftIO override here (#53).
+        occtDep("OCCTSwiftScripts", from: "1.4.1"),
+        occtDep("OCCTSwiftTools", from: "1.2.1"),
         // Viewport floored at 1.1.20: 1.0.3 fixes an uncatchable quantize()
         // crash on body load (Viewport #30) that would trap the MCP server
         // during render-preview; 1.0.4 makes the package dependency-free;
@@ -88,6 +102,15 @@ let package = Package(
         // surface-point reconstruction that respects the body transform.
         occtDep("OCCTSwiftViewport", from: "1.1.20"),
         occtDep("OCCTSwiftAIS", from: "1.0.3"),
+        // OCCTSwiftIO is a transitive dependency of OCCTSwiftScripts / OCCTSwiftTools,
+        // declared open-endedly (`from: 1.0.x`) in their manifests. After the
+        // SecondMouseAU migration its 1.1.0+ releases became reachable, and those
+        // pull a heavy mesh-IO stack (SwiftPMX / SwiftGLTF / ThreeMF / SwiftJWW /
+        // SwiftX) that doesn't resolve in this graph — OCCTMCP only needs the
+        // BREP/STEP core. Cap it to the compatible 1.0.x line, which is the version
+        // OCCTMCP has always built against. Also re-homes the pin to SecondMouseAU
+        // (root URL wins), so no gsdali/OCCTSwiftIO leaks into the lockfile (#53).
+        occtDepUpToNextMinor("OCCTSwiftIO", from: "1.0.1"),
     ],
     targets: [
         .target(


### PR DESCRIPTION
## What
Closes #53. After the `gsdali` → `SecondMouseAU` org migration the committed `Package.resolved` still pinned `gsdali`, so SwiftPM (which matches deps by identity) kept fetching from the old org.

## Changes
- **`Package.swift`** — `occtDep` URL template now points at `SecondMouseAU`.
- **Upstream tags consumed** — bumped to `OCCTSwiftScripts 1.4.1` and `OCCTSwiftTools 1.2.1`, the first tags whose manifests declare `OCCTSwiftIO` at SecondMouseAU (the org migration of those repos was a prerequisite — see SecondMouseAU/ecosystem#1).
- **`OCCTSwiftIO` version cap** — `occtDepUpToNextMinor("OCCTSwiftIO", from: "1.0.1")`. `OCCTSwiftIO` is a transitive dep of Scripts/Tools, declared open-endedly (`from: 1.0.x`). Pre-migration, `gsdali/OCCTSwiftIO` only had tags ≤ 1.0.1, so it was capped by accident. Post-migration its 1.1.0+ minors became reachable, and those pull a heavy mesh-IO stack (SwiftPMX / SwiftGLTF / ThreeMF / SwiftJWW / SwiftX) that **does not resolve** in this graph. The cap pins the compatible 1.0.x line (what OCCTMCP has always built against) and keeps the SecondMouseAU URL (root wins).
- **`Package.resolved`** — regenerated in a sibling-free checkout.

## Done when ✅
`Package.resolved` contains only `github.com/SecondMouseAU/...` — **0 gsdali pins** across all seven OCCT packages (OCCTSwift 1.8.2, OCCTSwiftAIS 1.0.3, OCCTSwiftIO 1.0.1, OCCTSwiftMesh 1.1.1, OCCTSwiftScripts 1.4.1, OCCTSwiftTools 1.2.1, OCCTSwiftViewport 1.1.22).

## Verification
- Sibling-free `swift package resolve` → 0 gsdali, OCCTSwiftIO 1.0.1, 14 pins (no mesh-IO stack).
- `swift build` + `swift test` (41/41) pass with siblings.
- Tools 1.2.1's `CADFileLoader` uses only `ShapeLoader.load` / `loadFromManifest`, both present in OCCTSwiftIO 1.0.1; Scripts 1.4.1 is a docs-only delta over the already-green 1.4.0.

Ref: SecondMouseAU/ecosystem#1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)