### PR TITLE
docs: import_file BREP (#56) + SecondMouseAU links

### DIFF
--- a/context7.json
+++ b/context7.json
@@ -23,6 +23,7 @@
     "measure_distance is the MINIMUM gap (≈0 for overlapping bodies); use measure_deviation for one-sided / symmetric surface Hausdorff when certifying a reconstruction against a source mesh.",
     "compute_metrics `boundingBox` is the default Bnd_Box (over-reports curved B-spline faces); request `boundingBoxOptimal` for a tight AddOptimal extent.",
     "Swift-only tools (absent from the Node server): the selection/remap family (select_topology, remap_selection, find_correspondences, select_by_feature, list/clear_selections), annotations (add_dimension, add_scene_primitive, auto_dimension, show_bounding_box, diff_overlay, remove_scene_annotation, list_annotations), the reconstruct_* group, graph_select, pick_surface_point, and ping.",
-    "read_brep / import_file gate on shape validity by default; pass `allowInvalid: true` to load a loose-face / invalid in-progress reconstruction so compute_metrics / measure_deviation / validate_geometry can measure it."
+    "read_brep / import_file gate on shape validity by default; pass `allowInvalid: true` to load a loose-face / invalid in-progress reconstruction so compute_metrics / measure_deviation / validate_geometry can measure it.",
+    "import_file is the single entry point for STEP / IGES / OBJ / BREP (`.brep` / `.brp`, auto-detected by extension or `format: \"brep\"`). On the Node server BREP is routed to the occtkit load-brep verb (occtkit `import` has no BREP loader); on Swift it loads in-process — so you needn't fall back to read_brep for BREP."
   ]
 }

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -13,7 +13,7 @@ remote_theme: just-the-docs/just-the-docs@v0.3.3
 search_enabled: true
 heading_anchors: true
 aux_links:
-  "GitHub": ["https://github.com/gsdali/OCCTMCP"]
+  "GitHub": ["https://github.com/SecondMouseAU/OCCTMCP"]
 aux_links_new_tab: true
 
 exclude:

--- a/docs/guides/architecture.md
+++ b/docs/guides/architecture.md
@@ -117,7 +117,7 @@ DrawingComposer    — 2D drawing / general-arrangement output (via OCCTSwiftScr
 
 `render_preview` depends on **OCCTSwiftTools + OCCTSwiftViewport** to compose body overlays (measurements, annotations, point clouds, bounding boxes). The Node server does not have in-process access to this stack — it shells to `occtkit` for every call.
 
-For the ecosystem package versions and dependency pins, see `Package.swift` and the [OCCTMCP README](https://github.com/gsdali/OCCTMCP#mcp-tools).
+For the ecosystem package versions and dependency pins, see `Package.swift` and the [OCCTMCP README](https://github.com/SecondMouseAU/OCCTMCP#mcp-tools).
 
 ---
 

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -18,7 +18,7 @@ This page covers installing OCCTMCP, wiring it into an MCP client, and making yo
 
 - Node.js 18+
 - The `occtkit` CLI on `$PATH` — install it by running `make install` inside a clone of
-  [OCCTSwiftScripts](https://github.com/gsdali/OCCTSwiftScripts), or keep a sibling clone at
+  [OCCTSwiftScripts](https://github.com/SecondMouseAU/OCCTSwiftScripts), or keep a sibling clone at
   `~/Projects/OCCTSwiftScripts` so OCCTMCP can fall back to `swift run -c release occtkit` automatically
 
 The Node server exposes a 37-tool subset; the Swift server exposes all 59 tools (selection, remap,
@@ -32,7 +32,7 @@ per-tool server availability.
 ### Swift
 
 ```bash
-git clone https://github.com/gsdali/OCCTMCP.git
+git clone https://github.com/SecondMouseAU/OCCTMCP.git
 cd OCCTMCP
 swift build -c release
 # binary at: .build/release/occtmcp-server
@@ -41,7 +41,7 @@ swift build -c release
 ### Node
 
 ```bash
-git clone https://github.com/gsdali/OCCTMCP.git
+git clone https://github.com/SecondMouseAU/OCCTMCP.git
 cd OCCTMCP
 npm install
 npm run build

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,7 +6,7 @@ nav_order: 1
 # OCCTMCP documentation
 
 An **MCP server** that gives LLMs the ability to author, inspect, measure and iterate on 3D CAD models
-with [OpenCASCADE](https://www.opencascade.com/) via the [OCCTSwift](https://github.com/gsdali/OCCTSwift)
+with [OpenCASCADE](https://www.opencascade.com/) via the [OCCTSwift](https://github.com/SecondMouseAU/OCCTSwift)
 family. The LLM picks a typed tool; OCCTMCP runs the OCCT operation in-process and writes BREP / STEP /
 PNG + a `manifest.json` scene the viewer auto-reloads.
 
@@ -46,7 +46,7 @@ real workflows, with `render_preview` figures. The **[Cookbook index](guides/coo
 
 - **[Tool Reference](reference/)** — per-tool-family detail: every tool's JSON-Schema parameters,
   returns, an example call + result, Node availability, and the OCCTSwift / occtkit behind it.
-- [README tool table](https://github.com/gsdali/OCCTMCP#mcp-tools) — the one-line catalog.
+- [README tool table](https://github.com/SecondMouseAU/OCCTMCP#mcp-tools) — the one-line catalog.
 
 ## Guides & concepts
 
@@ -55,5 +55,5 @@ real workflows, with `render_preview` figures. The **[Cookbook index](guides/coo
 
 ## Project
 
-- Source & issues: [github.com/gsdali/OCCTMCP](https://github.com/gsdali/OCCTMCP)
-- Part of the [OCCTSwift ecosystem](https://github.com/gsdali/OCCTSwift/blob/main/docs/ecosystem.md). SemVer-stable since v1.0.0.
+- Source & issues: [github.com/SecondMouseAU/OCCTMCP](https://github.com/SecondMouseAU/OCCTMCP)
+- Part of the [OCCTSwift ecosystem](https://github.com/SecondMouseAU/OCCTSwift/blob/main/docs/ecosystem.md). SemVer-stable since v1.0.0.

--- a/docs/reference/README.md
+++ b/docs/reference/README.md
@@ -17,7 +17,7 @@ notes its Node availability.
 
 This complements the other docs:
 - [Cookbook](../guides/cookbook/) — *task-oriented* recipes that chain these tools.
-- [README tool table](https://github.com/gsdali/OCCTMCP#mcp-tools) — the one-line catalog.
+- [README tool table](https://github.com/SecondMouseAU/OCCTMCP#mcp-tools) — the one-line catalog.
 
 ## Page layout
 
@@ -82,7 +82,7 @@ nav_order: <n>
 4. **Examples must be schema-faithful** — only real parameters, correct types. Keep them minimal and
    realistic (a `bodyId` like `"part"`, a path under the output dir). Mark illustrative result JSON as
    an example; don't over-specify exact numbers you can't know.
-5. **No invention.** Behaviour comes from the schema `description`, the [README](https://github.com/gsdali/OCCTMCP#mcp-tools),
+5. **No invention.** Behaviour comes from the schema `description`, the [README](https://github.com/SecondMouseAU/OCCTMCP#mcp-tools),
    and the architecture notes in your prompt. If a detail is unclear, state it briefly — don't fabricate.
 6. **Concise.** Reference, not prose: one summary line, a parameter table, returns, one example.
 

--- a/docs/reference/io.md
+++ b/docs/reference/io.md
@@ -57,7 +57,7 @@ Multi-format CAD import (STEP / IGES / BREP / OBJ). Adds the imported shape as a
 | name | type | required | description |
 |------|------|:--------:|-------------|
 | `inputPath` | string | yes | Path to the file to import. |
-| `format` | `"auto"` \| `"step"` \| `"iges"` \| `"obj"` \| `"brep"` | no | File format; defaults to `"auto"` (inferred from extension). |
+| `format` | `"auto"` \| `"step"` \| `"iges"` \| `"obj"` \| `"brep"` | no | File format; defaults to `"auto"`, inferred from extension (`.step`/`.stp`, `.iges`/`.igs`, `.obj`, `.brep`/`.brp`). |
 | `idPrefix` | string | no | Prefix for auto-generated body IDs when the file contains multiple parts. |
 | `allowInvalid` | boolean | no | Import a topologically invalid / loose-face shape as-is (skip the validity write-gate) so the analysis tools can measure an in-progress reconstruction. Default `false`. |
 
@@ -75,6 +75,8 @@ Multi-format CAD import (STEP / IGES / BREP / OBJ). Adds the imported shape as a
 ```
 
 **Notes** — Like `read_brep`, `allowInvalid: true` bypasses the write-gate so you can load a loose-face or open-shell STEP file produced by a reconstruction tool and immediately measure it with `measure_deviation` or `validate_geometry`. STEP assemblies with multiple solids produce one body per solid, each prefixed with `idPrefix`.
+
+BREP (`.brep` / `.brp`) is a single shape, so it imports as one body. On the **Swift** server it loads in-process via `Shape.loadBREP`. On the **Node** server it is routed to the occtkit `load-brep` verb — occtkit's `import` verb itself has no BREP loader — so `import_file` is a single entry point for every format on both servers (you don't need to fall back to `read_brep` for BREP).
 
 ---
 


### PR DESCRIPTION
Refreshes the docs site + `context7.json` for the latest changes:

- **import_file BREP (#56)** — `io.md` and `context7.json` now document `.brep` / `.brp` auto-detect and that the Node server routes BREP to occtkit `load-brep` (occtkit `import` has no BREP loader), so `import_file` is a single entry point for every format on both servers.
- **Org migration** — repointed all docs GitHub links `gsdali` → `SecondMouseAU`.

`measure_deviation` (#55) was already documented; verified accurate, no change needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)