### PR TITLE
feat(deviation): signed/spatial deviation diagnostics (#61/#62/#63)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,7 +6,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 MCP server that gives LLMs the ability to author, inspect, and iterate on 3D CAD models with OpenCASCADE via the OCCTSwift family. Two implementations live side-by-side:
 
-- **Swift** (`Sources/`, `Package.swift`) — the **primary**, in-process server. Uses the official Swift MCP SDK, calls OCCTSwift / OCCTSwiftMesh / OCCTSwiftTools / OCCTSwiftAIS / DrawingComposer directly. 59 typed tools. macOS 15+.
+- **Swift** (`Sources/`, `Package.swift`) — the **primary**, in-process server. Uses the official Swift MCP SDK, calls OCCTSwift / OCCTSwiftMesh / OCCTSwiftTools / OCCTSwiftAIS / DrawingComposer directly. 63 typed tools. macOS 15+.
 - **Node / TypeScript** (`src/`, `dist/`) — the original implementation. Shells out to the `occtkit` CLI via `OCCTSwiftScripts`. 37 tools (the pre-v0.4 surface; selection / remap / annotations are Swift-only).
 
 Both speak stdio MCP and read/write the same `manifest.json` + `annotations.json` files in the output directory. Pick whichever fits the host: the Swift binary eliminates JSONL marshalling and per-call subprocess spawn; the Node server runs anywhere a Node 18+ runtime exists, but needs `occtkit` on `$PATH`.
@@ -20,7 +20,7 @@ The Swift port reached **v1.0.0** on 2026-05-09 and is published on the [Swift P
 ```bash
 swift build -c release         # debug build is `swift build`
 swift run occtmcp-server       # stdio transport
-swift test                     # 39 swift-testing cases under SwiftTests/OCCTMCPCoreTests
+swift test                     # 47 swift-testing cases under SwiftTests/OCCTMCPCoreTests
 ```
 
 `swift test` runs unit + integration tests against a tempdir. Integration tests spawn the built `occtmcp-server` binary and drive it over stdio (so a `swift build` must precede them; the harness itself does this).
@@ -41,13 +41,17 @@ npm run test:integration  # node:test end-to-end chain through occtkit (slow; ~3
 
 `Sources/OCCTMCPCore/` (library) + `Sources/OCCTMCPServer/` (executable that connects stdio).
 
-- `Server.swift` — `createServer()` factory: registers all 59 tools with their JSON Schemas, returns an `MCP.Server` ready to bind to a transport. Tests import `createServer()` to introspect the registry without binding stdio. The `get_api_reference` tool's `mcp_tools` category dumps the live registry as JSON Schema for LLM auto-discovery.
+- `Server.swift` — `createServer()` factory: registers all 63 tools with their JSON Schemas, returns an `MCP.Server` ready to bind to a transport. Tests import `createServer()` to introspect the registry without binding stdio. The `get_api_reference` tool's `mcp_tools` category dumps the live registry as JSON Schema for LLM auto-discovery.
 - `Tools/` — one file per tool family:
   - `CoreTools.swift` — `get_scene`, `get_script`, `export_model`, `get_api_reference`
   - `ExecuteScriptTool.swift` — `execute_script` (writes Swift to tempfile, `occtkit run` via the resolved binary, parses manifest)
   - `SceneTools.swift` — `remove_body`, `clear_scene`, `rename_body`, `set_appearance`, `compare_versions`, `export_scene` (pure manifest manipulation; `export_scene` runs a templated script via occtkit)
   - `IntrospectionTools.swift` — `validate_geometry`, `compute_metrics`, `query_topology`, `measure_distance` (in-process via OCCTSwift)
-  - `DeviationTools.swift` — `measure_deviation` (directed + symmetric surface Hausdorff between two bodies; meshes both, KD-tree nearest-vertex → exact point-to-triangle distance, both directions. The certify-a-reconstruction metric `measure_distance` can't give since it's min-only — #41)
+  - `DeviationTools.swift` — `measure_deviation` (meshes both bodies, KD-tree → exact point-to-triangle distance both directions. As of #62 the report is a *vector*: max / rms / mean / p95 / `signedMean` (sign from the nearest target triangle's outward face normal — + proud / − shy) / signedMin/Max, plus an optional per-section signedMean sweep when `sectionAxis`+`sections` is given. Also the shared signed-distance engine (`TriMesh`, `signedQuery`, `signedDistances`, `closestPointOnTriangle`) reused by the new diagnostics. The certify-a-reconstruction metric `measure_distance` can't give since it's min-only — #41/#62)
+  - `DeviationHistogramTool.swift` — `deviation_histogram` (#62): signed point-to-surface distribution (μ/σ/median/p95/extremes, percent-within-±tol, buckets) + optional histogram PNG
+  - `CrossSectionCompareTool.swift` — `cross_section_compare` (#61): slices BOTH bodies (meshed) with the SAME `OCCTSwiftMesh.Mesh.crossSection` `CutPlane` at N stations along a shared axis — identical (u,v) basis ⇒ directly comparable 2D profiles — per-section signedMean/RMS/area-ratio/centroid-offset + a pose-robust radial-signature shape scalar, with overlay PNGs. The detector for a systematic wrong-section
+  - `HeatmapTools.swift` — `signed_deviation_heatmap` + `overlay_render` (#63): the heatmap colours per-triangle signed distance via the diverging colormap by grouping a band's triangles into one flat-coloured `ViewportBody` (OffscreenRenderer has no per-triangle/per-vertex *surface* colour pass — only the point pass reads `vertexColors`), then composites a colorbar legend; `overlay_render` draws the reference mesh translucent (OffscreenRenderer's transparent pass: effective opacity < 1) over the opaque solid
+  - `ChartRenderer.swift` — pure-Swift Core Graphics + Core Text PNG helper (histogram, 2D profile overlay, colorbar legend) and the shared diverging colormap. Headless; no Python/matplotlib, no AppKit
   - `FeatureTools.swift` — `recognize_features`, `apply_feature`
   - `ConstructionTools.swift` — `transform_body`, `boolean_op`, `mirror_or_pattern` (record history into `HistoryRegistry`)
   - `EngineeringTools.swift` — `check_thickness`, `analyze_clearance`
@@ -157,7 +161,7 @@ The Node server does not expose the v0.4+ tool surface (selection / remap / anno
 
 ## MCP Tools
 
-59 tools in Swift; 37 in Node (no selection / remap / annotations / history / reconstruct). See README.md for the categorized table — that's the LLM-facing surface and stays canonical.
+63 tools in Swift; 37 in Node (no selection / remap / annotations / history / reconstruct). See README.md for the categorized table — that's the LLM-facing surface and stays canonical.
 
 ## Script Template
 

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "00ddb1821dd91c45c30db82470401666599849e9924c1b8d2cc70803757964cc",
+  "originHash" : "22d8466ec79caa5aa66b8436a48d536372b499d772e357ea261ff7c1e1063ad2",
   "pins" : [
     {
       "identity" : "eventsource",
@@ -13,16 +13,16 @@
     {
       "identity" : "occtswift",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/gsdali/OCCTSwift.git",
+      "location" : "https://github.com/SecondMouseAU/OCCTSwift.git",
       "state" : {
-        "revision" : "94eea64c25c265f268ecd6da6fef36b05a60ce9b",
-        "version" : "1.8.0"
+        "revision" : "240ad38b8d877a351f38a7f0eac8c0360ae353dd",
+        "version" : "1.8.2"
       }
     },
     {
       "identity" : "occtswiftais",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/gsdali/OCCTSwiftAIS.git",
+      "location" : "https://github.com/SecondMouseAU/OCCTSwiftAIS.git",
       "state" : {
         "revision" : "d531a505a079450462569007ec6272b40ed94768",
         "version" : "1.0.3"
@@ -31,7 +31,7 @@
     {
       "identity" : "occtswiftio",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/gsdali/OCCTSwiftIO.git",
+      "location" : "https://github.com/SecondMouseAU/OCCTSwiftIO.git",
       "state" : {
         "revision" : "05881da56a557873d3bd8a1a3b48f997eef504a6",
         "version" : "1.0.1"
@@ -40,7 +40,7 @@
     {
       "identity" : "occtswiftmesh",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/gsdali/OCCTSwiftMesh.git",
+      "location" : "https://github.com/SecondMouseAU/OCCTSwiftMesh.git",
       "state" : {
         "revision" : "70a0bdad8377d928710a22b92d8bc93aeca45470",
         "version" : "1.1.1"
@@ -49,28 +49,28 @@
     {
       "identity" : "occtswiftscripts",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/gsdali/OCCTSwiftScripts.git",
+      "location" : "https://github.com/SecondMouseAU/OCCTSwiftScripts.git",
       "state" : {
-        "revision" : "4859b273fee198e27f48225b6e13ebd98601c52d",
-        "version" : "1.4.0"
+        "revision" : "9ada338939ae66767884d6b76e26fd1d03a18079",
+        "version" : "1.4.1"
       }
     },
     {
       "identity" : "occtswifttools",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/gsdali/OCCTSwiftTools.git",
+      "location" : "https://github.com/SecondMouseAU/OCCTSwiftTools.git",
       "state" : {
-        "revision" : "a80581273e9299aa72b2f0e6d1ac786208c50950",
-        "version" : "1.1.2"
+        "revision" : "ec34b6c9a828c5752c4ac68b269e3c1947cf56ef",
+        "version" : "1.2.1"
       }
     },
     {
       "identity" : "occtswiftviewport",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/gsdali/OCCTSwiftViewport.git",
+      "location" : "https://github.com/SecondMouseAU/OCCTSwiftViewport.git",
       "state" : {
-        "revision" : "069d894a9c3f9c366e4387eff2cda796703faf99",
-        "version" : "1.1.20"
+        "revision" : "250a500e950efd7d8824b179b7c124ea8e84347c",
+        "version" : "1.1.22"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -24,6 +24,17 @@ func occtDep(_ name: String, from version: String) -> Package.Dependency {
     return .package(url: "https://github.com/SecondMouseAU/\(name).git", from: Version(version)!)
 }
 
+// As occtDep, but pins to the package's minor line (`.upToNextMinor`) instead of
+// the major. Used to cap a transitive dependency whose newer minors pull deps we
+// don't want in the graph — see the OCCTSwiftIO note in `dependencies` below.
+func occtDepUpToNextMinor(_ name: String, from version: String) -> Package.Dependency {
+    let manifestDir = URL(fileURLWithPath: #filePath).deletingLastPathComponent().path
+    if FileManager.default.fileExists(atPath: manifestDir + "/../\(name)/Package.swift") {
+        return .package(path: "../\(name)")
+    }
+    return .package(url: "https://github.com/SecondMouseAU/\(name).git", .upToNextMinor(from: Version(version)!))
+}
+
 let package = Package(
     name: "OCCTMCP",
     platforms: [
@@ -78,8 +89,11 @@ let package = Package(
         // convexity-attributed faceAdjacency (OCCTSwiftScripts #54/#55).
         // v1.4.0 = measure-deviation verb + metrics boundingBoxOptimal (#44) +
         // load-brep/import --allow-invalid (#41), used by the Node server.
-        occtDep("OCCTSwiftScripts", from: "1.4.0"),
-        occtDep("OCCTSwiftTools", from: "1.1.2"),
+        // v1.4.1 / Tools v1.2.1 = SecondMouseAU org migration: their manifests now
+        // declare OCCTSwiftIO at SecondMouseAU, so the transitive pin re-homes
+        // without a root-level OCCTSwiftIO override here (#53).
+        occtDep("OCCTSwiftScripts", from: "1.4.1"),
+        occtDep("OCCTSwiftTools", from: "1.2.1"),
         // Viewport floored at 1.1.20: 1.0.3 fixes an uncatchable quantize()
         // crash on body load (Viewport #30) that would trap the MCP server
         // during render-preview; 1.0.4 makes the package dependency-free;
@@ -88,6 +102,15 @@ let package = Package(
         // surface-point reconstruction that respects the body transform.
         occtDep("OCCTSwiftViewport", from: "1.1.20"),
         occtDep("OCCTSwiftAIS", from: "1.0.3"),
+        // OCCTSwiftIO is a transitive dependency of OCCTSwiftScripts / OCCTSwiftTools,
+        // declared open-endedly (`from: 1.0.x`) in their manifests. After the
+        // SecondMouseAU migration its 1.1.0+ releases became reachable, and those
+        // pull a heavy mesh-IO stack (SwiftPMX / SwiftGLTF / ThreeMF / SwiftJWW /
+        // SwiftX) that doesn't resolve in this graph — OCCTMCP only needs the
+        // BREP/STEP core. Cap it to the compatible 1.0.x line, which is the version
+        // OCCTMCP has always built against. Also re-homes the pin to SecondMouseAU
+        // (root URL wins), so no gsdali/OCCTSwiftIO leaks into the lockfile (#53).
+        occtDepUpToNextMinor("OCCTSwiftIO", from: "1.0.1"),
     ],
     targets: [
         .target(

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ MCP server that gives LLMs the ability to author, inspect, and iterate on 3D CAD
 
 Part of the [OCCTSwift ecosystem](https://github.com/gsdali/OCCTSwift/blob/main/docs/ecosystem.md) — see the ecosystem map for how this package sits on top of the kernel, viewport, bridge, and AIS layers. SemVer-stable from v1.0.0.
 
-The Swift implementation calls OCCT directly in-process — no subprocess, no JSONL marshalling — and exposes 59 typed MCP tools that cover authoring, scene reads, mutation, introspection, construction, analysis, I/O, mesh, drawing, selection / remap, and dimension overlays.
+The Swift implementation calls OCCT directly in-process — no subprocess, no JSONL marshalling — and exposes 63 typed MCP tools that cover authoring, scene reads, mutation, introspection, construction, analysis, I/O, mesh, drawing, selection / remap, and dimension overlays.
 
 ## How It Works
 
@@ -22,7 +22,7 @@ For novel geometry the typed tools don't cover, the LLM falls back to `execute_s
 
 ## Tools
 
-59 tools, organized below. Call `get_api_reference({ category: "mcp_tools" })` to dump every tool's JSON Schema in one shot — useful for LLM auto-discovery. Most flows can answer "what's the volume?", "make it red", "boolean-subtract these", "render a preview", "add a dimension between these two faces", "export to STEP", and "draw this" without ever touching `execute_script`.
+63 tools, organized below. Call `get_api_reference({ category: "mcp_tools" })` to dump every tool's JSON Schema in one shot — useful for LLM auto-discovery. Most flows can answer "what's the volume?", "make it red", "boolean-subtract these", "render a preview", "add a dimension between these two faces", "export to STEP", and "draw this" without ever touching `execute_script`.
 
 ### Authoring
 
@@ -57,7 +57,7 @@ For novel geometry the typed tools don't cover, the LLM falls back to `execute_s
 | `compute_metrics` | Volume, area, centroid, bounding box, principal axes |
 | `query_topology` | Find faces / edges / vertices matching criteria, return stable IDs |
 | `measure_distance` | Min distance + contacts between two bodies |
-| `measure_deviation` | Directed + symmetric surface deviation (Hausdorff) between two bodies — worst / RMS / mean each way + worstPoint. The certify-a-reconstruction metric (`measure_distance` is min-only) |
+| `measure_deviation` | Signed, spatially-resolved surface deviation between two bodies — max / rms / mean / p95 / `signedMean` (systematic proud(+)/shy(−) bias) each way + worstPoint, plus an optional per-section signedMean sweep along an axis. The certify-a-reconstruction metric (`measure_distance` is min-only) |
 | `recognize_features` | Pockets and holes via AAG heuristics |
 | `inspect_assembly` | Walk an XCAF assembly tree (STEP / IGES / XBF) |
 
@@ -77,6 +77,17 @@ For novel geometry the typed tools don't cover, the LLM falls back to `execute_s
 | `check_thickness` | Wall-thickness analysis with thin-region flags |
 | `analyze_clearance` | Pairwise interference / minimum clearance |
 | `heal_shape` | Heal imported / non-watertight geometry; before/after stats |
+
+### Deviation & reconstruction QA
+
+Signed, spatially-resolved comparison of a reconstruction against its source mesh. Where `measure_deviation`'s scalars can hide a *systematic* shape error (a wrong cross-section that averages out), these expose **where** and **which way** the candidate departs. Pure-Swift rendering — no Python/matplotlib.
+
+| Tool | Purpose |
+|------|---------|
+| `deviation_histogram` | Signed point-to-surface deviation distribution: μ / σ / median / p95 / proud-shy extremes, percent within ±tolerance, bucket histogram + optional PNG. A non-zero mean or bimodal shape ⇒ systematic error |
+| `cross_section_compare` | Slice both bodies at N stations along a shared axis; per-section signed-mean / RMS / area-ratio / centroid-offset + a pose-robust radial shape scalar, with overlay PNGs. The highest-leverage detector of a wrong-shape section |
+| `signed_deviation_heatmap` | Render the candidate surface coloured by signed distance (proud = red, shy = blue) through a diverging colormap with a colorbar legend |
+| `overlay_render` | Render the reference mesh semi-transparent over the opaque candidate solid — see the departure in 3D |
 
 ### Selection & remap
 
@@ -148,7 +159,7 @@ LLM read/write over an attributed reconstruction graph — annotate per-node dec
 
 This repo ships two implementations side-by-side:
 
-- **Swift** (`Sources/`, `Package.swift`) — the **primary** server. In-process against OCCTSwift / OCCTSwiftMesh / OCCTSwiftTools / OCCTSwiftAIS / DrawingComposer using the [official Swift MCP SDK](https://swiftpackageindex.com/modelcontextprotocol/swift-sdk). 59 tools. macOS 15+ (the OCCT.xcframework arm64 platform).
+- **Swift** (`Sources/`, `Package.swift`) — the **primary** server. In-process against OCCTSwift / OCCTSwiftMesh / OCCTSwiftTools / OCCTSwiftAIS / DrawingComposer using the [official Swift MCP SDK](https://swiftpackageindex.com/modelcontextprotocol/swift-sdk). 63 tools. macOS 15+ (the OCCT.xcframework arm64 platform).
 - **Node / TypeScript** (`src/`, `dist/`) — the original implementation. Shells out to the `occtkit` CLI for everything Swift-side. 37 tools (the pre-v0.4 surface; selection / remap / annotations are Swift-only). Useful if you can't run a macOS binary.
 
 Both speak stdio MCP and read/write the same manifest format.

--- a/Sources/OCCTMCPCore/ChartRenderer.swift
+++ b/Sources/OCCTMCPCore/ChartRenderer.swift
@@ -1,0 +1,316 @@
+// ChartRenderer — pure-Swift Core Graphics 2D rendering for the deviation
+// diagnostics (#61 / #62 / #63). No Python / matplotlib: histograms, cross-
+// section profile overlays, and the colorbar legend are drawn with CoreGraphics
+// + CoreText into PNGs. Headless-safe (no AppKit, no run loop): a bitmap
+// CGContext + CGImageDestination.
+//
+// The diverging colormap here is shared with the surface heatmap so a band's
+// fill colour and the legend agree exactly.
+
+import Foundation
+import CoreGraphics
+import CoreText
+import ImageIO
+import UniformTypeIdentifiers
+import simd
+
+enum ChartRenderer {
+
+    enum ChartError: Error, CustomStringConvertible {
+        case contextFailed
+        case imageFailed
+        case writeFailed(String)
+        var description: String {
+            switch self {
+            case .contextFailed: return "Failed to create CoreGraphics bitmap context."
+            case .imageFailed:   return "Failed to snapshot CGImage."
+            case .writeFailed(let p): return "Failed to write PNG to \(p)."
+            }
+        }
+    }
+
+    // MARK: - Colormap
+
+    /// Diverging "coolwarm" colormap for a signed, normalized value `t ∈ [-1, 1]`.
+    /// Blue = shy (under-build, t < 0), near-white = on-target, red = proud
+    /// (over-build, t > 0).
+    static func divergingColor(_ tIn: Double) -> SIMD4<Float> {
+        let t = max(-1.0, min(1.0, tIn))
+        let blue  = SIMD3<Float>(0.23, 0.30, 0.75)
+        let white = SIMD3<Float>(0.96, 0.96, 0.96)
+        let red   = SIMD3<Float>(0.71, 0.02, 0.15)
+        let c: SIMD3<Float>
+        if t < 0 {
+            c = simd_mix(white, blue, SIMD3<Float>(repeating: Float(-t)))
+        } else {
+            c = simd_mix(white, red, SIMD3<Float>(repeating: Float(t)))
+        }
+        return SIMD4<Float>(c.x, c.y, c.z, 1)
+    }
+
+    // MARK: - Low-level
+
+    static func makeContext(width: Int, height: Int, background: SIMD4<Float>) -> CGContext? {
+        let cs = CGColorSpaceCreateDeviceRGB()
+        guard let ctx = CGContext(
+            data: nil, width: width, height: height,
+            bitsPerComponent: 8, bytesPerRow: 0, space: cs,
+            bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+        ) else { return nil }
+        ctx.setFillColor(cg(background))
+        ctx.fill(CGRect(x: 0, y: 0, width: width, height: height))
+        ctx.textMatrix = .identity
+        ctx.setLineJoin(.round)
+        return ctx
+    }
+
+    static func finalize(_ ctx: CGContext, to url: URL) throws {
+        guard let image = ctx.makeImage() else { throw ChartError.imageFailed }
+        try write(image, to: url)
+    }
+
+    static func write(_ image: CGImage, to url: URL) throws {
+        try? FileManager.default.createDirectory(
+            at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
+        guard let dest = CGImageDestinationCreateWithURL(
+            url as CFURL, UTType.png.identifier as CFString, 1, nil
+        ) else { throw ChartError.writeFailed(url.path) }
+        CGImageDestinationAddImage(dest, image, nil)
+        guard CGImageDestinationFinalize(dest) else { throw ChartError.writeFailed(url.path) }
+    }
+
+    static func cg(_ c: SIMD4<Float>) -> CGColor {
+        CGColor(red: CGFloat(c.x), green: CGFloat(c.y), blue: CGFloat(c.z), alpha: CGFloat(c.w))
+    }
+
+    /// Draw a text label. `anchor` controls horizontal alignment around `at`.
+    static func drawText(
+        _ text: String, at p: CGPoint, fontSize: CGFloat,
+        color: SIMD4<Float>, in ctx: CGContext, anchor: TextAnchor = .left
+    ) {
+        let font = CTFontCreateWithName("Helvetica" as CFString, fontSize, nil)
+        let attrs = [
+            kCTFontAttributeName: font,
+            kCTForegroundColorAttributeName: cg(color),
+        ] as CFDictionary
+        guard let attr = CFAttributedStringCreate(nil, text as CFString, attrs) else { return }
+        let line = CTLineCreateWithAttributedString(attr)
+        let w = CTLineGetTypographicBounds(line, nil, nil, nil)
+        var x = p.x
+        switch anchor {
+        case .left:   break
+        case .center: x = p.x - CGFloat(w) / 2
+        case .right:  x = p.x - CGFloat(w)
+        }
+        ctx.textPosition = CGPoint(x: x, y: p.y)
+        CTLineDraw(line, ctx)
+    }
+
+    enum TextAnchor { case left, center, right }
+
+    // MARK: - Histogram (#62)
+
+    /// Histogram of signed deviation values with an optional ±tolerance band.
+    static func histogram(
+        values: [Double], tolerance: Double?, bins: Int,
+        title: String, width: Int = 800, height: Int = 480, to url: URL
+    ) throws {
+        guard let ctx = makeContext(width: width, height: height, background: SIMD4(1, 1, 1, 1)) else {
+            throw ChartError.contextFailed
+        }
+        let ink = SIMD4<Float>(0.12, 0.12, 0.14, 1)
+        let grid = SIMD4<Float>(0.85, 0.85, 0.87, 1)
+        let bar = SIMD4<Float>(0.30, 0.45, 0.78, 1)
+        let band = SIMD4<Float>(0.55, 0.80, 0.45, 0.30)
+
+        let margin = CGRect(x: 56, y: 44, width: CGFloat(width) - 80, height: CGFloat(height) - 80)
+
+        drawText(title, at: CGPoint(x: 12, y: CGFloat(height) - 26), fontSize: 15, color: ink, in: ctx)
+
+        guard !values.isEmpty else {
+            drawText("no samples", at: CGPoint(x: margin.midX, y: margin.midY), fontSize: 13, color: ink, in: ctx, anchor: .center)
+            try finalize(ctx, to: url)
+            return
+        }
+
+        var lo = values.min()!, hi = values.max()!
+        if hi - lo < 1e-9 { lo -= 0.5; hi += 0.5 }
+        let n = max(2, bins)
+        let bw = (hi - lo) / Double(n)
+        var counts = [Int](repeating: 0, count: n)
+        for v in values {
+            var b = Int((v - lo) / bw)
+            if b >= n { b = n - 1 }
+            if b < 0 { b = 0 }
+            counts[b] += 1
+        }
+        let maxCount = max(1, counts.max()!)
+
+        // value → x pixel, count → y pixel
+        func px(_ v: Double) -> CGFloat { margin.minX + CGFloat((v - lo) / (hi - lo)) * margin.width }
+        func py(_ c: Int) -> CGFloat { margin.minY + CGFloat(Double(c) / Double(maxCount)) * margin.height }
+
+        // ±tolerance band
+        if let tol = tolerance, tol > 0 {
+            let x0 = px(max(lo, -tol)), x1 = px(min(hi, tol))
+            ctx.setFillColor(cg(band))
+            ctx.fill(CGRect(x: x0, y: margin.minY, width: max(0, x1 - x0), height: margin.height))
+        }
+
+        // axes
+        ctx.setStrokeColor(cg(grid)); ctx.setLineWidth(1)
+        ctx.stroke(margin)
+
+        // zero line
+        if lo < 0 && hi > 0 {
+            ctx.setStrokeColor(cg(SIMD4(0.5, 0.5, 0.5, 1))); ctx.setLineWidth(1.2)
+            ctx.beginPath()
+            ctx.move(to: CGPoint(x: px(0), y: margin.minY))
+            ctx.addLine(to: CGPoint(x: px(0), y: margin.maxY))
+            ctx.strokePath()
+        }
+
+        // bars
+        ctx.setFillColor(cg(bar))
+        for b in 0..<n where counts[b] > 0 {
+            let x0 = px(lo + Double(b) * bw)
+            let x1 = px(lo + Double(b + 1) * bw)
+            let h = py(counts[b]) - margin.minY
+            ctx.fill(CGRect(x: x0 + 0.5, y: margin.minY, width: max(0, x1 - x0 - 1), height: h))
+        }
+
+        // x tick labels: lo, 0, hi
+        let fmt = "%.3g"
+        drawText(String(format: fmt, lo), at: CGPoint(x: margin.minX, y: margin.minY - 16), fontSize: 11, color: ink, in: ctx, anchor: .center)
+        drawText(String(format: fmt, hi), at: CGPoint(x: margin.maxX, y: margin.minY - 16), fontSize: 11, color: ink, in: ctx, anchor: .center)
+        if lo < 0 && hi > 0 {
+            drawText("0", at: CGPoint(x: px(0), y: margin.minY - 16), fontSize: 11, color: ink, in: ctx, anchor: .center)
+        }
+        drawText("count (peak \(maxCount))", at: CGPoint(x: margin.minX, y: margin.maxY + 6), fontSize: 11, color: ink, in: ctx)
+
+        try finalize(ctx, to: url)
+    }
+
+    // MARK: - Cross-section profile overlay (#61)
+
+    struct ProfileLayer {
+        let loops: [[SIMD2<Double>]]
+        let color: SIMD4<Float>
+        let label: String
+    }
+
+    /// Overlay two (or more) sets of 2D loops in a shared plane frame.
+    static func profileOverlay(
+        layers: [ProfileLayer], title: String,
+        width: Int = 640, height: Int = 640, to url: URL
+    ) throws {
+        guard let ctx = makeContext(width: width, height: height, background: SIMD4(1, 1, 1, 1)) else {
+            throw ChartError.contextFailed
+        }
+        let ink = SIMD4<Float>(0.12, 0.12, 0.14, 1)
+        drawText(title, at: CGPoint(x: 12, y: CGFloat(height) - 24), fontSize: 14, color: ink, in: ctx)
+
+        // combined bounds
+        var lo = SIMD2<Double>(.greatestFiniteMagnitude, .greatestFiniteMagnitude)
+        var hi = SIMD2<Double>(-.greatestFiniteMagnitude, -.greatestFiniteMagnitude)
+        var any = false
+        for layer in layers {
+            for loop in layer.loops {
+                for p in loop { any = true; lo = simd_min(lo, p); hi = simd_max(hi, p) }
+            }
+        }
+        guard any else {
+            drawText("no contours at this station", at: CGPoint(x: CGFloat(width) / 2, y: CGFloat(height) / 2), fontSize: 13, color: ink, in: ctx, anchor: .center)
+            try finalize(ctx, to: url)
+            return
+        }
+        var size = hi - lo
+        if size.x < 1e-9 { size.x = 1 }
+        if size.y < 1e-9 { size.y = 1 }
+
+        let pad: CGFloat = 48
+        let plot = CGRect(x: pad, y: pad, width: CGFloat(width) - 2 * pad, height: CGFloat(height) - 2 * pad)
+        // uniform scale preserving aspect
+        let scale = min(plot.width / CGFloat(size.x), plot.height / CGFloat(size.y))
+        let centre = (lo + hi) * 0.5
+        func map(_ p: SIMD2<Double>) -> CGPoint {
+            CGPoint(
+                x: plot.midX + CGFloat(p.x - centre.x) * scale,
+                y: plot.midY + CGFloat(p.y - centre.y) * scale
+            )
+        }
+
+        ctx.setLineWidth(1.6)
+        for layer in layers {
+            ctx.setStrokeColor(cg(layer.color))
+            for loop in layer.loops where loop.count >= 2 {
+                ctx.beginPath()
+                ctx.move(to: map(loop[0]))
+                for p in loop.dropFirst() { ctx.addLine(to: map(p)) }
+                ctx.closePath()
+                ctx.strokePath()
+            }
+        }
+
+        // legend (top-right)
+        var ly = CGFloat(height) - 28
+        for layer in layers {
+            let sw = CGRect(x: CGFloat(width) - 150, y: ly, width: 16, height: 8)
+            ctx.setFillColor(cg(layer.color)); ctx.fill(sw)
+            drawText(layer.label, at: CGPoint(x: CGFloat(width) - 128, y: ly), fontSize: 12, color: ink, in: ctx)
+            ly -= 18
+        }
+        // scale note
+        drawText(String(format: "%.3g × %.3g mm", size.x, size.y),
+                 at: CGPoint(x: plot.minX, y: 12), fontSize: 11, color: ink, in: ctx)
+
+        try finalize(ctx, to: url)
+    }
+
+    // MARK: - Colorbar legend composited onto an existing render (#63)
+
+    /// Load `pngURL`, draw a vertical diverging colorbar with min/0/max labels in
+    /// the top-right, and rewrite the file in place.
+    static func overlayColorbar(on pngURL: URL, minValue: Double, maxValue: Double, label: String) throws {
+        guard let src = CGImageSourceCreateWithURL(pngURL as CFURL, nil),
+              let base = CGImageSourceCreateImageAtIndex(src, 0, nil) else {
+            throw ChartError.imageFailed
+        }
+        let w = base.width, h = base.height
+        guard let ctx = makeContext(width: w, height: h, background: SIMD4(0, 0, 0, 0)) else {
+            throw ChartError.contextFailed
+        }
+        ctx.draw(base, in: CGRect(x: 0, y: 0, width: w, height: h))
+
+        let ink = SIMD4<Float>(0.10, 0.10, 0.12, 1)
+        let barW: CGFloat = 18
+        let barH: CGFloat = min(CGFloat(h) * 0.5, 220)
+        let barX = CGFloat(w) - 96
+        let barY = CGFloat(h) - 40 - barH
+
+        // gradient strip, drawn as horizontal slabs bottom(neg)→top(pos)
+        let slabs = 64
+        let absMax = max(abs(minValue), abs(maxValue), 1e-9)
+        for i in 0..<slabs {
+            let frac = Double(i) / Double(slabs - 1)             // 0..1 bottom→top
+            let value = minValue + frac * (maxValue - minValue)
+            let t = value / absMax
+            ctx.setFillColor(cg(divergingColor(t)))
+            let y = barY + CGFloat(frac) * barH
+            ctx.fill(CGRect(x: barX, y: y, width: barW, height: barH / CGFloat(slabs) + 1))
+        }
+        ctx.setStrokeColor(cg(ink)); ctx.setLineWidth(1)
+        ctx.stroke(CGRect(x: barX, y: barY, width: barW, height: barH))
+
+        let lx = barX + barW + 6
+        drawText(String(format: "%+.3g", maxValue), at: CGPoint(x: lx, y: barY + barH - 6), fontSize: 11, color: ink, in: ctx)
+        drawText(String(format: "%+.3g", minValue), at: CGPoint(x: lx, y: barY), fontSize: 11, color: ink, in: ctx)
+        if minValue < 0 && maxValue > 0 {
+            let zy = barY + CGFloat(-minValue / (maxValue - minValue)) * barH
+            drawText("0", at: CGPoint(x: lx, y: zy - 4), fontSize: 11, color: ink, in: ctx)
+        }
+        drawText(label, at: CGPoint(x: barX, y: barY + barH + 6), fontSize: 11, color: ink, in: ctx)
+
+        try finalize(ctx, to: pngURL)
+    }
+}

--- a/Sources/OCCTMCPCore/Server.swift
+++ b/Sources/OCCTMCPCore/Server.swift
@@ -796,7 +796,7 @@ func catalogTools() -> [Tool] {
         ),
         Tool(
             name: "measure_deviation",
-            description: "Surface deviation (one-sided + symmetric Hausdorff) between two scene bodies — the metric for certifying a reconstruction against its source mesh. Unlike measure_distance (minimum gap, ≈0 for overlapping bodies), this samples each body's tessellated surface and reports the worst / RMS / mean distance to the other in BOTH directions: `fromToTo` (from's surface vs to — over-extension) and `toToFrom` (under-coverage), each with a worstPoint, plus `symmetricHausdorff`. Mesh-based; fidelity scales with `deflection` (default 0.5% of the from-body bbox diagonal). `maxSamples` (default 20000) stride-subsamples the source surface per direction.",
+            description: "Signed, spatially-resolved surface deviation between two scene bodies — the metric for certifying a reconstruction against its source mesh. Unlike measure_distance (minimum gap, ≈0 for overlapping bodies), this samples each body's tessellated surface and reports, in BOTH directions (`fromToTo` = from's surface vs to / over-extension, `toToFrom` = under-coverage): max, rms, mean, p95 (robust worst-case), `signedMean` (≠0 ⇒ a systematic proud(+)/shy(−) bias a Hausdorff hides), signedMin/signedMax, and a worstPoint — plus `symmetricHausdorff`. Optional `sectionAxis`+`sections` bins the forward samples along an axis into per-station signedMean (a near-constant non-zero value across stations ⇒ systematic section-shape error). Mesh-based; fidelity scales with `deflection` (default 0.5% of the from-body bbox diagonal). `maxSamples` (default 20000) stride-subsamples per direction.",
             inputSchema: .object([
                 "type": .string("object"),
                 "properties": .object([
@@ -810,8 +810,89 @@ func catalogTools() -> [Tool] {
                         "type": .string("integer"),
                         "description": .string("Max source surface samples per direction (stride-subsampled). Default 20000."),
                     ]),
+                    "sectionAxis": .object([
+                        "type": .string("array"),
+                        "items": .object(["type": .string("number")]),
+                        "minItems": .int(3), "maxItems": .int(3),
+                        "description": .string("[x,y,z] axis to bin the forward (from→to) samples along. When set with `sections`, the report gains a per-station signedMean array."),
+                    ]),
+                    "sections": .object([
+                        "type": .string("integer"),
+                        "description": .string("Number of along-axis bins for the per-section signedMean sweep (≥2). Requires sectionAxis."),
+                    ]),
                 ]),
                 "required": .array([.string("fromBodyId"), .string("toBodyId")]),
+                "additionalProperties": .bool(false),
+            ])
+        ),
+        Tool(
+            name: "deviation_histogram",
+            description: "Signed point-to-surface deviation DISTRIBUTION of `fromBodyId` vs `referenceBodyId`: μ (mean — non-zero ⇒ systematic bias), σ, median, p95 (of |dev|), proud/shy extremes, percent within ±tolerance, and a bucket histogram — plus an optional PNG. A tight unimodal histogram on 0 is honest noise; a non-zero mean or two humps is a systematic shape error even when the headline mean looks small.",
+            inputSchema: .object([
+                "type": .string("object"),
+                "properties": .object([
+                    "fromBodyId": .object(["type": .string("string")]),
+                    "referenceBodyId": .object(["type": .string("string")]),
+                    "deflection": .object(["type": .string("number"), "description": .string("Mesh linear deflection. Default 0.5% of the from-body bbox diagonal.")]),
+                    "bins": .object(["type": .string("integer"), "description": .string("Histogram bucket count. Default 40.")]),
+                    "maxSamples": .object(["type": .string("integer"), "description": .string("Max from-surface vertices sampled (stride-subsampled). Default 50000.")]),
+                    "tolerance": .object(["type": .string("number"), "description": .string("± band (model units); report fraction of samples within it + shade it on the PNG.")]),
+                    "outputPath": .object(["type": .string("string"), "description": .string("PNG path for the histogram image. Omit to return stats only.")]),
+                ]),
+                "required": .array([.string("fromBodyId"), .string("referenceBodyId")]),
+                "additionalProperties": .bool(false),
+            ])
+        ),
+        Tool(
+            name: "cross_section_compare",
+            description: "Slice BOTH bodies at N stations along a shared axis, overlay the two 2D profiles, and report per-section signed-mean (the direct detector of a systematic section offset), RMS, area ratio, centroid offset, and a pose-robust radial shape scalar (catches wrong-shape a Hausdorff misses). The highest-leverage tool for a reconstruction whose cross-section is the wrong shape everywhere yet whose 3D mean looks fine. Optional per-station overlay PNGs.",
+            inputSchema: .object([
+                "type": .string("object"),
+                "properties": .object([
+                    "fromBodyId": .object(["type": .string("string"), "description": .string("Candidate body (e.g. the reconstruction).")]),
+                    "referenceBodyId": .object(["type": .string("string"), "description": .string("Reference body (e.g. the source mesh).")]),
+                    "axis": .object(["type": .string("array"), "items": .object(["type": .string("number")]), "minItems": .int(3), "maxItems": .int(3), "description": .string("[x,y,z] section sweep axis (e.g. the carbody longitudinal axis).")]),
+                    "stations": .object(["type": .string("integer"), "description": .string("Number of evenly-spaced cut planes across the bodies' shared overlap. Default 12.")]),
+                    "through": .object(["type": .string("array"), "items": .object(["type": .string("number")]), "minItems": .int(3), "maxItems": .int(3), "description": .string("A point the axis passes through. Default: from-body bbox centre.")]),
+                    "deflection": .object(["type": .string("number"), "description": .string("Mesh linear deflection. Default 0.5% of the from-body bbox diagonal.")]),
+                    "outputDir": .object(["type": .string("string"), "description": .string("Directory for per-station overlay PNGs. Omit to return numbers only.")]),
+                    "imagePrefix": .object(["type": .string("string"), "description": .string("Filename prefix for station PNGs. Default \"section\".")]),
+                ]),
+                "required": .array([.string("fromBodyId"), .string("referenceBodyId"), .string("axis")]),
+                "additionalProperties": .bool(false),
+            ])
+        ),
+        Tool(
+            name: "signed_deviation_heatmap",
+            description: "Render `fromBodyId`'s surface coloured by SIGNED distance to `referenceBodyId` — proud (over-build) red, on-target near-white, shy (under-build) blue — via a diverging colormap, with a colorbar legend. Shows exactly WHERE a reconstruction departs, which a scalar deviation can't. Per-triangle bands; pure-Swift offscreen render to PNG.",
+            inputSchema: .object([
+                "type": .string("object"),
+                "properties": .object([
+                    "fromBodyId": .object(["type": .string("string")]),
+                    "referenceBodyId": .object(["type": .string("string")]),
+                    "outputPath": .object(["type": .string("string")]),
+                    "deflection": .object(["type": .string("number"), "description": .string("Mesh linear deflection. Default 0.5% of the from-body bbox diagonal.")]),
+                    "bands": .object(["type": .string("integer"), "description": .string("Colormap band count. Default 11.")]),
+                    "clamp": .object(["type": .string("number"), "description": .string("|signed| ≥ clamp saturates to full red/blue. Default: p95 of |signed|.")]),
+                    "options": .object(["type": .string("object"), "description": .string("Render options — same shape as render_preview.options (camera, width, height, background).")]),
+                ]),
+                "required": .array([.string("fromBodyId"), .string("referenceBodyId"), .string("outputPath")]),
+                "additionalProperties": .bool(false),
+            ])
+        ),
+        Tool(
+            name: "overlay_render",
+            description: "Render the reference mesh (`meshBodyId`, semi-transparent amber) superimposed over the opaque candidate solid (`solidBodyId`, steel-grey) — see in 3D exactly where the reconstruction departs from the source mesh. Pure-Swift offscreen render to PNG.",
+            inputSchema: .object([
+                "type": .string("object"),
+                "properties": .object([
+                    "solidBodyId": .object(["type": .string("string"), "description": .string("Opaque body (the candidate solid).")]),
+                    "meshBodyId": .object(["type": .string("string"), "description": .string("Translucent body (the reference mesh).")]),
+                    "outputPath": .object(["type": .string("string")]),
+                    "transparency": .object(["type": .string("number"), "description": .string("Reference-mesh opacity 0.05–0.95. Default 0.5.")]),
+                    "options": .object(["type": .string("object"), "description": .string("Render options — same shape as render_preview.options.")]),
+                ]),
+                "required": .array([.string("solidBodyId"), .string("meshBodyId"), .string("outputPath")]),
                 "additionalProperties": .bool(false),
             ])
         ),
@@ -1585,8 +1666,83 @@ func dispatch(callName: String, arguments: [String: Value]) async -> CallTool.Re
         }
         let deflection = arguments["deflection"]?.doubleValue
         let maxSamples = arguments["maxSamples"]?.intValue ?? 20_000
+        var sectionAxis: SIMD3<Double>? = nil
+        if let arr = arguments["sectionAxis"]?.arrayValue, arr.count == 3,
+           let x = arr[0].numberValue, let y = arr[1].numberValue, let z = arr[2].numberValue {
+            sectionAxis = SIMD3(x, y, z)
+        }
+        let sectionCount = arguments["sections"]?.intValue ?? 0
         return await DeviationTools.measureDeviation(
-            fromBodyId: fromId, toBodyId: toId, deflection: deflection, maxSamples: maxSamples
+            fromBodyId: fromId, toBodyId: toId, deflection: deflection, maxSamples: maxSamples,
+            sectionAxis: sectionAxis, sectionCount: sectionCount
+        ).asCallToolResult()
+
+    case "deviation_histogram":
+        guard let fromId = arguments["fromBodyId"]?.stringValue,
+              let refId = arguments["referenceBodyId"]?.stringValue else {
+            return ToolText("deviation_histogram requires `fromBodyId` and `referenceBodyId`.", isError: true).asCallToolResult()
+        }
+        return await DeviationHistogramTool.deviationHistogram(
+            fromBodyId: fromId,
+            referenceBodyId: refId,
+            deflection: arguments["deflection"]?.doubleValue,
+            bins: arguments["bins"]?.intValue ?? 40,
+            maxSamples: arguments["maxSamples"]?.intValue ?? 50_000,
+            tolerance: arguments["tolerance"]?.doubleValue,
+            outputPath: arguments["outputPath"]?.stringValue
+        ).asCallToolResult()
+
+    case "cross_section_compare":
+        guard let fromId = arguments["fromBodyId"]?.stringValue,
+              let refId = arguments["referenceBodyId"]?.stringValue,
+              let axisArr = arguments["axis"]?.arrayValue, axisArr.count == 3,
+              let ax = axisArr[0].numberValue, let ay = axisArr[1].numberValue, let az = axisArr[2].numberValue else {
+            return ToolText("cross_section_compare requires `fromBodyId`, `referenceBodyId`, and `axis` [x,y,z].", isError: true).asCallToolResult()
+        }
+        var through: SIMD3<Double>? = nil
+        if let t = arguments["through"]?.arrayValue, t.count == 3,
+           let tx = t[0].numberValue, let ty = t[1].numberValue, let tz = t[2].numberValue {
+            through = SIMD3(tx, ty, tz)
+        }
+        return await CrossSectionCompareTool.crossSectionCompare(
+            fromBodyId: fromId,
+            referenceBodyId: refId,
+            axis: SIMD3(ax, ay, az),
+            stations: arguments["stations"]?.intValue ?? 12,
+            through: through,
+            deflection: arguments["deflection"]?.doubleValue,
+            outputDir: arguments["outputDir"]?.stringValue,
+            imagePrefix: arguments["imagePrefix"]?.stringValue ?? "section"
+        ).asCallToolResult()
+
+    case "signed_deviation_heatmap":
+        guard let fromId = arguments["fromBodyId"]?.stringValue,
+              let refId = arguments["referenceBodyId"]?.stringValue,
+              let outputPath = arguments["outputPath"]?.stringValue else {
+            return ToolText("signed_deviation_heatmap requires `fromBodyId`, `referenceBodyId`, and `outputPath`.", isError: true).asCallToolResult()
+        }
+        return await HeatmapTools.signedDeviationHeatmap(
+            fromBodyId: fromId,
+            referenceBodyId: refId,
+            outputPath: outputPath,
+            deflection: arguments["deflection"]?.doubleValue,
+            bands: arguments["bands"]?.intValue ?? 11,
+            clamp: arguments["clamp"]?.doubleValue,
+            options: parseRenderOptions(arguments["options"])
+        ).asCallToolResult()
+
+    case "overlay_render":
+        guard let solidId = arguments["solidBodyId"]?.stringValue,
+              let meshId = arguments["meshBodyId"]?.stringValue,
+              let outputPath = arguments["outputPath"]?.stringValue else {
+            return ToolText("overlay_render requires `solidBodyId`, `meshBodyId`, and `outputPath`.", isError: true).asCallToolResult()
+        }
+        return await HeatmapTools.overlayRender(
+            solidBodyId: solidId,
+            meshBodyId: meshId,
+            outputPath: outputPath,
+            transparency: arguments["transparency"]?.doubleValue ?? 0.5,
+            options: parseRenderOptions(arguments["options"])
         ).asCallToolResult()
 
     case "transform_body":

--- a/Sources/OCCTMCPCore/Tools/CrossSectionCompareTool.swift
+++ b/Sources/OCCTMCPCore/Tools/CrossSectionCompareTool.swift
@@ -1,0 +1,334 @@
+// CrossSectionCompareTool — `cross_section_compare` (#61). The highest-leverage
+// detector for the failure that motivated #61/#62/#63: a reconstruction whose
+// cross-section is the WRONG SHAPE everywhere, yet whose 3D mean deviation looks
+// fine because the correct faces dominate the samples and the wrong arc averages
+// out.
+//
+// It slices BOTH bodies at N stations along a shared axis, overlays the two 2D
+// profiles per station, and reports a per-section signed-mean (the direct
+// detector of a systematic section offset) plus a pose-robust radial shape
+// scalar (catches wrong-shape that a Hausdorff misses). A systematically-wrong
+// section shows two visibly different profiles AND a near-constant non-zero
+// signedMean across the stack.
+//
+// Both bodies are meshed and sliced with OCCTSwiftMesh's `Mesh.crossSection`,
+// which derives its (u, v) plane basis deterministically from the plane normal —
+// so slicing both with the SAME `CutPlane` puts the two profiles in the SAME 2D
+// frame, directly comparable with no pose alignment.
+
+import Foundation
+import OCCTSwift
+import OCCTSwiftMesh
+import simd
+
+public enum CrossSectionCompareTool {
+
+    public struct SectionResult: Encodable {
+        public let station: Int
+        /// Offset of the cut plane along the axis from the overlap-range start.
+        public let offset: Double
+        public let fromContours: Int
+        public let referenceContours: Int
+        public let fromArea: Double
+        public let referenceArea: Double
+        public let areaRatio: Double
+        /// Distance between the two main loops' centroids, in the plane.
+        public let centroidOffset: Double
+        /// Signed mean point-to-profile deviation of the `from` loop vs the
+        /// `reference` loop (+ = from is outside reference / proud).
+        public let signedMean: Double
+        public let rms: Double
+        public let maxAbs: Double
+        /// Pose-robust radial-signature L2 (0 = same shape). Independent of size
+        /// and centre, so it flags a wrong shape even when areas match.
+        public let shapeL2: Double
+        public let imagePath: String?
+    }
+
+    public struct CompareReport: Encodable {
+        public let from: String
+        public let reference: String
+        public let axis: [Double]
+        public let deflection: Double
+        public let stations: Int
+        /// Mean of the per-section signedMean — a non-zero value across the whole
+        /// stack is the systematic-offset fingerprint.
+        public let meanSignedAcrossSections: Double
+        public let maxAbsSignedSection: Double
+        public let worstStation: Int
+        public let sections: [SectionResult]
+    }
+
+    public static func crossSectionCompare(
+        fromBodyId: String,
+        referenceBodyId: String,
+        axis: SIMD3<Double>,
+        stations: Int = 12,
+        through: SIMD3<Double>? = nil,
+        deflection: Double? = nil,
+        outputDir: String? = nil,
+        imagePrefix: String = "section",
+        store: ManifestStore = ManifestStore()
+    ) async -> ToolText {
+        guard simd_length(axis) > 1e-12 else {
+            return .init("axis must be non-zero.", isError: true)
+        }
+        guard stations >= 1 else { return .init("stations must be ≥ 1.", isError: true) }
+
+        let fromShape: Shape, refShape: Shape
+        do {
+            fromShape = try IntrospectionTools.loadShape(bodyId: fromBodyId, store: store).shape
+            refShape = try IntrospectionTools.loadShape(bodyId: referenceBodyId, store: store).shape
+        } catch {
+            return .init("\(error)")
+        }
+
+        let defl = deflection ?? DeviationTools.defaultDeflection(for: fromShape)
+        guard defl > 0 else { return .init("deflection must be positive.", isError: true) }
+
+        guard let fromMesh = mesh(fromShape, deflection: defl) else {
+            return .init("Failed to tessellate '\(fromBodyId)'.", isError: true)
+        }
+        guard let refMesh = mesh(refShape, deflection: defl) else {
+            return .init("Failed to tessellate '\(referenceBodyId)'.", isError: true)
+        }
+
+        let n = simd_normalize(axis)
+        let nf = SIMD3<Float>(Float(n.x), Float(n.y), Float(n.z))
+        let pt = through ?? midpoint(of: fromShape)
+        let ptf = SIMD3<Float>(Float(pt.x), Float(pt.y), Float(pt.z))
+
+        // Axis range = OVERLAP of both meshes' projections, so every station cuts
+        // both bodies.
+        let (loA, hiA) = projectRange(fromMesh.vertices, origin: ptf, axis: nf)
+        let (loB, hiB) = projectRange(refMesh.vertices, origin: ptf, axis: nf)
+        let lo = Double(max(loA, loB)), hi = Double(min(hiA, hiB))
+        guard hi - lo > 1e-9 else {
+            return .init("Bodies do not overlap along the given axis — no shared sections.", isError: true)
+        }
+        let margin = (hi - lo) * 0.02
+        let start = lo + margin, end = hi - margin
+        let span = max(1e-9, end - start)
+        let step = stations > 1 ? span / Double(stations - 1) : 0
+
+        var results: [SectionResult] = []
+        for s in 0..<stations {
+            let t = stations > 1 ? start + Double(s) * step : (start + end) / 2
+            let plane = CutPlane(point: pt + n * t, normal: n)
+            let fromSec = fromMesh.crossSection(plane: plane)
+            let refSec = refMesh.crossSection(plane: plane)
+
+            let fromLoops = (fromSec?.contours ?? []).map { $0.points }
+            let refLoops = (refSec?.contours ?? []).map { $0.points }
+
+            let fromMain = mainLoop(fromSec?.contours ?? [])
+            let refMain = mainLoop(refSec?.contours ?? [])
+
+            var imagePath: String? = nil
+            if let outputDir {
+                let path = "\(outputDir)/\(imagePrefix)_\(String(format: "%02d", s)).png"
+                do {
+                    try ChartRenderer.profileOverlay(
+                        layers: [
+                            .init(loops: refLoops, color: SIMD4(0.18, 0.42, 0.86, 1), label: "reference (\(referenceBodyId))"),
+                            .init(loops: fromLoops, color: SIMD4(0.86, 0.20, 0.18, 1), label: "from (\(fromBodyId))"),
+                        ],
+                        title: "station \(s)  offset \(String(format: "%.3g", t - lo))",
+                        to: URL(fileURLWithPath: path)
+                    )
+                    imagePath = path
+                } catch {
+                    // A render failure shouldn't abort the numeric comparison.
+                    imagePath = nil
+                }
+            }
+
+            // Numeric comparison needs both main loops.
+            if let fromMain, let refMain, fromMain.count >= 3, refMain.count >= 3 {
+                let (signedMean, rms, maxAbs) = signedProfileDeviation(from: fromMain, reference: refMain)
+                let shapeL2 = radialShapeL2(fromMain, refMain, samples: 180)
+                let fa = abs(shoelace(fromMain)), ra = abs(shoelace(refMain))
+                let cFrom = centroid(fromMain), cRef = centroid(refMain)
+                results.append(SectionResult(
+                    station: s, offset: t - lo,
+                    fromContours: fromLoops.count, referenceContours: refLoops.count,
+                    fromArea: fa, referenceArea: ra,
+                    areaRatio: ra > 1e-12 ? fa / ra : 0,
+                    centroidOffset: simd_distance(cFrom, cRef),
+                    signedMean: signedMean, rms: rms, maxAbs: maxAbs,
+                    shapeL2: shapeL2, imagePath: imagePath
+                ))
+            } else {
+                results.append(SectionResult(
+                    station: s, offset: t - lo,
+                    fromContours: fromLoops.count, referenceContours: refLoops.count,
+                    fromArea: 0, referenceArea: 0, areaRatio: 0, centroidOffset: 0,
+                    signedMean: 0, rms: 0, maxAbs: 0, shapeL2: 0, imagePath: imagePath
+                ))
+            }
+        }
+
+        let valid = results.filter { $0.rms > 0 || $0.maxAbs > 0 }
+        let meanSigned = valid.isEmpty ? 0 : valid.reduce(0) { $0 + $1.signedMean } / Double(valid.count)
+        let worst = results.enumerated().max(by: { abs($0.element.signedMean) < abs($1.element.signedMean) })
+        let report = CompareReport(
+            from: fromBodyId, reference: referenceBodyId,
+            axis: [axis.x, axis.y, axis.z], deflection: defl, stations: results.count,
+            meanSignedAcrossSections: meanSigned,
+            maxAbsSignedSection: worst.map { abs($0.element.signedMean) } ?? 0,
+            worstStation: worst?.offset ?? 0,
+            sections: results
+        )
+        return IntrospectionTools.encode(report)
+    }
+
+    // MARK: - Mesh helpers
+
+    static func mesh(_ shape: Shape, deflection: Double) -> Mesh? {
+        var params = MeshParameters.default
+        params.deflection = deflection
+        params.internalVertices = true
+        params.inParallel = true
+        params.allowQualityDecrease = true
+        return shape.mesh(parameters: params)
+    }
+
+    static func midpoint(of shape: Shape) -> SIMD3<Double> {
+        let b = shape.bounds
+        return (b.min + b.max) * 0.5
+    }
+
+    static func projectRange(_ verts: [SIMD3<Float>], origin: SIMD3<Float>, axis: SIMD3<Float>) -> (Float, Float) {
+        var lo = Float.greatestFiniteMagnitude, hi = -Float.greatestFiniteMagnitude
+        for v in verts {
+            let d = simd_dot(v - origin, axis)
+            if d < lo { lo = d }
+            if d > hi { hi = d }
+        }
+        return (lo, hi)
+    }
+
+    // MARK: - 2D contour math
+
+    /// Largest-area outermost (depth 0) loop of a section.
+    static func mainLoop(_ contours: [MeshContour]) -> [SIMD2<Double>]? {
+        let outer = contours.filter { $0.depth == 0 }
+        let pool = outer.isEmpty ? contours : outer
+        return pool.max(by: { $0.area < $1.area })?.points
+    }
+
+    static func shoelace(_ ring: [SIMD2<Double>]) -> Double {
+        guard ring.count >= 3 else { return 0 }
+        var s = 0.0
+        for i in ring.indices {
+            let a = ring[i], b = ring[(i + 1) % ring.count]
+            s += a.x * b.y - b.x * a.y
+        }
+        return s * 0.5
+    }
+
+    static func centroid(_ ring: [SIMD2<Double>]) -> SIMD2<Double> {
+        guard !ring.isEmpty else { return .zero }
+        var c = SIMD2<Double>.zero
+        for p in ring { c += p }
+        return c / Double(ring.count)
+    }
+
+    /// Even-odd point-in-polygon.
+    static func contains(_ ring: [SIMD2<Double>], _ p: SIMD2<Double>) -> Bool {
+        var inside = false
+        var j = ring.count - 1
+        for i in ring.indices {
+            let a = ring[i], b = ring[j]
+            if (a.y > p.y) != (b.y > p.y) {
+                let x = a.x + (p.y - a.y) / (b.y - a.y) * (b.x - a.x)
+                if p.x < x { inside.toggle() }
+            }
+            j = i
+        }
+        return inside
+    }
+
+    static func pointToLoopDistance(_ p: SIMD2<Double>, _ loop: [SIMD2<Double>]) -> Double {
+        var best = Double.greatestFiniteMagnitude
+        for i in loop.indices {
+            let a = loop[i], b = loop[(i + 1) % loop.count]
+            best = min(best, pointSegmentDistance(p, a, b))
+        }
+        return best
+    }
+
+    static func pointSegmentDistance(_ p: SIMD2<Double>, _ a: SIMD2<Double>, _ b: SIMD2<Double>) -> Double {
+        let ab = b - a
+        let len2 = simd_dot(ab, ab)
+        if len2 < 1e-18 { return simd_distance(p, a) }
+        var t = simd_dot(p - a, ab) / len2
+        t = max(0, min(1, t))
+        return simd_distance(p, a + ab * t)
+    }
+
+    /// Signed point-to-profile deviation of `from` vs `reference`. Sign is + when
+    /// the `from` point lies OUTSIDE the reference loop (proud), − inside (shy).
+    static func signedProfileDeviation(from: [SIMD2<Double>], reference: [SIMD2<Double>])
+        -> (signedMean: Double, rms: Double, maxAbs: Double)
+    {
+        var sum = 0.0, sumSq = 0.0, maxAbs = 0.0
+        for p in from {
+            let d = pointToLoopDistance(p, reference)
+            let signed = contains(reference, p) ? -d : d
+            sum += signed
+            sumSq += signed * signed
+            if abs(signed) > maxAbs { maxAbs = abs(signed) }
+        }
+        let n = Double(from.count)
+        return (sum / n, (sumSq / n).squareRoot(), maxAbs)
+    }
+
+    /// Arc-length resample of a closed loop to `n` evenly-spaced points.
+    static func resampleClosed(_ loop: [SIMD2<Double>], _ n: Int) -> [SIMD2<Double>] {
+        guard loop.count >= 2, n >= 3 else { return loop }
+        var cum: [Double] = [0]
+        var total = 0.0
+        for i in loop.indices {
+            let a = loop[i], b = loop[(i + 1) % loop.count]
+            total += simd_distance(a, b)
+            cum.append(total)
+        }
+        guard total > 1e-12 else { return loop }
+        var out: [SIMD2<Double>] = []
+        out.reserveCapacity(n)
+        var seg = 0
+        for k in 0..<n {
+            let target = total * Double(k) / Double(n)
+            while seg < loop.count && cum[seg + 1] < target { seg += 1 }
+            let a = loop[seg % loop.count], b = loop[(seg + 1) % loop.count]
+            let segLen = cum[seg + 1] - cum[seg]
+            let t = segLen > 1e-12 ? (target - cum[seg]) / segLen : 0
+            out.append(a + (b - a) * t)
+        }
+        return out
+    }
+
+    /// Pose-robust radial-signature L2. Resample both, take distance-from-centroid
+    /// as a function of normalized arc length, scale each by its own mean radius,
+    /// and return the RMS difference. 0 ⇒ same shape regardless of size/position.
+    /// Both loops already share the section's (u, v) frame, so no rotation
+    /// alignment is required.
+    static func radialShapeL2(_ a: [SIMD2<Double>], _ b: [SIMD2<Double>], samples: Int) -> Double {
+        let ra = radialSignature(a, samples)
+        let rb = radialSignature(b, samples)
+        guard ra.count == rb.count, !ra.isEmpty else { return 0 }
+        var s = 0.0
+        for i in ra.indices { let d = ra[i] - rb[i]; s += d * d }
+        return (s / Double(ra.count)).squareRoot()
+    }
+
+    static func radialSignature(_ loop: [SIMD2<Double>], _ n: Int) -> [Double] {
+        let rs = resampleClosed(loop, n)
+        let c = centroid(rs)
+        var radii = rs.map { simd_distance($0, c) }
+        let mean = radii.reduce(0, +) / Double(max(1, radii.count))
+        if mean > 1e-12 { for i in radii.indices { radii[i] /= mean } }
+        return radii
+    }
+}

--- a/Sources/OCCTMCPCore/Tools/DeviationHistogramTool.swift
+++ b/Sources/OCCTMCPCore/Tools/DeviationHistogramTool.swift
@@ -1,0 +1,145 @@
+// DeviationHistogramTool — `deviation_histogram` (#62).
+//
+// Where `measure_deviation` aggregates to a handful of scalars, this returns the
+// full *distribution* of the signed point-to-surface deviation of `fromBodyId`
+// against `referenceBodyId`: μ, σ, median, p95, the proud/shy extremes, the
+// fraction within ±tolerance, and a bucket histogram — plus an optional PNG.
+//
+// Read the shape, not just the number: a tight unimodal histogram centred on 0
+// is honest noise; a histogram with a non-zero mean or two separate humps is a
+// *systematic* shape error (the carbody-cross-section bug that motivated #61/#62)
+// even when the headline mean looks small.
+
+import Foundation
+import OCCTSwift
+import simd
+
+public enum DeviationHistogramTool {
+
+    public struct Bucket: Encodable {
+        public let lo: Double
+        public let hi: Double
+        public let count: Int
+    }
+
+    public struct HistogramReport: Encodable {
+        public let from: String
+        public let reference: String
+        public let deflection: Double
+        public let samples: Int
+        /// Mean of the signed deviation (μ). Non-zero ⇒ systematic proud/shy bias.
+        public let mean: Double
+        /// Standard deviation (σ) of the signed deviation.
+        public let std: Double
+        /// Median signed deviation.
+        public let median: Double
+        /// 95th percentile of |deviation|.
+        public let p95: Double
+        public let signedMin: Double
+        public let signedMax: Double
+        public let maxAbs: Double
+        public let tolerance: Double?
+        /// Fraction of samples with |deviation| ≤ tolerance (0…1). Nil if no tol.
+        public let withinTolerance: Double?
+        public let buckets: [Bucket]
+        public let imagePath: String?
+    }
+
+    public static func deviationHistogram(
+        fromBodyId: String,
+        referenceBodyId: String,
+        deflection: Double? = nil,
+        bins: Int = 40,
+        maxSamples: Int = 50_000,
+        tolerance: Double? = nil,
+        outputPath: String? = nil,
+        store: ManifestStore = ManifestStore()
+    ) async -> ToolText {
+        let fromShape: Shape, refShape: Shape
+        do {
+            fromShape = try IntrospectionTools.loadShape(bodyId: fromBodyId, store: store).shape
+            refShape = try IntrospectionTools.loadShape(bodyId: referenceBodyId, store: store).shape
+        } catch {
+            return .init("\(error)")
+        }
+
+        let defl = deflection ?? DeviationTools.defaultDeflection(for: fromShape)
+        guard defl > 0 else { return .init("deflection must be positive.", isError: true) }
+
+        guard let fromTris = DeviationTools.TriMesh(shape: fromShape, deflection: defl) else {
+            return .init("Failed to tessellate '\(fromBodyId)'.", isError: true)
+        }
+        guard let refTris = DeviationTools.TriMesh(shape: refShape, deflection: defl) else {
+            return .init("Failed to tessellate '\(referenceBodyId)'.", isError: true)
+        }
+
+        // Stride-subsample the source vertices to honour the sample cap.
+        let all = fromTris.vertices
+        let stride = maxSamples > 0 ? max(1, (all.count + maxSamples - 1) / maxSamples) : 1
+        var points: [SIMD3<Double>] = []
+        points.reserveCapacity((all.count + stride - 1) / stride)
+        var i = 0
+        while i < all.count { points.append(all[i]); i += stride }
+
+        let signed = DeviationTools.signedDistances(of: points, to: refTris)
+        guard !signed.isEmpty else { return .init("No samples produced.", isError: true) }
+
+        // Aggregate stats.
+        let n = Double(signed.count)
+        let sum = signed.reduce(0, +)
+        let mean = sum / n
+        let sumSq = signed.reduce(0) { $0 + $1 * $1 }
+        let variance = max(0, sumSq / n - mean * mean)
+        let std = variance.squareRoot()
+        let sortedSigned = signed.sorted()
+        let median = DeviationTools.percentile(sortedSigned, 0.5)
+        let absSorted = signed.map { abs($0) }.sorted()
+        let p95 = DeviationTools.percentile(absSorted, 0.95)
+        let maxAbs = absSorted.last ?? 0
+        let signedMin = sortedSigned.first ?? 0
+        let signedMax = sortedSigned.last ?? 0
+
+        var within: Double? = nil
+        if let tol = tolerance, tol >= 0 {
+            let ok = signed.reduce(0) { $0 + (abs($1) <= tol ? 1 : 0) }
+            within = Double(ok) / n
+        }
+
+        // Buckets across the signed range.
+        var lo = signedMin, hi = signedMax
+        if hi - lo < 1e-9 { lo -= 0.5; hi += 0.5 }
+        let nb = max(2, bins)
+        let bw = (hi - lo) / Double(nb)
+        var counts = [Int](repeating: 0, count: nb)
+        for v in signed {
+            var b = Int((v - lo) / bw)
+            if b >= nb { b = nb - 1 }
+            if b < 0 { b = 0 }
+            counts[b] += 1
+        }
+        let buckets = (0..<nb).map { Bucket(lo: lo + Double($0) * bw, hi: lo + Double($0 + 1) * bw, count: counts[$0]) }
+
+        // Optional PNG.
+        var imagePath: String? = nil
+        if let outputPath {
+            do {
+                try ChartRenderer.histogram(
+                    values: signed, tolerance: tolerance, bins: nb,
+                    title: "signed deviation  \(fromBodyId) → \(referenceBodyId)  (μ=\(String(format: "%.3g", mean)), σ=\(String(format: "%.3g", std)))",
+                    to: URL(fileURLWithPath: outputPath)
+                )
+                imagePath = outputPath
+            } catch {
+                return .init("Histogram render failed: \(error)", isError: true)
+            }
+        }
+
+        let report = HistogramReport(
+            from: fromBodyId, reference: referenceBodyId, deflection: defl,
+            samples: signed.count, mean: mean, std: std, median: median, p95: p95,
+            signedMin: signedMin, signedMax: signedMax, maxAbs: maxAbs,
+            tolerance: tolerance, withinTolerance: within, buckets: buckets, imagePath: imagePath
+        )
+        return IntrospectionTools.encode(report)
+    }
+}

--- a/Sources/OCCTMCPCore/Tools/DeviationTools.swift
+++ b/Sources/OCCTMCPCore/Tools/DeviationTools.swift
@@ -1,17 +1,25 @@
-// DeviationTools — surface-deviation (one-sided / symmetric Hausdorff) between
-// two scene bodies. Where `measure_distance` returns the *minimum* gap (≈0 for
-// an overlapping reconstruction-vs-source pair, hence useless as a fidelity
-// figure), this samples one body's tessellated surface and projects each sample
-// onto the other body's triangles to report the *worst* and RMS deviation in
-// each direction. This is the metric a mesh→analytic reconstruction check needs
-// (OCCTMCP #41): fromToTo surfaces departing from `to` (over-extension), and
-// toToFrom (missing material / under-coverage).
+// DeviationTools — surface-deviation between two scene bodies. Where
+// `measure_distance` returns the *minimum* gap (≈0 for an overlapping
+// reconstruction-vs-source pair, hence useless as a fidelity figure), this
+// samples one body's tessellated surface and projects each sample onto the
+// other body's triangles to report deviation in each direction.
+//
+// As of #62 the report is a *vector*, not a lone scalar. A symmetric Hausdorff
+// hides systematic shape error — a reconstructed carbody whose cross-section is
+// the wrong shape *everywhere* still reads as a small mean, because the correct
+// faces dominate the samples and the wrong arc averages out. The fix is to also
+// report the **sign** (so a constant proud/shy bias shows up as a non-zero
+// `signedMean`), a robust **p95** worst-case, and an optional **per-section**
+// signed-mean array along an axis (a near-constant non-zero signedMean across
+// the stack is the fingerprint of a systematic section offset).
 //
 // Mesh-based by design: both bodies are typically meshes (an STL source vs a
 // STEP reconstruction), and meshing once + a KD-tree is far cheaper than N
-// per-point BRep extrema. Fidelity scales with `deflection` — a finer mesh
-// tightens the bound. The per-sample distance is exact point-to-triangle, so
-// the only approximation is the tessellation itself, not nearest-vertex.
+// per-point BRep extrema. Fidelity scales with `deflection`. The per-sample
+// distance is exact point-to-triangle; the sign comes from the nearest target
+// triangle's outward face normal (OCCT meshes a solid with consistent outward
+// winding), so signed distance is + outside the reference (proud / over-build)
+// and − inside it (shy / missing material).
 
 import Foundation
 import OCCTSwift
@@ -20,10 +28,35 @@ import simd
 public enum DeviationTools {
 
     public struct DirectionStat: Encodable {
+        /// Worst unsigned distance.
         public let max: Double
+        /// Unsigned RMS.
         public let rms: Double
+        /// Unsigned mean.
         public let mean: Double
+        /// 95th percentile of |distance| — a robust worst-case that an outlier
+        /// triangle can't dominate.
+        public let p95: Double
+        /// Mean of the *signed* distance. ≠ 0 ⇒ a systematic proud (+) / shy (−)
+        /// bias — the figure a symmetric Hausdorff throws away.
+        public let signedMean: Double
+        /// Most-shy (most negative) signed sample — deepest under-build.
+        public let signedMin: Double
+        /// Most-proud (most positive) signed sample — worst over-build.
+        public let signedMax: Double
         public let worstPoint: [Double]
+        public let samples: Int
+    }
+
+    /// One station of an along-axis section sweep over the forward (from→to)
+    /// samples. A near-constant non-zero `signedMean` across stations is the
+    /// fingerprint of a systematic section-shape error.
+    public struct SectionStat: Encodable {
+        /// Offset of the bin centre along the section axis, measured from the
+        /// minimum sample projection.
+        public let offset: Double
+        public let signedMean: Double
+        public let rms: Double
         public let samples: Int
     }
 
@@ -37,6 +70,9 @@ public enum DeviationTools {
         public let toToFrom: DirectionStat
         /// max(fromToTo.max, toToFrom.max) — the symmetric Hausdorff distance.
         public let symmetricHausdorff: Double
+        /// Forward (from→to) signed samples binned along `sectionAxis`. Present
+        /// only when a section axis + count was requested.
+        public let sections: [SectionStat]?
     }
 
     public static func measureDeviation(
@@ -44,6 +80,8 @@ public enum DeviationTools {
         toBodyId: String,
         deflection: Double? = nil,
         maxSamples: Int = 20_000,
+        sectionAxis: SIMD3<Double>? = nil,
+        sectionCount: Int = 0,
         store: ManifestStore = ManifestStore()
     ) async -> ToolText {
         let fromShape: Shape, toShape: Shape
@@ -68,11 +106,16 @@ public enum DeviationTools {
             return .init("Failed to tessellate '\(toBodyId)' for deviation.", isError: true)
         }
 
-        guard let fwd = directedDeviation(source: fromTris, target: toTris, maxSamples: maxSamples) else {
+        guard let (fwd, fwdSamples) = directedStats(source: fromTris, target: toTris, maxSamples: maxSamples) else {
             return .init("Deviation computation failed (empty tessellation).", isError: true)
         }
-        guard let rev = directedDeviation(source: toTris, target: fromTris, maxSamples: maxSamples) else {
+        guard let (rev, _) = directedStats(source: toTris, target: fromTris, maxSamples: maxSamples) else {
             return .init("Deviation computation failed (empty tessellation).", isError: true)
+        }
+
+        var sections: [SectionStat]? = nil
+        if let axis = sectionAxis, sectionCount >= 2, simd_length(axis) > 1e-12 {
+            sections = sectionize(samples: fwdSamples, axis: simd_normalize(axis), bins: sectionCount)
         }
 
         let report = DeviationReport(
@@ -81,12 +124,19 @@ public enum DeviationTools {
             deflection: defl,
             fromToTo: fwd,
             toToFrom: rev,
-            symmetricHausdorff: Swift.max(fwd.max, rev.max)
+            symmetricHausdorff: Swift.max(fwd.max, rev.max),
+            sections: sections
         )
         return IntrospectionTools.encode(report)
     }
 
     // ── tessellation snapshot ───────────────────────────────────────────
+
+    /// One sampled source point and its signed distance to the target.
+    struct SignedSample {
+        let point: SIMD3<Double>
+        let signed: Double
+    }
 
     /// Double-precision triangle soup + a KD-tree over vertices, with a
     /// vertex→incident-triangle adjacency for exact point-to-triangle queries.
@@ -129,74 +179,182 @@ public enum DeviationTools {
             self.kd = kd
             self.incident = adj
         }
+
+        /// Outward face normal of triangle `ti` (unit, or zero if degenerate).
+        func faceNormal(_ ti: Int) -> SIMD3<Double> {
+            let (a, b, c) = triangles[ti]
+            let n = simd_cross(vertices[Int(b)] - vertices[Int(a)],
+                               vertices[Int(c)] - vertices[Int(a)])
+            let len = simd_length(n)
+            return len > 1e-18 ? n / len : SIMD3<Double>(0, 0, 0)
+        }
     }
 
     // ── directed deviation: source samples → nearest point on target ─────
 
-    static func directedDeviation(source: TriMesh, target: TriMesh, maxSamples: Int) -> DirectionStat? {
+    /// Directed deviation with sign. Returns the aggregate `DirectionStat` plus
+    /// the per-sample signed list (for sectioning / histograms).
+    static func directedStats(source: TriMesh, target: TriMesh, maxSamples: Int)
+        -> (DirectionStat, [SignedSample])?
+    {
         let n = source.vertices.count
         guard n > 0 else { return nil }
         // Stride-subsample the source vertices to honour the sample cap.
         let stride = maxSamples > 0 ? Swift.max(1, (n + maxSamples - 1) / maxSamples) : 1
         let k = 6                      // candidate target vertices per query
+        // Reused stamp array dedups incident triangles across the k candidates.
+        var stamp = [Int](repeating: -1, count: target.triangles.count)
+
+        var samples: [SignedSample] = []
+        samples.reserveCapacity((n + stride - 1) / stride)
+        var dists: [Double] = []
+        dists.reserveCapacity(samples.capacity)
 
         var maxD = 0.0
         var sumSq = 0.0
         var sum = 0.0
-        var count = 0
+        var signedSum = 0.0
+        var signedMin = Double.greatestFiniteMagnitude
+        var signedMax = -Double.greatestFiniteMagnitude
         var worst = SIMD3<Double>(0, 0, 0)
-        // Reused stamp array dedups incident triangles across the k candidates.
-        var stamp = [Int](repeating: -1, count: target.triangles.count)
 
         var i = 0
         while i < n {
             let p = source.vertices[i]
-            var best = Double.greatestFiniteMagnitude
-
-            let neighbours = target.kd.kNearest(to: p, k: k)
-            if neighbours.isEmpty {
-                // Degenerate target KD result — fall back to nearest vertex.
-                if let nv = target.kd.nearest(to: p) { best = nv.distance }
-            } else {
-                for (vi, _) in neighbours {
-                    for ti in target.incident[vi] where stamp[ti] != i {
-                        stamp[ti] = i
-                        let (a, b, c) = target.triangles[ti]
-                        let d = pointTriangleDistance(
-                            p,
-                            target.vertices[Int(a)],
-                            target.vertices[Int(b)],
-                            target.vertices[Int(c)]
-                        )
-                        if d < best { best = d }
-                    }
-                }
-                // A nearest vertex with no incident triangles (isolated) — guard.
-                if best == .greatestFiniteMagnitude, let nv = target.kd.nearest(to: p) {
-                    best = nv.distance
-                }
-            }
-
-            if best != .greatestFiniteMagnitude {
-                if best > maxD { maxD = best; worst = p }
-                sumSq += best * best
-                sum += best
-                count += 1
+            if let signed = signedQuery(p, target: target, k: k, stamp: &stamp, stampToken: i) {
+                let d = abs(signed)
+                if d > maxD { maxD = d; worst = p }
+                sumSq += d * d
+                sum += d
+                signedSum += signed
+                if signed < signedMin { signedMin = signed }
+                if signed > signedMax { signedMax = signed }
+                dists.append(d)
+                samples.append(SignedSample(point: p, signed: signed))
             }
             i += stride
         }
 
+        let count = samples.count
         guard count > 0 else { return nil }
-        return DirectionStat(
+        dists.sort()
+        let stat = DirectionStat(
             max: maxD,
             rms: (sumSq / Double(count)).squareRoot(),
             mean: sum / Double(count),
+            p95: percentile(dists, 0.95),
+            signedMean: signedSum / Double(count),
+            signedMin: signedMin == .greatestFiniteMagnitude ? 0 : signedMin,
+            signedMax: signedMax == -.greatestFiniteMagnitude ? 0 : signedMax,
             worstPoint: [worst.x, worst.y, worst.z],
             samples: count
         )
+        return (stat, samples)
+    }
+
+    /// Signed distance from `p` to the target surface, using a shared `stamp`
+    /// array for incident-triangle dedup across the k nearest candidates.
+    /// `stampToken` must be unique per query (the source sample index works).
+    static func signedQuery(
+        _ p: SIMD3<Double>, target: TriMesh, k: Int,
+        stamp: inout [Int], stampToken: Int
+    ) -> Double? {
+        var best = Double.greatestFiniteMagnitude
+        var bestClosest = SIMD3<Double>(0, 0, 0)
+        var bestTri = -1
+
+        let neighbours = target.kd.kNearest(to: p, k: k)
+        if neighbours.isEmpty {
+            if let nv = target.kd.nearest(to: p) {
+                // No triangle context — report unsigned (sign 0).
+                return nv.distance
+            }
+            return nil
+        }
+        for (vi, _) in neighbours {
+            for ti in target.incident[vi] where stamp[ti] != stampToken {
+                stamp[ti] = stampToken
+                let (a, b, c) = target.triangles[ti]
+                let cp = closestPointOnTriangle(p, target.vertices[Int(a)],
+                                                target.vertices[Int(b)],
+                                                target.vertices[Int(c)])
+                let d = simd_length(p - cp)
+                if d < best { best = d; bestClosest = cp; bestTri = ti }
+            }
+        }
+        if bestTri < 0 {
+            // Nearest vertex had no incident triangles (isolated) — fall back.
+            if let nv = target.kd.nearest(to: p) { return nv.distance }
+            return nil
+        }
+        let nrm = target.faceNormal(bestTri)
+        let side = simd_dot(p - bestClosest, nrm)
+        return side >= 0 ? best : -best
+    }
+
+    /// Per-vertex signed-distance field for an arbitrary mesh's vertices against
+    /// a reference `TriMesh`. Used by the heatmap (per-triangle centroid) and the
+    /// histogram. No subsampling — every supplied point is queried.
+    static func signedDistances(of points: [SIMD3<Double>], to target: TriMesh) -> [Double] {
+        var stamp = [Int](repeating: -1, count: target.triangles.count)
+        var out = [Double](repeating: 0, count: points.count)
+        for (i, p) in points.enumerated() {
+            out[i] = signedQuery(p, target: target, k: 6, stamp: &stamp, stampToken: i) ?? 0
+        }
+        return out
+    }
+
+    // ── per-section binning ──────────────────────────────────────────────
+
+    /// Bin forward samples by their projection onto `axis` (unit) into `bins`
+    /// equal-width stations, reporting per-station signed-mean / RMS.
+    static func sectionize(samples: [SignedSample], axis: SIMD3<Double>, bins: Int) -> [SectionStat] {
+        guard !samples.isEmpty, bins >= 2 else { return [] }
+        var ts = [Double](repeating: 0, count: samples.count)
+        var lo = Double.greatestFiniteMagnitude, hi = -Double.greatestFiniteMagnitude
+        for (i, s) in samples.enumerated() {
+            let t = simd_dot(s.point, axis)
+            ts[i] = t
+            if t < lo { lo = t }
+            if t > hi { hi = t }
+        }
+        let span = hi - lo
+        guard span > 1e-12 else { return [] }
+        let width = span / Double(bins)
+
+        var signedSum = [Double](repeating: 0, count: bins)
+        var sqSum = [Double](repeating: 0, count: bins)
+        var counts = [Int](repeating: 0, count: bins)
+        for (i, s) in samples.enumerated() {
+            var b = Int((ts[i] - lo) / width)
+            if b >= bins { b = bins - 1 }
+            if b < 0 { b = 0 }
+            signedSum[b] += s.signed
+            sqSum[b] += s.signed * s.signed
+            counts[b] += 1
+        }
+
+        var out: [SectionStat] = []
+        out.reserveCapacity(bins)
+        for b in 0..<bins where counts[b] > 0 {
+            let c = Double(counts[b])
+            out.append(SectionStat(
+                offset: (Double(b) + 0.5) * width,
+                signedMean: signedSum[b] / c,
+                rms: (sqSum[b] / c).squareRoot(),
+                samples: counts[b]
+            ))
+        }
+        return out
     }
 
     // ── geometry helpers ────────────────────────────────────────────────
+
+    static func percentile(_ sorted: [Double], _ q: Double) -> Double {
+        guard !sorted.isEmpty else { return 0 }
+        let idx = Int((Double(sorted.count - 1) * q).rounded())
+        return sorted[Swift.min(Swift.max(idx, 0), sorted.count - 1)]
+    }
 
     static func defaultDeflection(for shape: Shape) -> Double {
         let b = shape.bounds
@@ -205,53 +363,64 @@ public enum DeviationTools {
         return Swift.max(diag * 0.005, 1e-6)
     }
 
-    /// Exact distance from point `p` to triangle (a,b,c).
-    /// Closest-point-on-triangle, Ericson "Real-Time Collision Detection" §5.1.5.
-    static func pointTriangleDistance(
+    /// Closest point on triangle (a,b,c) to `p`.
+    /// Ericson "Real-Time Collision Detection" §5.1.5.
+    static func closestPointOnTriangle(
         _ p: SIMD3<Double>,
         _ a: SIMD3<Double>,
         _ b: SIMD3<Double>,
         _ c: SIMD3<Double>
-    ) -> Double {
+    ) -> SIMD3<Double> {
         let ab = b - a
         let ac = c - a
         let ap = p - a
         let d1 = simd_dot(ab, ap)
         let d2 = simd_dot(ac, ap)
-        if d1 <= 0 && d2 <= 0 { return simd_length(ap) }                 // vertex A
+        if d1 <= 0 && d2 <= 0 { return a }                               // vertex A
 
         let bp = p - b
         let d3 = simd_dot(ab, bp)
         let d4 = simd_dot(ac, bp)
-        if d3 >= 0 && d4 <= d3 { return simd_length(bp) }                // vertex B
+        if d3 >= 0 && d4 <= d3 { return b }                              // vertex B
 
         let vc = d1 * d4 - d3 * d2
         if vc <= 0 && d1 >= 0 && d3 <= 0 {                                // edge AB
             let v = d1 / (d1 - d3)
-            return simd_length(p - (a + v * ab))
+            return a + v * ab
         }
 
         let cp = p - c
         let d5 = simd_dot(ab, cp)
         let d6 = simd_dot(ac, cp)
-        if d6 >= 0 && d5 <= d6 { return simd_length(cp) }                // vertex C
+        if d6 >= 0 && d5 <= d6 { return c }                              // vertex C
 
         let vb = d5 * d2 - d1 * d6
         if vb <= 0 && d2 >= 0 && d6 <= 0 {                                // edge AC
             let w = d2 / (d2 - d6)
-            return simd_length(p - (a + w * ac))
+            return a + w * ac
         }
 
         let va = d3 * d6 - d5 * d4
         if va <= 0 && (d4 - d3) >= 0 && (d5 - d6) >= 0 {                  // edge BC
             let w = (d4 - d3) / ((d4 - d3) + (d5 - d6))
-            return simd_length(p - (b + w * (c - b)))
+            return b + w * (c - b)
         }
 
         // Interior — barycentric projection onto the triangle plane.
         let denom = 1.0 / (va + vb + vc)
         let v = vb * denom
         let w = vc * denom
-        return simd_length(p - (a + ab * v + ac * w))
+        return a + ab * v + ac * w
+    }
+
+    /// Exact distance from point `p` to triangle (a,b,c). Retained for callers
+    /// that only need the magnitude.
+    static func pointTriangleDistance(
+        _ p: SIMD3<Double>,
+        _ a: SIMD3<Double>,
+        _ b: SIMD3<Double>,
+        _ c: SIMD3<Double>
+    ) -> Double {
+        simd_length(p - closestPointOnTriangle(p, a, b, c))
     }
 }

--- a/Sources/OCCTMCPCore/Tools/HeatmapTools.swift
+++ b/Sources/OCCTMCPCore/Tools/HeatmapTools.swift
@@ -1,0 +1,238 @@
+// HeatmapTools — visual deviation diagnostics (#63).
+//
+//  • signed_deviation_heatmap — per-triangle SIGNED distance from one body to a
+//    reference, mapped through a diverging colormap and rendered as a shaded
+//    surface. OffscreenRenderer only colours the *point* pass per-vertex and has
+//    no per-triangle style pass, so a true coloured SURFACE is built as one
+//    flat-coloured ViewportBody per signed-distance band — the band's triangles
+//    grouped and tinted with the band colour. A colorbar legend is composited
+//    onto the PNG so + (proud / red) and − (shy / blue) read at a glance.
+//
+//  • overlay_render — the reference mesh drawn semi-transparent over the opaque
+//    candidate solid, so you can see in 3D exactly where the reconstruction
+//    departs from the source. OffscreenRenderer's transparent pass kicks in for
+//    any body whose effective opacity < 1.
+//
+// Both reuse RenderPreviewTool's camera framing helpers.
+
+import Foundation
+import simd
+import OCCTSwift
+import OCCTSwiftTools
+import OCCTSwiftViewport
+
+public enum HeatmapTools {
+
+    // MARK: - signed_deviation_heatmap
+
+    public struct HeatmapReport: Encodable {
+        public let outputPath: String
+        public let width: Int
+        public let height: Int
+        public let bands: Int
+        /// Colormap saturation bound: |signed| ≥ clamp maps to full red/blue.
+        public let clamp: Double
+        public let triangles: Int
+        public let signedMin: Double
+        public let signedMax: Double
+        public let signedMean: Double
+        public let mimeType: String
+    }
+
+    @MainActor
+    public static func signedDeviationHeatmap(
+        fromBodyId: String,
+        referenceBodyId: String,
+        outputPath: String,
+        deflection: Double? = nil,
+        bands: Int = 11,
+        clamp: Double? = nil,
+        options: RenderPreviewTool.Options = .init(),
+        store: ManifestStore = ManifestStore()
+    ) async -> ToolText {
+        let fromShape: Shape, refShape: Shape
+        do {
+            fromShape = try IntrospectionTools.loadShape(bodyId: fromBodyId, store: store).shape
+            refShape = try IntrospectionTools.loadShape(bodyId: referenceBodyId, store: store).shape
+        } catch {
+            return .init("\(error)")
+        }
+
+        let defl = deflection ?? DeviationTools.defaultDeflection(for: fromShape)
+        guard defl > 0 else { return .init("deflection must be positive.", isError: true) }
+
+        guard let mesh = CrossSectionCompareTool.mesh(fromShape, deflection: defl) else {
+            return .init("Failed to tessellate '\(fromBodyId)'.", isError: true)
+        }
+        guard let refTris = DeviationTools.TriMesh(shape: refShape, deflection: defl) else {
+            return .init("Failed to tessellate '\(referenceBodyId)'.", isError: true)
+        }
+
+        let verts = mesh.vertices
+        let normals = mesh.normals
+        let idx = mesh.indices
+        guard idx.count >= 3 else { return .init("Body '\(fromBodyId)' has no triangles to colour.", isError: true) }
+        let hasNormals = normals.count == verts.count
+
+        // Per-triangle signed distance, sampled at the centroid.
+        let triCount = idx.count / 3
+        var centroids: [SIMD3<Double>] = []
+        centroids.reserveCapacity(triCount)
+        for t in 0..<triCount {
+            let a = verts[Int(idx[t * 3])], b = verts[Int(idx[t * 3 + 1])], c = verts[Int(idx[t * 3 + 2])]
+            let ctr = (a + b + c) / 3
+            centroids.append(SIMD3<Double>(Double(ctr.x), Double(ctr.y), Double(ctr.z)))
+        }
+        let signed = DeviationTools.signedDistances(of: centroids, to: refTris)
+
+        let signedMin = signed.min() ?? 0
+        let signedMax = signed.max() ?? 0
+        let signedMean = signed.isEmpty ? 0 : signed.reduce(0, +) / Double(signed.count)
+
+        // Colormap bound: explicit clamp, else robust p95 of |signed|.
+        let absSorted = signed.map { abs($0) }.sorted()
+        let autoClamp = DeviationTools.percentile(absSorted, 0.95)
+        let bound = (clamp ?? autoClamp) > 1e-12 ? (clamp ?? autoClamp) : max(1e-9, absSorted.last ?? 1)
+
+        // Bucket triangles into bands across [-bound, +bound].
+        let nb = max(2, bands)
+        var bandTris = [[Int]](repeating: [], count: nb)
+        for t in 0..<triCount {
+            let norm = max(-1.0, min(1.0, signed[t] / bound))     // -1..1
+            var b = Int((norm + 1) / 2 * Double(nb))              // 0..nb
+            if b >= nb { b = nb - 1 }
+            if b < 0 { b = 0 }
+            bandTris[b].append(t)
+        }
+
+        // One flat-coloured ViewportBody per non-empty band.
+        var bodies: [ViewportBody] = []
+        for b in 0..<nb where !bandTris[b].isEmpty {
+            let bandCenter = (Double(b) + 0.5) / Double(nb) * 2 - 1   // -1..1
+            let color = ChartRenderer.divergingColor(bandCenter)
+            var positions: [Float] = []
+            var bnormals: [Float] = []
+            var indices: [UInt32] = []
+            positions.reserveCapacity(bandTris[b].count * 9)
+            bnormals.reserveCapacity(bandTris[b].count * 9)
+            indices.reserveCapacity(bandTris[b].count * 3)
+            for t in bandTris[b] {
+                let ia = Int(idx[t * 3]), ib = Int(idx[t * 3 + 1]), ic = Int(idx[t * 3 + 2])
+                let pa = verts[ia], pb = verts[ib], pc = verts[ic]
+                let fn: SIMD3<Float>
+                if hasNormals {
+                    fn = SIMD3<Float>(0, 0, 0)  // use per-vertex below
+                } else {
+                    let n = simd_cross(pb - pa, pc - pa)
+                    let l = simd_length(n)
+                    fn = l > 1e-12 ? n / l : SIMD3<Float>(0, 0, 1)
+                }
+                for (vi, p) in [(ia, pa), (ib, pb), (ic, pc)] {
+                    positions.append(p.x); positions.append(p.y); positions.append(p.z)
+                    let nrm = hasNormals ? normals[vi] : fn
+                    bnormals.append(nrm.x); bnormals.append(nrm.y); bnormals.append(nrm.z)
+                }
+                let base = UInt32(indices.count)
+                indices.append(base); indices.append(base + 1); indices.append(base + 2)
+            }
+            bodies.append(ViewportBody.directMesh(
+                id: "\(fromBodyId)#band\(b)",
+                positions: positions, normals: bnormals, indices: indices, color: color
+            ))
+        }
+        guard !bodies.isEmpty else { return .init("No coloured surface produced.", isError: true) }
+
+        guard let renderer = OffscreenRenderer() else {
+            return .init("OffscreenRenderer init failed (no Metal device available).", isError: true)
+        }
+        var ro = OffscreenRenderOptions(
+            width: options.width, height: options.height,
+            displayMode: .shaded,                       // edges off — bands read cleaner
+            backgroundColor: options.background.color
+        )
+        ro.cameraState = RenderPreviewTool.makeCameraState(options: options, bodies: bodies)
+
+        let url = URL(fileURLWithPath: outputPath)
+        do {
+            _ = try renderer.renderToPNG(bodies: bodies, url: url, options: ro)
+        } catch {
+            return .init("Render failed: \(error.localizedDescription)", isError: true)
+        }
+        // Composite the colorbar legend onto the render.
+        try? ChartRenderer.overlayColorbar(on: url, minValue: -bound, maxValue: bound, label: "signed mm")
+
+        return IntrospectionTools.encode(HeatmapReport(
+            outputPath: outputPath, width: options.width, height: options.height,
+            bands: nb, clamp: bound, triangles: triCount,
+            signedMin: signedMin, signedMax: signedMax, signedMean: signedMean,
+            mimeType: "image/png"
+        ))
+    }
+
+    // MARK: - overlay_render
+
+    public struct OverlayReport: Encodable {
+        public let outputPath: String
+        public let width: Int
+        public let height: Int
+        public let solidBodyId: String
+        public let meshBodyId: String
+        public let transparency: Double
+        public let mimeType: String
+    }
+
+    @MainActor
+    public static func overlayRender(
+        solidBodyId: String,
+        meshBodyId: String,
+        outputPath: String,
+        transparency: Double = 0.5,
+        options: RenderPreviewTool.Options = .init(),
+        store: ManifestStore = ManifestStore()
+    ) async -> ToolText {
+        let solidShape: Shape, meshShape: Shape
+        do {
+            solidShape = try IntrospectionTools.loadShape(bodyId: solidBodyId, store: store).shape
+            meshShape = try IntrospectionTools.loadShape(bodyId: meshBodyId, store: store).shape
+        } catch {
+            return .init("\(error)")
+        }
+        let alpha = Float(max(0.05, min(0.95, transparency)))
+
+        // Opaque candidate solid (steel-grey), translucent reference mesh (amber).
+        let (solidVBopt, _) = CADFileLoader.shapeToBodyAndMetadata(
+            solidShape, id: solidBodyId, color: SIMD4(0.66, 0.69, 0.74, 1))
+        let (meshVBopt, _) = CADFileLoader.shapeToBodyAndMetadata(
+            meshShape, id: meshBodyId, color: SIMD4(0.95, 0.65, 0.20, alpha))
+        guard var solidVB = solidVBopt, var meshVB = meshVBopt else {
+            return .init("Failed to build renderable bodies.", isError: true)
+        }
+        // Force the reference body translucent on whichever material path is live.
+        meshVB.color.w = alpha
+        if var m = meshVB.material { m.opacity = alpha; meshVB.material = m }
+        solidVB.color.w = 1
+
+        let bodies = [solidVB, meshVB]
+        guard let renderer = OffscreenRenderer() else {
+            return .init("OffscreenRenderer init failed (no Metal device available).", isError: true)
+        }
+        var ro = OffscreenRenderOptions(
+            width: options.width, height: options.height,
+            displayMode: options.displayMode,
+            backgroundColor: options.background.color
+        )
+        ro.cameraState = RenderPreviewTool.makeCameraState(options: options, bodies: bodies)
+
+        let url = URL(fileURLWithPath: outputPath)
+        do {
+            _ = try renderer.renderToPNG(bodies: bodies, url: url, options: ro)
+        } catch {
+            return .init("Render failed: \(error.localizedDescription)", isError: true)
+        }
+        return IntrospectionTools.encode(OverlayReport(
+            outputPath: outputPath, width: options.width, height: options.height,
+            solidBodyId: solidBodyId, meshBodyId: meshBodyId,
+            transparency: Double(alpha), mimeType: "image/png"
+        ))
+    }
+}

--- a/SwiftTests/OCCTMCPCoreTests/IntegrationTests.swift
+++ b/SwiftTests/OCCTMCPCoreTests/IntegrationTests.swift
@@ -84,6 +84,8 @@ struct IntegrationTests {
             "pick_surface_point",
             "compute_metrics", "measure_deviation", "boolean_op", "set_assembly_metadata",
             "check_thickness",
+            "deviation_histogram", "cross_section_compare",
+            "signed_deviation_heatmap", "overlay_render",
         ] {
             #expect(names.contains(expected), "missing tool: \(expected)")
         }

--- a/SwiftTests/OCCTMCPCoreTests/SignedSpatialDeviationTests.swift
+++ b/SwiftTests/OCCTMCPCoreTests/SignedSpatialDeviationTests.swift
@@ -1,0 +1,203 @@
+// Tests for the signed / spatially-resolved deviation diagnostics:
+// measure_deviation vector upgrade + per-section (#62), deviation_histogram
+// (#62), cross_section_compare (#61), signed_deviation_heatmap / overlay_render
+// (#63).
+//
+// Two fixtures (see helpers): concentric spheres for the 3D signed / histogram /
+// render tests (the whole inner surface is a uniform 0.5 inside the outer solid,
+// so signedMean is unambiguously ≈ −0.5), and coaxial cylinders for the 2D
+// cross-section test (its circular profiles see only the uniformly-offset
+// lateral face). In both the inner body sits INSIDE the outer, so every signed
+// figure is negative — shy / under-build.
+
+import Foundation
+import Testing
+import OCCTSwift
+import ScriptHarness
+import simd
+@testable import OCCTMCPCore
+
+@Suite("signed + spatial deviation (#61/#62/#63)")
+struct SignedSpatialDeviationTests {
+
+    func scene(_ bodies: [(id: String, shape: Shape)]) throws -> ManifestStore {
+        let dir = NSTemporaryDirectory() + "occtmcp-sdev-\(UUID().uuidString)"
+        try FileManager.default.createDirectory(atPath: dir, withIntermediateDirectories: true)
+        let descriptors = bodies.map { BodyDescriptor(id: $0.id, file: "\($0.id).brep", color: [1, 1, 1, 1]) }
+        let manifest = ScriptManifest(version: 1, timestamp: Date(), description: "sdev", bodies: descriptors)
+        let store = ManifestStore(path: "\(dir)/manifest.json")
+        try store.write(manifest)
+        for b in bodies {
+            try Exporter.writeBREP(shape: b.shape, to: URL(fileURLWithPath: "\(dir)/\(b.id).brep"))
+        }
+        return store
+    }
+
+    func dirOf(_ store: ManifestStore) -> String { (store.path as NSString).deletingLastPathComponent }
+
+    /// Coaxial cylinders (lateral face uniformly offset; caps near-coincident).
+    /// Used by cross_section_compare, whose 2D circles see only the lateral face.
+    func coaxialCylinders() throws -> ManifestStore {
+        let inner = Shape.cylinder(radius: 5.0, height: 20)!
+        let outer = Shape.cylinder(radius: 5.5, height: 20)!
+        return try scene([("inner", inner), ("outer", outer)])
+    }
+
+    /// Concentric spheres — the ENTIRE inner surface is a uniform 0.5 inside the
+    /// outer solid, so the signed mean is unambiguously ≈ −0.5 (no flat caps to
+    /// dilute it). Used by the 3D signed / histogram / render tests.
+    func concentricSpheres() throws -> ManifestStore {
+        let inner = Shape.sphere(radius: 5.0)!
+        let outer = Shape.sphere(radius: 5.5)!
+        return try scene([("inner", inner), ("outer", outer)])
+    }
+
+    // ── decode mirrors ──────────────────────────────────────────────────
+
+    struct DevReport: Decodable {
+        struct Dir: Decodable {
+            let max, rms, mean, p95, signedMean, signedMin, signedMax: Double
+            let worstPoint: [Double]; let samples: Int
+        }
+        struct Section: Decodable { let offset, signedMean, rms: Double; let samples: Int }
+        let fromToTo: Dir; let toToFrom: Dir; let symmetricHausdorff: Double
+        let sections: [Section]?
+    }
+
+    struct HistReport: Decodable {
+        struct Bucket: Decodable { let lo, hi: Double; let count: Int }
+        let mean, std, median, p95, signedMin, signedMax, maxAbs: Double
+        let withinTolerance: Double?; let buckets: [Bucket]; let samples: Int
+    }
+
+    struct CompareReport: Decodable {
+        struct Section: Decodable {
+            let station: Int; let offset, fromArea, referenceArea, areaRatio: Double
+            let centroidOffset, signedMean, rms, maxAbs, shapeL2: Double
+        }
+        let meanSignedAcrossSections, maxAbsSignedSection: Double
+        let sections: [Section]
+    }
+
+    struct HeatReport: Decodable {
+        let outputPath: String; let bands, triangles: Int
+        let clamp, signedMin, signedMax, signedMean: Double
+    }
+
+    // ── #62: measure_deviation vector + per-section ──────────────────────
+
+    @Test("measure_deviation reports a negative signedMean + per-section array")
+    func signedAndSections() async throws {
+        let store = try concentricSpheres()
+        defer { try? FileManager.default.removeItem(atPath: dirOf(store)) }
+
+        let result = await DeviationTools.measureDeviation(
+            fromBodyId: "inner", toBodyId: "outer", deflection: 0.05,
+            sectionAxis: SIMD3(0, 0, 1), sectionCount: 5, store: store)
+        #expect(!result.isError, "unexpected error: \(result.text)")
+        let r = try JSONDecoder().decode(DevReport.self, from: Data(result.text.utf8))
+
+        // Inner surface is inside the outer solid ⇒ systematically shy.
+        #expect(r.fromToTo.signedMean < -0.25)
+        #expect(r.fromToTo.signedMean > -0.7)
+        #expect(r.fromToTo.signedMin < -0.4)        // deepest shy ≈ −0.5
+        #expect(r.fromToTo.p95 > 0.3)
+        #expect(r.fromToTo.samples > 0)
+
+        // Per-section sweep present and consistently shy (systematic).
+        let sections = try #require(r.sections)
+        #expect(sections.count >= 3)
+        #expect(sections.contains { $0.signedMean < -0.4 })
+        #expect(sections.allSatisfy { $0.signedMean < 0.05 })
+    }
+
+    @Test("measure_deviation omits sections when no axis given")
+    func noSections() async throws {
+        let store = try coaxialCylinders()
+        defer { try? FileManager.default.removeItem(atPath: dirOf(store)) }
+        let result = await DeviationTools.measureDeviation(
+            fromBodyId: "inner", toBodyId: "outer", deflection: 0.1, store: store)
+        let r = try JSONDecoder().decode(DevReport.self, from: Data(result.text.utf8))
+        #expect(r.sections == nil)
+    }
+
+    // ── #62: deviation_histogram ─────────────────────────────────────────
+
+    @Test("deviation_histogram: negative mean + within-tolerance + buckets")
+    func histogram() async throws {
+        let store = try concentricSpheres()
+        defer { try? FileManager.default.removeItem(atPath: dirOf(store)) }
+
+        let png = dirOf(store) + "/hist.png"
+        let result = await DeviationHistogramTool.deviationHistogram(
+            fromBodyId: "inner", referenceBodyId: "outer", deflection: 0.05,
+            tolerance: 1.0, outputPath: png, store: store)
+        #expect(!result.isError, "unexpected error: \(result.text)")
+        let r = try JSONDecoder().decode(HistReport.self, from: Data(result.text.utf8))
+
+        #expect(r.mean < -0.2 && r.mean > -0.7)
+        #expect(r.signedMin < -0.4)
+        #expect(!r.buckets.isEmpty)
+        #expect(r.samples > 0)
+        // Every |dev| ≈ 0.5 ≤ 1.0 ⇒ all within tolerance.
+        let within = try #require(r.withinTolerance)
+        #expect(within > 0.9)
+        #expect(FileManager.default.fileExists(atPath: png))
+    }
+
+    // ── #61: cross_section_compare ───────────────────────────────────────
+
+    @Test("cross_section_compare: area ratio + shy signedMean + matching shape")
+    func crossSection() async throws {
+        let store = try coaxialCylinders()
+        defer { try? FileManager.default.removeItem(atPath: dirOf(store)) }
+
+        let result = await CrossSectionCompareTool.crossSectionCompare(
+            fromBodyId: "inner", referenceBodyId: "outer", axis: SIMD3(0, 0, 1),
+            stations: 6, deflection: 0.05, store: store)
+        #expect(!result.isError, "unexpected error: \(result.text)")
+        let r = try JSONDecoder().decode(CompareReport.self, from: Data(result.text.utf8))
+
+        let valid = r.sections.filter { $0.fromArea > 0 }
+        #expect(!valid.isEmpty)
+        for s in valid {
+            #expect(s.areaRatio > 0.7 && s.areaRatio < 0.95)   // (5/5.5)^2 ≈ 0.826
+            #expect(s.signedMean < -0.2)                        // inner shy vs outer
+            #expect(s.shapeL2 < 0.1)                            // same circular shape
+        }
+        #expect(r.meanSignedAcrossSections < -0.2)
+    }
+
+    // ── #63: heatmap + overlay (render; skip if no Metal device) ──────────
+
+    @MainActor
+    @Test("signed_deviation_heatmap renders a PNG")
+    func heatmap() async throws {
+        let store = try concentricSpheres()
+        defer { try? FileManager.default.removeItem(atPath: dirOf(store)) }
+        let png = dirOf(store) + "/heat.png"
+        let result = await HeatmapTools.signedDeviationHeatmap(
+            fromBodyId: "inner", referenceBodyId: "outer", outputPath: png,
+            deflection: 0.2, store: store)
+        if result.isError && result.text.contains("Metal") { return }   // headless w/o GPU
+        #expect(!result.isError, "unexpected error: \(result.text)")
+        let r = try JSONDecoder().decode(HeatReport.self, from: Data(result.text.utf8))
+        #expect(r.triangles > 0)
+        #expect(r.signedMin < 0)            // shy somewhere
+        #expect(FileManager.default.fileExists(atPath: png))
+    }
+
+    @MainActor
+    @Test("overlay_render renders a PNG")
+    func overlay() async throws {
+        let store = try concentricSpheres()
+        defer { try? FileManager.default.removeItem(atPath: dirOf(store)) }
+        let png = dirOf(store) + "/overlay.png"
+        let result = await HeatmapTools.overlayRender(
+            solidBodyId: "inner", meshBodyId: "outer", outputPath: png,
+            transparency: 0.4, store: store)
+        if result.isError && result.text.contains("Metal") { return }
+        #expect(!result.isError, "unexpected error: \(result.text)")
+        #expect(FileManager.default.fileExists(atPath: png))
+    }
+}


### PR DESCRIPTION
Closes #61, closes #62, closes #63.

A symmetric Hausdorff scalar hides systematic shape error because it discards the **sign** and the **spatial/section distribution** — the carbody-cross-section case that motivated these issues. This PR adds signed, spatially-resolved comparison of a reconstruction against its source mesh, reusing the existing mesh + KD-tree + exact point-to-triangle engine already behind `measure_deviation` (the libigl/VTK/Open3D options in the issues weren't needed). **All rendering is pure-Swift CoreGraphics/CoreText — no Python/matplotlib.**

## #62 — `measure_deviation` vector + `deviation_histogram`
- `measure_deviation` now reports per direction: `max / rms / mean / p95 / signedMean / signedMin / signedMax` (+ `worstPoint`), plus an optional **per-section signedMean sweep** along `sectionAxis`. Sign comes from the nearest target triangle's outward face normal (+ proud / − shy). Backward-compatible — existing fields/tests preserved.
- `deviation_histogram` — full signed distribution (μ/σ/median/p95/extremes, percent within ±tolerance, buckets) + optional histogram PNG.

## #61 — `cross_section_compare`
Slices **both** bodies via `OCCTSwiftMesh.Mesh.crossSection` at the **same** `CutPlane` per station → identical (u,v) basis → directly comparable 2D profiles. Per-section signed-mean / RMS / area-ratio / centroid-offset + a pose-robust radial-signature shape scalar, with overlay PNGs.

## #63 — `signed_deviation_heatmap` + `overlay_render`
- Heatmap: per-triangle signed distance through a diverging colormap. `OffscreenRenderer` has no per-triangle/per-vertex *surface* colour pass (`vertexColors` is point-only), so each signed band's triangles are grouped into one flat-coloured `ViewportBody`; a colorbar legend is composited on.
- `overlay_render`: reference mesh translucent over the opaque candidate solid (OffscreenRenderer's transparent pass).

## Notes
- New files: `ChartRenderer.swift`, `Tools/DeviationHistogramTool.swift`, `Tools/CrossSectionCompareTool.swift`, `Tools/HeatmapTools.swift`.
- Tool count **59 → 63**. README "Deviation & reconstruction QA" section + CLAUDE.md updated.
- **6 new tests (47 total)**, all green via `swift test --no-parallel`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)