### PR TITLE
fix(deps+heatmap): occtDep checkouts guard + ViewportBody.directMesh drift

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -15,10 +15,13 @@ import Foundation
 // Prefer a local sibling checkout (../<name>) when present, else the published URL — so the whole
 // OCCT ecosystem SHARES the single OCCTSwift/Libraries/OCCT.xcframework instead of each repo
 // extracting its own 1.3 GB copy. CI / fresh clones (no sibling) use the URL pin. `#filePath`-relative
-// so it's independent of build CWD.
+// so it's independent of build CWD. Guarded against SwiftPM's own checkout layout: a transitively-
+// resolved checkout under a consumer's .build/ must never be treated as a local dev sibling
+// (ecosystem issue OCCTSwiftScripts#69 / #70).
 func occtDep(_ name: String, from version: String) -> Package.Dependency {
     let manifestDir = URL(fileURLWithPath: #filePath).deletingLastPathComponent().path
-    if FileManager.default.fileExists(atPath: manifestDir + "/../\(name)/Package.swift") {
+    if !manifestDir.contains("/.build/"),
+       FileManager.default.fileExists(atPath: manifestDir + "/../\(name)/Package.swift") {
         return .package(path: "../\(name)")
     }
     return .package(url: "https://github.com/SecondMouseAU/\(name).git", from: Version(version)!)
@@ -27,9 +30,11 @@ func occtDep(_ name: String, from version: String) -> Package.Dependency {
 // As occtDep, but pins to the package's minor line (`.upToNextMinor`) instead of
 // the major. Used to cap a transitive dependency whose newer minors pull deps we
 // don't want in the graph — see the OCCTSwiftIO note in `dependencies` below.
+// Same checkout-layout guard as occtDep (ecosystem issue OCCTSwiftScripts#69 / #70).
 func occtDepUpToNextMinor(_ name: String, from version: String) -> Package.Dependency {
     let manifestDir = URL(fileURLWithPath: #filePath).deletingLastPathComponent().path
-    if FileManager.default.fileExists(atPath: manifestDir + "/../\(name)/Package.swift") {
+    if !manifestDir.contains("/.build/"),
+       FileManager.default.fileExists(atPath: manifestDir + "/../\(name)/Package.swift") {
         return .package(path: "../\(name)")
     }
     return .package(url: "https://github.com/SecondMouseAU/\(name).git", .upToNextMinor(from: Version(version)!))

--- a/Sources/OCCTMCPCore/Tools/HeatmapTools.swift
+++ b/Sources/OCCTMCPCore/Tools/HeatmapTools.swift
@@ -135,9 +135,19 @@ public enum HeatmapTools {
                 let base = UInt32(indices.count)
                 indices.append(base); indices.append(base + 1); indices.append(base + 2)
             }
-            bodies.append(ViewportBody.directMesh(
+            // ViewportBody.directMesh (positions/normals as separate arrays) no longer exists —
+            // ViewportBody's init takes a single interleaved vertexData ([px,py,pz,nx,ny,nz,...],
+            // stride 6), so zip the two flat per-vertex arrays together here (same idiom the
+            // OCCTSwiftViewport primitive factories, e.g. .box, use internally).
+            var vertexData: [Float] = []
+            vertexData.reserveCapacity(positions.count * 2)
+            for i in stride(from: 0, to: positions.count, by: 3) {
+                vertexData.append(positions[i]); vertexData.append(positions[i + 1]); vertexData.append(positions[i + 2])
+                vertexData.append(bnormals[i]); vertexData.append(bnormals[i + 1]); vertexData.append(bnormals[i + 2])
+            }
+            bodies.append(ViewportBody(
                 id: "\(fromBodyId)#band\(b)",
-                positions: positions, normals: bnormals, indices: indices, color: color
+                vertexData: vertexData, indices: indices, edges: [], color: color
             ))
         }
         guard !bodies.isEmpty else { return .init("No coloured surface produced.", isError: true) }


### PR DESCRIPTION
Two independent fixes, both required for this repo to build clean again.

## 1. `occtDep`/`occtDepUpToNextMinor` checkouts guard
Same fleet-wide fix as [OCCTSwiftScripts#69/#70](https://github.com/SecondMouseAU/OCCTSwiftScripts/pull/70) and OCCTSwiftIO's 2026-06-23 fix: the sibling probe is a plain filesystem check with no guard against SwiftPM's own flat `.build/checkouts/` layout, so this manifest's own dependency declaration could flip from url to path mid-resolution whenever this package is consumed transitively (or, as seen here, when one of its own transitive deps — OCCTSwiftScripts — hadn't yet had the same fix merged). **Confirmed live**: before Scripts#70 merged, this repo's build hit the classic "exhausted attempts to resolve the dependencies graph"; after the merge + this guard, resolution succeeds cleanly.

## 2. `ViewportBody.directMesh` API drift (genuinely unrelated bug)
Once resolution succeeded, `swift build` still failed on `Sources/OCCTMCPCore/Tools/HeatmapTools.swift:138`: `ViewportBody.directMesh(positions:normals:indices:color:)` no longer exists in OCCTSwiftViewport — its real `init` takes a single interleaved `vertexData` (`stride 6`), not separate arrays. Fixed by interleaving `positions`/`bnormals` into that layout directly (the same idiom OCCTSwiftViewport's own primitive factories use).

## Verified
- `swift build`: **Build complete!**
- `swift test --no-parallel`: **48/48 tests passed**, including `signed_deviation_heatmap` and the other heatmap tests that exercise the fixed path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)