### PR TITLE
fix(deviation): accept integer-valued numeric args in dispatch

### DIFF
--- a/Sources/OCCTMCPCore/Server.swift
+++ b/Sources/OCCTMCPCore/Server.swift
@@ -1664,7 +1664,7 @@ func dispatch(callName: String, arguments: [String: Value]) async -> CallTool.Re
               let toId = arguments["toBodyId"]?.stringValue else {
             return ToolText("measure_deviation requires `fromBodyId` and `toBodyId`.", isError: true).asCallToolResult()
         }
-        let deflection = arguments["deflection"]?.doubleValue
+        let deflection = arguments["deflection"]?.numberValue
         let maxSamples = arguments["maxSamples"]?.intValue ?? 20_000
         var sectionAxis: SIMD3<Double>? = nil
         if let arr = arguments["sectionAxis"]?.arrayValue, arr.count == 3,
@@ -1685,10 +1685,10 @@ func dispatch(callName: String, arguments: [String: Value]) async -> CallTool.Re
         return await DeviationHistogramTool.deviationHistogram(
             fromBodyId: fromId,
             referenceBodyId: refId,
-            deflection: arguments["deflection"]?.doubleValue,
+            deflection: arguments["deflection"]?.numberValue,
             bins: arguments["bins"]?.intValue ?? 40,
             maxSamples: arguments["maxSamples"]?.intValue ?? 50_000,
-            tolerance: arguments["tolerance"]?.doubleValue,
+            tolerance: arguments["tolerance"]?.numberValue,
             outputPath: arguments["outputPath"]?.stringValue
         ).asCallToolResult()
 
@@ -1710,7 +1710,7 @@ func dispatch(callName: String, arguments: [String: Value]) async -> CallTool.Re
             axis: SIMD3(ax, ay, az),
             stations: arguments["stations"]?.intValue ?? 12,
             through: through,
-            deflection: arguments["deflection"]?.doubleValue,
+            deflection: arguments["deflection"]?.numberValue,
             outputDir: arguments["outputDir"]?.stringValue,
             imagePrefix: arguments["imagePrefix"]?.stringValue ?? "section"
         ).asCallToolResult()
@@ -1725,9 +1725,9 @@ func dispatch(callName: String, arguments: [String: Value]) async -> CallTool.Re
             fromBodyId: fromId,
             referenceBodyId: refId,
             outputPath: outputPath,
-            deflection: arguments["deflection"]?.doubleValue,
+            deflection: arguments["deflection"]?.numberValue,
             bands: arguments["bands"]?.intValue ?? 11,
-            clamp: arguments["clamp"]?.doubleValue,
+            clamp: arguments["clamp"]?.numberValue,
             options: parseRenderOptions(arguments["options"])
         ).asCallToolResult()
 
@@ -1741,7 +1741,7 @@ func dispatch(callName: String, arguments: [String: Value]) async -> CallTool.Re
             solidBodyId: solidId,
             meshBodyId: meshId,
             outputPath: outputPath,
-            transparency: arguments["transparency"]?.doubleValue ?? 0.5,
+            transparency: arguments["transparency"]?.numberValue ?? 0.5,
             options: parseRenderOptions(arguments["options"])
         ).asCallToolResult()
 


### PR DESCRIPTION
Found while testing the v1.10.0 tools over a live MCP session.

**Bug:** passing an integer for a float argument (e.g. `tolerance: 1`, `deflection: 2`) was silently dropped. `Value.doubleValue` returns `nil` for a JSON integer (`Value.int`), and LLM clients routinely send `1` rather than `1.0`. So `deviation_histogram`'s `tolerance`/`withinTolerance`, plus the `deflection` / `clamp` / `transparency` knobs on `measure_deviation` / `cross_section_compare` / `signed_deviation_heatmap` / `overlay_render`, were unreachable with integer input.

**Fix:** switch those scalar float optionals from `.doubleValue` → `.numberValue` (handles both int and double).

**Verified** over stdio against the installed binary — `deviation_histogram(..., tolerance: 1)` now returns `tolerance: 1` and `withinTolerance: 0.54` (was absent before). 47 tests green.

Follow-up to #64 (v1.10.0). Suggest tagging **v1.10.1** after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)