### PR TITLE
import_file handles BREP (.brep / .brp) (#56)

### DIFF
--- a/Sources/OCCTMCPCore/Tools/IOTools.swift
+++ b/Sources/OCCTMCPCore/Tools/IOTools.swift
@@ -104,7 +104,7 @@ public enum IOTools {
             case "step", "stp": return .step
             case "iges", "igs": return .iges
             case "obj": return .obj
-            case "brep": return .brep
+            case "brep", "brp": return .brep
             default: return nil
             }
         }

--- a/src/index.ts
+++ b/src/index.ts
@@ -727,11 +727,12 @@ server.tool(
 // ── import_file ───────────────────────────────────────────────────────────
 server.tool(
   "import_file",
-  "Multi-format CAD import (STEP / IGES / STL / OBJ) into the scene. Wraps " +
-    "occtkit import.",
+  "Multi-format CAD import (STEP / IGES / STL / OBJ / BREP) into the scene. " +
+    "Wraps occtkit import; BREP (.brep / .brp) is routed to occtkit load-brep, " +
+    "which occtkit import itself does not handle.",
   {
     inputPath: z.string(),
-    format: z.enum(["auto", "step", "iges", "stl", "obj"]).optional(),
+    format: z.enum(["auto", "step", "iges", "stl", "obj", "brep"]).optional(),
     idPrefix: z.string().optional(),
     preserveAssembly: z
       .boolean()

--- a/src/verb-tools.ts
+++ b/src/verb-tools.ts
@@ -638,13 +638,27 @@ export async function readBrep(
 
 export async function importFile(
   inputPath: string,
-  format?: "auto" | "step" | "iges" | "stl" | "obj",
+  format?: "auto" | "step" | "iges" | "stl" | "obj" | "brep",
   idPrefix?: string,
   preserveAssembly?: boolean,
   healOnImport?: boolean,
   allowInvalid?: boolean
 ): Promise<ToolResult> {
   if (!existsSync(inputPath)) return text(`File not found: ${inputPath}`);
+
+  // occtkit's `import` verb only handles STEP / IGES / STL / OBJ; BREP has its
+  // own `load-brep` verb. Route BREP (explicit format or .brep/.brp extension)
+  // there so import_file is a single entry point for all of them.
+  const ext = extname(inputPath).slice(1).toLowerCase();
+  const isAutoFormat = format === undefined || format === "auto";
+  const isBrep = format === "brep" || (isAutoFormat && (ext === "brep" || ext === "brp"));
+  if (isBrep) {
+    const brepReq: Record<string, unknown> = { inputBrep: inputPath };
+    if (idPrefix !== undefined) brepReq.id = idPrefix;
+    if (allowInvalid !== undefined) brepReq.allowInvalid = allowInvalid;
+    return mergeStagedImport("load-brep", brepReq, 60_000);
+  }
+
   const req: Record<string, unknown> = { inputPath };
   if (format !== undefined) req.format = format;
   if (idPrefix !== undefined) req.idPrefix = idPrefix;


### PR DESCRIPTION
## What
Closes #56. `import_file` could not import a `.brep` file — auto-detect failed (`Cannot auto-detect format from extension 'brep'`) and there was no way to force the format.

## Root cause
- **Swift** routed `brep` → in-process `Shape.loadBREP` and the schema already advertised BREP, but `ImportFormat.resolve` only matched the `.brep` extension, not `.brp`.
- **Node** `import_file` shells exclusively to occtkit `import`, whose format set is `auto/step/iges/stl/obj` — occtkit has **no BREP loader on that verb** (BREP lives behind the separate `load-brep` verb, already used by `read_brep`). So the Node enum had no `brep` and any `.brep` path hit the occtkit error.

## Fix
- **Swift** — `ImportFormat.resolve` now also matches `.brp`.
- **Node** — `format` enum gains `brep`; `import_file` routes BREP (explicit `format: "brep"`, or a `.brep`/`.brp` path under auto-detect) to the `load-brep` verb. Single entry point for all formats; no occtkit change required.

## Verification
- `swift build` + `swift test` — 41/41 pass.
- `npm run build` (tsc) + `npm test` — 23/23 pass.
- Node BREP routing mirrors `read_brep`'s already-working `mergeStagedImport("load-brep", …)` call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)